### PR TITLE
Cleaning up import statements

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -12,16 +12,16 @@ from PyQt5.QtWidgets import QApplication, QDialog, QVBoxLayout
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import QThreadPool,Qt
 
-from foraging_gui.Optogenetics import Ui_Optogenetics
-from foraging_gui.Calibration import Ui_WaterCalibration
-from foraging_gui.Camera import Ui_Camera
-from foraging_gui.MotorStage import Ui_MotorStage
-from foraging_gui.Manipulator import Ui_Manipulator
-from foraging_gui.LicksDistribution import Ui_LickDistribution
-from foraging_gui.TimeDistribution import Ui_TimeDistribution
-from foraging_gui.CalibrationLaser import Ui_CalibrationLaser
-from foraging_gui.MyFunctions import Worker
-from foraging_gui.Visualization import PlotWaterCalibration
+from Optogenetics import Ui_Optogenetics
+from Calibration import Ui_WaterCalibration
+from Camera import Ui_Camera
+from MotorStage import Ui_MotorStage
+from Manipulator import Ui_Manipulator
+from LicksDistribution import Ui_LickDistribution
+from TimeDistribution import Ui_TimeDistribution
+from CalibrationLaser import Ui_CalibrationLaser
+from MyFunctions import Worker
+from Visualization import PlotWaterCalibration
 
 
 class LickStaDialog(QDialog,Ui_LickDistribution):

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -12,16 +12,16 @@ from PyQt5.QtWidgets import QApplication, QDialog, QVBoxLayout
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import QThreadPool,Qt
 
-from Optogenetics import Ui_Optogenetics
-from Calibration import Ui_WaterCalibration
-from Camera import Ui_Camera
-from MotorStage import Ui_MotorStage
-from Manipulator import Ui_Manipulator
-from LicksDistribution import Ui_LickDistribution
-from TimeDistribution import Ui_TimeDistribution
-from CalibrationLaser import Ui_CalibrationLaser
-from MyFunctions import Worker
-from Visualization import PlotWaterCalibration
+from foraging_gui.Optogenetics import Ui_Optogenetics
+from foraging_gui.Calibration import Ui_WaterCalibration
+from foraging_gui.Camera import Ui_Camera
+from foraging_gui.MotorStage import Ui_MotorStage
+from foraging_gui.Manipulator import Ui_Manipulator
+from foraging_gui.LicksDistribution import Ui_LickDistribution
+from foraging_gui.TimeDistribution import Ui_TimeDistribution
+from foraging_gui.CalibrationLaser import Ui_CalibrationLaser
+from foraging_gui.MyFunctions import Worker
+from foraging_gui.Visualization import PlotWaterCalibration
 
 
 class LickStaDialog(QDialog,Ui_LickDistribution):

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 import numpy as np
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
-from PyQt5.QtWidgets import QApplication, QDialog, QMainWindow, QMessageBox,QFileDialog,QVBoxLayout
+from PyQt5.QtWidgets import QApplication, QDialog, QVBoxLayout
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import QThreadPool,Qt
 

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1,6 +1,17 @@
-import time,math,json,os,shutil,subprocess
+import time
+import math
+import json
+import os
+import shutil
+import subprocess
+from datetime import datetime
+
+import numpy as np
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from PyQt5.QtWidgets import QApplication, QDialog, QMainWindow, QMessageBox,QFileDialog,QVBoxLayout
 from PyQt5 import QtWidgets
+from PyQt5.QtCore import QThreadPool,Qt
+
 from Optogenetics import Ui_Optogenetics
 from Calibration import Ui_WaterCalibration
 from Camera import Ui_Camera
@@ -10,11 +21,8 @@ from LicksDistribution import Ui_LickDistribution
 from TimeDistribution import Ui_TimeDistribution
 from CalibrationLaser import Ui_CalibrationLaser
 from MyFunctions import Worker
-import numpy as np
-from PyQt5.QtCore import QThreadPool,Qt
-from datetime import datetime
-from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from Visualization import PlotWaterCalibration
+
 
 class LickStaDialog(QDialog,Ui_LickDistribution):
     '''Lick statistics dialog'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -5,25 +5,27 @@ import json
 import time
 import subprocess
 import math
-import numpy as np
-import json
+from datetime import date, datetime
+
 import serial 
-from subprocess import call
-from datetime import date, timedelta, datetime
-from PyQt5.QtWidgets import QApplication, QDialog, QMainWindow, QMessageBox,QFileDialog,QVBoxLayout,QLineEdit,QWidget,QSizePolicy
-from PyQt5 import QtWidgets,QtGui,QtCore
-from PyQt5.QtCore import QThreadPool,Qt,QMetaObject
+import numpy as np
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from scipy.io import savemat, loadmat
+from PyQt5.QtWidgets import QApplication, QMainWindow, QMessageBox
+from PyQt5.QtWidgets import QFileDialog,QVBoxLayout,QLineEdit
+from PyQt5 import QtWidgets,QtGui,QtCore
+from PyQt5.QtCore import QThreadPool,Qt
+from pyOSC3.OSC3 import OSCStreamingClient
+
 from ForagingGUI import Ui_ForagingGUI
 import rigcontrol
-from pyOSC3.OSC3 import OSCStreamingClient
 from Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
-from Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog,ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog,LickStaDialog,TimeDistributionDialog
+from Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
+from Dialogs import ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog
+from Dialogs import LickStaDialog,TimeDistributionDialog
 from MyFunctions import GenerateTrials, Worker,NewScaleSerialY
 from stage import Stage
 
-#warnings.filterwarnings("ignore")
 
 class NumpyEncoder(json.JSONEncoder):
     #def default(self, obj):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -17,14 +17,14 @@ from PyQt5 import QtWidgets,QtGui,QtCore
 from PyQt5.QtCore import QThreadPool,Qt
 from pyOSC3.OSC3 import OSCStreamingClient
 
-from foraging_gui.ForagingGUI import Ui_ForagingGUI
-import foraging_gui.rigcontrol as rigcontrol
-from foraging_gui.Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
-from foraging_gui.Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
-from foraging_gui.Dialogs import ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog
-from foraging_gui.Dialogs import LickStaDialog,TimeDistributionDialog
-from foraging_gui.MyFunctions import GenerateTrials, Worker,NewScaleSerialY
-from foraging_gui.stage import Stage
+from ForagingGUI import Ui_ForagingGUI
+import rigcontrol
+from Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
+from Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
+from Dialogs import ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog
+from Dialogs import LickStaDialog,TimeDistributionDialog
+from MyFunctions import GenerateTrials, Worker,NewScaleSerialY
+from stage import Stage
 
 
 class NumpyEncoder(json.JSONEncoder):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1,6 +1,15 @@
-import sys, os,traceback,json,time,subprocess,math
+import sys
+import os
+import traceback
+import json
+import time
+import subprocess
+import math
 import numpy as np
-from datetime import date,timedelta,datetime
+import json
+import serial 
+from subprocess import call
+from datetime import date, timedelta, datetime
 from PyQt5.QtWidgets import QApplication, QDialog, QMainWindow, QMessageBox,QFileDialog,QVBoxLayout,QLineEdit,QWidget,QSizePolicy
 from PyQt5 import QtWidgets,QtGui,QtCore
 from PyQt5.QtCore import QThreadPool,Qt,QMetaObject
@@ -12,9 +21,6 @@ from pyOSC3.OSC3 import OSCStreamingClient
 from Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
 from Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog,ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog,LickStaDialog,TimeDistributionDialog
 from MyFunctions import GenerateTrials, Worker,NewScaleSerialY
-import json
-import serial 
-from subprocess import call
 from stage import Stage
 
 #warnings.filterwarnings("ignore")

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -17,14 +17,14 @@ from PyQt5 import QtWidgets,QtGui,QtCore
 from PyQt5.QtCore import QThreadPool,Qt
 from pyOSC3.OSC3 import OSCStreamingClient
 
-from ForagingGUI import Ui_ForagingGUI
-import rigcontrol
-from Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
-from Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
-from Dialogs import ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog
-from Dialogs import LickStaDialog,TimeDistributionDialog
-from MyFunctions import GenerateTrials, Worker,NewScaleSerialY
-from stage import Stage
+from foraging_gui.ForagingGUI import Ui_ForagingGUI
+import foraging_gui.rigcontrol as rigcontrol
+from foraging_gui.Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
+from foraging_gui.Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
+from foraging_gui.Dialogs import ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog
+from foraging_gui.Dialogs import LickStaDialog,TimeDistributionDialog
+from foraging_gui.MyFunctions import GenerateTrials, Worker,NewScaleSerialY
+from foraging_gui.stage import Stage
 
 
 class NumpyEncoder(json.JSONEncoder):

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -10,7 +10,6 @@ import numpy as np
 from itertools import accumulate
 from serial.tools.list_ports import comports as list_comports
 from PyQt5 import QtWidgets
-from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import *
 
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -10,7 +10,7 @@ import numpy as np
 from itertools import accumulate
 from serial.tools.list_ports import comports as list_comports
 from PyQt5 import QtWidgets
-from PyQt5.QtCore import *
+from PyQt5 import QtCore
 
 
 if PLATFORM == 'win32':
@@ -1554,7 +1554,7 @@ class NewScaleSerialY():
                 data += c
                 if (c == '\r'): break
         return data
-class WorkerSignals(QObject):
+class WorkerSignals(QtCore.QObject):
     '''
     Defines the signals available from a running worker thread.
 
@@ -1573,13 +1573,13 @@ class WorkerSignals(QObject):
         int indicating % progress
 
     '''
-    finished = pyqtSignal()
-    error = pyqtSignal(tuple)
-    result = pyqtSignal(object)
-    progress = pyqtSignal(int)
+    finished = QtCore.pyqtSignal()
+    error = QtCore.pyqtSignal(tuple)
+    result = QtCore.pyqtSignal(object)
+    progress = QtCore.pyqtSignal(int)
 
 
-class Worker(QRunnable):
+class Worker(QtCore.QRunnable):
     '''
     Worker thread
 
@@ -1604,7 +1604,7 @@ class Worker(QRunnable):
         # Add the callback to our kwargs
         #self.kwargs['progress_callback'] = self.signals.progress
 
-    @pyqtSlot()
+    @QtCore.pyqtSlot()
     def run(self):
         '''
         Initialise the runner function with passed args, kwargs.

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1,17 +1,24 @@
-
-import random, traceback, math,time,sys
+import random
+import traceback
+import math
+import time
+import sys
+from sys import platform as PLATFORM
 from datetime import datetime
+
 import numpy as np
 from itertools import accumulate
+from serial.tools.list_ports import comports as list_comports
 from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import *
-from serial.tools.list_ports import comports as list_comports
-from sys import platform as PLATFORM
+
+
 if PLATFORM == 'win32':
     from newscale.usbxpress import USBXpressLib, USBXpressDevice
 VID_NEWSCALE = 0x10c4
 PID_NEWSCALE = 0xea61
+
 
 class GenerateTrials():
     def __init__(self,win):

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -1,15 +1,19 @@
 """
 Transfer current Json/mat format from Bonsai behavior control to NWB format
 """
+import json
+import os
+import datetime
 from uuid import uuid4
-import numpy as np, json,os,datetime
-from pynwb import NWBHDF5IO, NWBFile, TimeSeries
-from pynwb.behavior import Position, SpatialSeries
-from pynwb.epoch import TimeIntervals
-from pynwb.file import Subject
+
+import numpy as np
 from scipy.io import loadmat
+from pynwb.file import Subject
+from pynwb import NWBHDF5IO, NWBFile, TimeSeries
+
 
 SaveFolder='H:\\NWBFile\\'
+
 
 ######## load the Json/Mat file #######
 fname='E:\BonsaiForaging\Data\LA30\LA30_2023-04-27.mat'

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -1,10 +1,8 @@
 import numpy as np
-import matplotlib.pyplot as plt
-import pandas as pd
+from scipy import stats
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-from scipy import stats
 
 
 class PlotV(FigureCanvas):

--- a/src/foraging_gui/rigcontrol.py
+++ b/src/foraging_gui/rigcontrol.py
@@ -1,7 +1,8 @@
 import queue
-from enum import Enum
+
 from pyOSC3.OSC3 import OSCMessage
-import numpy as np
+
+
 class RigClient:
     def __init__(self, client):
         self.client = client
@@ -65,14 +66,12 @@ class RigClient:
 
     # waveform 1, location 1
     def WaveForm1_1(self, value):
-        #value=np.random.rand(2,441)
         self.send("/WaveForm1_1", value)
         #message = OSCMessage("/WaveForm1_1")
         #message.append(value.tobytes(),'b')
         #return self.client.sendOSC(message)
     # waveform 2, location 1
     def WaveForm2_1(self, value):
-        #value=np.random.rand(1,441)
         self.send("/WaveForm2_1", value)
         #message = OSCMessage("/WaveForm2_1")
         #message.append(value.tobytes(),'b')
@@ -80,7 +79,6 @@ class RigClient:
 
     # waveform 1, location 2
     def WaveForm1_2(self, value):
-        #value=np.random.rand(1,441)
         self.send("/WaveForm1_2", value)
         
         #message = OSCMessage("/WaveForm1_2")
@@ -89,7 +87,6 @@ class RigClient:
 
     # waveform 2, location 2
     def WaveForm2_2(self, value):
-        #value=np.random.rand(2,441)
         self.send("/WaveForm2_2", value)
         
         #message = OSCMessage("/WaveForm2_2")


### PR DESCRIPTION
- [x] Resolves #30
- [x] Resolves #31
- [ ] Tested on a rig before deployment/merging
- [x] Removes unused module imports
- [x] Removes redundant imports of the same module
- [x] Reorganizes imports into PEP8 style
   - [x] Use absolute rather than relative import statements
   - [x] organizes import statements by type (generic, install package, this package)
   - [x] Breaks up long lines in import statements into <80 character lines
   - [x] Only imports from one module in a line
- [x] checks for circular imports
- Files to clean up
   - [x] Foraging.py
   - [x] Dialogs.py
   - [x] MyFunctions.py 
   - [x] rigcontrol.py
   - [x] TransferToNWB.py
   - [x] Visualization.py