### PR TITLE
Creating a logging system for python foraging gui

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 from datetime import datetime
+import logging
 
 import numpy as np
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
@@ -157,7 +158,7 @@ class OptogeneticsDialog(QDialog,Ui_Optogenetics):
                 if index != -1:
                     eval('self.LaserPowerRight_'+str(Numb)+'.setCurrentIndex(index)')
         except Exception as e:
-            print('dialogs._Frequency: Error ',str(e))
+            logging.error(str(e))
 
     def _activated(self,Numb):
         '''enable/disable items based on protocols and laser start/end'''
@@ -206,7 +207,7 @@ class OptogeneticsDialog(QDialog,Ui_Optogenetics):
         try:
             self.LatestCalibrationDate.setText(self.MainWindow.RecentCalibrationDate)
         except Exception as e:
-            print('dialogs._Laser: ',str(e))
+            logging.error(str(e))
         Inactlabel=range(2,17)
         if eval('self.Laser_'+str(Numb)+'.currentText()')=='NA':
             Label=False
@@ -340,8 +341,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                         widget = widget_dict[key]
                         self.WaterCalibrationPar[CalibrationType][K]=widget.text()
                 except Exception as e:
-                    print('dialogs._SaveCalibrationPar: ',str(e))
-                    print('Water calibration parameters saved incorrectly!')
+                    logging.error('Water Calibration {}'.format(str(e)))
         # save
         if not os.path.exists(os.path.dirname(self.MainWindow.WaterCalibrationParFiles)):
             os.makedirs(os.path.dirname(self.MainWindow.WaterCalibrationParFiles))
@@ -384,7 +384,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
             total_water=float(self.TotalWaterSingleLeft.text())  
         except Exception as e:
             total_water=''
-            print('dialogs._SaveLeft: ',str(e))
+            logging.error(str(e))
         self._Save(valve=valve,valve_open_time=valve_open_time,valve_open_interval=valve_open_interval,cycle=cycle,total_water=total_water,tube_weight=0)
         self.SaveLeft.setStyleSheet("background-color : none")
         self.SaveLeft.setChecked(False)
@@ -400,7 +400,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
             total_water=float(self.TotalWaterSingleRight.text()) 
         except Exception as e:
             total_water=''
-            print('dialogs._SaveRight: ',str(e))
+            logging.error(str(e))
         self._Save(valve=valve,valve_open_time=valve_open_time,valve_open_interval=valve_open_interval,cycle=cycle,total_water=total_water,tube_weight=0)
         self.SaveRight.setStyleSheet("background-color : none")
         self.SaveRight.setChecked(False)
@@ -420,8 +420,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                         widget = widget_dict[key]
                         widget.setText(str(self.WaterCalibrationPar[CalibrationType][K]))
                 except Exception as e:
-                    print('dialogs._CalibrationType: ',str(e))
-                    print('Water calibration parameters uploaded incorrectly!')
+                    logging.error(str(e))
 
     def _LoadCaliPar(self):
         '''load the pre-stored calibration parameters'''
@@ -570,7 +569,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                                         self.WeightBeforeLeft.setText(self.TubeWeightLeft.text())
                                     self.TubeWeightLeft.setText('')
                                 except Exception as e:
-                                    print('dialogs._StartCalibratingLeft: ',str(e))
+                                    logging.error(str(e))
                                     continuetag=0
                                     self.Warning.setText('Please enter the correct weight after(mg)/weight before(mg) and click the continue button again!\nOr enter a negative value to repeat the current calibration.')
                         if continuetag==1:
@@ -583,7 +582,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                     else:
                         break
                 except Exception as e:
-                    print('dialogs._StartCalibratingLeft,2: ',str(e))
+                    logging.error(str(e))
                     break
         try: 
             # calibration complete indication
@@ -591,7 +590,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                 self.Warning.setText('Calibration is complete!')
                 self._UpdateFigure()
         except Exception as e:
-            print('dialogs._StartCalibratingLeft,3: ',str(e))
+            logging.error(str(e))
             self.Warning.setText('Calibration is not complete! Parameters error!')
             self.Warning.setStyleSheet("color: red;")
         # set the default valve open time
@@ -732,7 +731,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                                         self.WeightBeforeRight.setText(self.TubeWeightRight.text())
                                     self.TubeWeightRight.setText('')
                                 except Exception as e:
-                                    print('dialogs.StartCalibratingRight: ',str(e))
+                                    logging.error(str(e))
                                     continuetag=0
                                     self.Warning.setText('Please enter the correct weight after(mg)/tube weight(mg) and click the continue button again!\nOr enter a negative value to repeat the current calibration.')
                         if continuetag==1:
@@ -745,7 +744,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                     else:
                         break
                 except Exception as e:
-                    print('dialogs.StartCalibratingRight,2: ',str(e))
+                    logging.error(str(e))
                     break
         try: 
             # calibration complete indication
@@ -753,7 +752,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
                 self.Warning.setText('Calibration is complete!')
                 self._UpdateFigure()
         except Exception as e:
-            print('dialogs.StartCalibrationRight,3: ',str(e))
+            logging.error(str(e))
             self.Warning.setText('Calibration is not complete! Parameters error!')
             self.Warning.setStyleSheet("color: red;")
 
@@ -867,24 +866,7 @@ class WaterCalibrationDialog(QDialog,Ui_WaterCalibration):
             self.MainWindow.Channel3.ManualWater_Right(int(1))
             # set the default valve open time
             self.MainWindow.Channel.RightValue(float(self.MainWindow.RightValue.text())*1000)
-    """
-    def _thread_completeLeft(self):
-        '''Finish of left valve calibration'''
-        self.FinishLeftValve=1
-        print(self.FinishLeftValve)
-    def _OpenLeft(self):
-        '''Calibration of left valve'''
-        if self.OpenLeftTag==0:
-            workerLeft = Worker(self._OpenLeftThread,self.MainWindow.Channel)
-            workerLeft.signals.finished.connect(self._thread_completeLeft)
-            self.workerLeft=workerLeft
-            self.OpenLeftTag=1
-        else:
-            workerLeft=self.workerLeft
-        if self.OpenLeft.isChecked() and self.FinishLeftValve==1:
-            self.FinishLeftValve=0
-            self.threadpoolL.start(workerLeft)
-    """
+
     def _OpenLeft(self):    
         '''Calibration of left valve in a different thread'''
         if self.OpenLeft.isChecked():
@@ -949,7 +931,7 @@ class CameraDialog(QDialog,Ui_Camera):
             try:
                 subprocess.Popen(['explorer', self.MainWindow.Ot_log_folder])
             except Exception as e:
-                print('dialogs._OpenSaveFolder: ', str(e))
+                logging.error(str(e))
                 self.WarningLabelOpenSave.setText('No logging folder found!')
                 self.WarningLabelOpenSave.setStyleSheet("color: red;")
         else:
@@ -994,11 +976,11 @@ class CameraDialog(QDialog,Ui_Camera):
             # Remove a directory and its contents (recursively)
             if os.path.exists(self.MainWindow.temporary_video_folder):
                 shutil.rmtree(self.MainWindow.temporary_video_folder)
-                print(f"Directory '{self.MainWindow.temporary_video_folder}' and its contents removed successfully.")
+                logging.info(f"Directory '{self.MainWindow.temporary_video_folder}' and its contents removed successfully.")
             else:
-                print(f"Directory '{self.MainWindow.temporary_video_folder}' does not exist.")
+                logging.info(f"Directory '{self.MainWindow.temporary_video_folder}' does not exist.")
         except Exception as e:
-            print('dialogs.ClearTemporaryVideo: ',str(e))
+            logging.error(str(e))
 
     def _StartCamera(self):
         '''Start/stop the camera'''
@@ -1412,7 +1394,7 @@ class LaserCalibrationDialog(QDialog,Ui_CalibrationLaser):
         try:
             self.LCM_MeasureTime.copy()
         except Exception as e:
-            print('dialogs.Save: ',str(e))
+            logging.error(str(e))
             self.Warning.setText('Data not saved! Please Capture the power first!')
             self.Warning.setStyleSheet("color: red;")
             self.Warning.setAlignment(Qt.AlignCenter)
@@ -1612,7 +1594,7 @@ class LaserCalibrationDialog(QDialog,Ui_CalibrationLaser):
                 Sum=Sum+float(List[i])
                 N=N+1
             except Exception as e:
-                print('dialogs.getmean: ',str(e))
+                logging.error(str(e))
 
         Sum=Sum/N
         return Sum

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2289,30 +2289,58 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 except Exception as e:
                     print('foraging._UpdateSuggestedWater: Error,2 ',str(e))
 
-if __name__ == "__main__":
-    # Start logging
-
-    current_time = datetime.now()
-    formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
+def start_gui_log_file():
+    '''
+        Starts a log file for the gui.
+        The log file is located at C:/Users/<username>/Documents/foraging_gui_logs
+        One log file is created for each time the GUI is started
+        The name of the gui file is tower_<tower num>_gui_log_<date and time>.txt
+        If no tower number is available, then tower_num = 0
+    '''
+    # Check if the log folder exists, if it doesn't make it
     logging_folder = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs')
     if not os.path.exists(logging_folder):
         os.makedirs(logging_folder)
-    logging_filename = os.path.join(logging_folder,'gui_log_'+formatted_datetime+'.txt')
+
+    # Determine name of this log file
+    # Get current time
+    current_time = datetime.now()
+    formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
+
+    # What tower is this for?
+    if len(sys.argv) >=2:
+        tower_num = sys.argv[1]
+    else:
+        tower_num = 0
+
+    # Build logfile name
+    filename = 'tower_{}_gui_log_{}.txt'.format(tower_num,formated_datetime)
+    logging_filename = os.path.join(logging_folder,filename)
+
+    # Start the log file
+    print('Starting a GUI log file at: ')
     print(logging_filename)
-
     logging.basicConfig(filename=logging_filename, level=logging.INFO)
-    logging.info('Starting log')
-    print(sys.argv)
-    logging.info(sys.argv)
+    logging.info('Starting logfile!')
 
+if __name__ == "__main__":
+    # Start logging
+    start_gui_log_file()
+
+    # Formating GUI graphics
+    logging.info('Setting QApplication attributes')
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)
     QApplication.setAttribute(Qt.AA_DisableHighDpiScaling,False)
     QApplication.setAttribute(Qt.AA_Use96Dpi,False)
     QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     
+    # Start Q, and Gui Window
+    logging.info('Starting QApplication and Window')
     app = QApplication(sys.argv)
     win = Window()
     win.show()
     # Run your application's event loop and stop after closing all windows
     sys.exit(app.exec())
+
+

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2294,7 +2294,10 @@ if __name__ == "__main__":
 
     current_time = datetime.now()
     formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
-    logging_filename = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs','gui_log_'+formatted_datetime+'.txt')
+    logging_folder = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs')
+    if not os.path.exists(logging_folder):
+        os.makedirs(logging_folder)
+    logging_filename = os.path.join(logging_folder,'gui_log_'+formatted_datetime+'.txt')
     print(logging_filename)
 
     logging.basicConfig(filename=logging_filename, level=logging.INFO)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -63,11 +63,13 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.TrainingStageFiles=os.path.join(self.SettingFolder,'TrainingStagePar.json')
         try:
             self._GetLaserCalibration()
-        except:
+        except Exception as e:
             print('foraging.Window.__init__: Could not load laser calibration file, continuing')
+            logging.error(str(e))
         try:
             self._GetWaterCalibration()
-        except:
+        except Exception as e:
+            logging.error(str(e))
             print('foraging.Window.__init__: Could not load water calibration file, continuing')
         self.StartANewSession=1 # to decide if should start a new session
         self.ToInitializeVisual=1
@@ -80,8 +82,10 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self._InitializeBonsai()
             self.InitializeBonsaiSuccessfully=1
             print('Bonsai started successfully')
+            logging.info('Bonsai started successfully')
         except Exception as e:
             print('foraging.Window.__init__: An error occurred while initializing Bonsai:', str(e))
+            logging.error('Initializing Bonsai: {}'.format(str(e)))
             self.InitializeBonsaiSuccessfully=0
             self.WarningLabel_2.setText('Start without bonsai connected!')
             self.WarningLabel_2.setStyleSheet("color: red;")

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2287,6 +2287,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
 
 if __name__ == "__main__":
     # Start logging
+    logging_filename= 'test_log.txt'
     logging.basicConfig(filename=logging_filename, level=logging.DEBUG)
     logging.info('Starting log')
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -825,7 +825,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     if not (isinstance(widget, QtWidgets.QComboBox) or isinstance(widget, QtWidgets.QPushButton)):
                         widget.clear()
         except Exception as e:
-            # Catch the exception and print error information
+            # Catch the exception and log error information
             logging.error(str(e))
         
     def _SaveTraining(self):
@@ -922,7 +922,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
             event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, Qt.Key_Return, Qt.KeyboardModifiers())
         if (event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter):
             # handle the return key press event here
-            print("Parameter changes confirmed!")
             logging.info('parameter changes confirmed')
             # prevent the default behavior of the return key press event
             event.accept()
@@ -953,7 +952,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         float(child.text())
                     except Exception as e:
                         logging.error(str(e))
-                        print('foraging.keyPressEvent: Error ', str(e))
                         if isinstance(child, QtWidgets.QDoubleSpinBox):
                             child.setValue(float(getattr(Parameters, 'TP_'+child.objectName())))
                         elif isinstance(child, QtWidgets.QSpinBox):
@@ -1004,7 +1002,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
                             float(child.text())
                             self.UpdateParameters=0 # Changes are not allowed until press is typed
                         except Exception as e:
-                            print('An error occurred when changing a parameter (Foraging.py):', str(e))
                             logging.error(str(e))
                             # Invalid float. Do not change the parameter
                             if isinstance(child, QtWidgets.QDoubleSpinBox):
@@ -1020,7 +1017,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         child.setStyleSheet('color: black;')
                         child.setStyleSheet('background-color: white;')
                 except Exception as e:
-                    print('An error occured when changing a parameters (Foraging.py,2):',str(e))
                     logging.error(str(e))
 
     def _CheckFormat(self,child):
@@ -1272,7 +1268,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 else:
                     self.ShowRewardPairs.setText('Reward pairs: '+str(np.round(self.RewardProb,2))+'\n\n'+'Current pair: ') 
         except Exception as e:
-            # Catch the exception and print error information
+            # Catch the exception and log error information
             logging.error(str(e))
 
     def closeEvent(self, event):
@@ -1469,7 +1465,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.CreateNewFolder=0
         if not os.path.exists(os.path.dirname(self.SaveFileJson)):
             os.makedirs(os.path.dirname(self.SaveFileJson))
-            print(f"Created new folder: {os.path.dirname(self.SaveFileJson)}")
             logging.info(f"Created new folder: {os.path.dirname(self.SaveFileJson)}")
         Names = QFileDialog.getSaveFileName(self, 'Save File',self.SaveFileJson,"JSON files (*.json);;MAT files (*.mat);;JSON parameters (*_par.json)")
         if Names[1]=='JSON parameters (*_par.json)':
@@ -1598,28 +1593,24 @@ class Window(QMainWindow, Ui_ForagingGUI):
         if CTrainingFolder==1:
             if not os.path.exists(self.TrainingFolder):
                 os.makedirs(self.TrainingFolder)
-                print(f"Created new folder: {self.TrainingFolder}")
                 logging.info(f"Created new folder: {self.TrainingFolder}")
         if CHarpFolder==1:
             if not os.path.exists(self.HarpFolder):
                 os.makedirs(self.HarpFolder)
-                print(f"Created new folder: {self.HarpFolder}")
                 logging.info(f"Created new folder: {self.HarpFolder}")
         if CVideoFolder==1:
             if not os.path.exists(self.VideoFolder):
                 os.makedirs(self.VideoFolder)
-                print(f"Created new folder: {self.VideoFolder}")
                 logging.info(f"Created new folder: {self.VideoFolder}")
         if CPhotometryFolder==1:
             if not os.path.exists(self.PhotometryFolder):
                 os.makedirs(self.PhotometryFolder)
-                print(f"Created new folder: {self.PhotometryFolder}")
                 logging.info(f"Created new folder: {self.PhotometryFolder}")
         if CEphysFolder==1:
             if not os.path.exists(self.EphysFolder):
                 os.makedirs(self.EphysFolder)
-                print(f"Created new folder: {self.EphysFolder}")
                 logging.info(f"Created new folder: {self.EphysFolder}")
+
     def _GetSaveFileName(self):
         '''Get the name of the save file. This is an old data structure and has been deprecated.'''
         SaveFileMat = os.path.join(self.default_saveFolder, self.Tower.currentText(),self.AnimalName.text(), f'{self.AnimalName.text()}_{date.today()}.mat')
@@ -1627,7 +1618,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
         SaveFileParJson= os.path.join(self.default_saveFolder, self.Tower.currentText(),self.AnimalName.text(), f'{self.AnimalName.text()}_{date.today()}_par.json')
         if not os.path.exists(os.path.dirname(SaveFileJson)):
             os.makedirs(os.path.dirname(SaveFileJson))
-            print(f"Created new folder: {os.path.dirname(SaveFileJson)}")
             logging.info(f"Created new folder: {os.path.dirname(SaveFileJson)}")
         N=0
         while 1:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -40,6 +40,7 @@ class NumpyEncoder(json.JSONEncoder):
     
 class Window(QMainWindow, Ui_ForagingGUI):
     def __init__(self, parent=None):
+        logging.info('Creating Window')
         super().__init__(parent)
         self.setupUi(self)
         
@@ -63,10 +64,12 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.TrainingStageFiles=os.path.join(self.SettingFolder,'TrainingStagePar.json')
         try:
             self._GetLaserCalibration()
+            logging.info('Loaded Laser Calibration')
         except Exception as e:
             logging.error('Could not load laser calibration file: {}'.format(str(e)))
         try:
             self._GetWaterCalibration()
+            logging.info('Loaded Water Calibration')
         except Exception as e:
             logging.error('Could not load water calibration file: {}'.format(str(e)))
         self.StartANewSession=1 # to decide if should start a new session
@@ -122,6 +125,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         self._StageSerialNum()
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
+
     def connectSignalsSlots(self):
         '''Define callbacks'''
         self.action_About.triggered.connect(self._about)
@@ -498,13 +502,16 @@ class Window(QMainWindow, Ui_ForagingGUI):
 
     def _InitializeBonsai(self):
         '''Initializing osc messages'''
+        logging.info('initializing Bonsai')
         # open the bondai workflow and run
         self._OpenBonsaiWorkflow()
         time.sleep(3)
         self._ConnectOSC()
+
     def _ConnectOSC(self):
         '''Connect the GUI and Bonsai through OSC messages'''    
         # connect the bonsai workflow with the python GUI
+        logging.info('connecting to GUI and Bonsai through OSC')
         self.ip = "127.0.0.1"
         if len(sys.argv)==1:
             self.bonsai_tag=1
@@ -600,12 +607,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
             subprocess.Popen(['explorer', self.SettingFolder])
         except Exception as e:
             logging.error(str(e))
+
     def _ForceSave(self):
         '''Save whether the current trial is complete or not'''
         self._Save(ForceSave=1)
+
     def _SaveContinue(self):
         '''Do not restart a session after saving'''
         self._Save(SaveContinue=1)
+
     def _WaterVolumnManage1(self):
         '''Change the water volume based on the valve open time'''
         self.LeftValue.textChanged.disconnect(self._WaterVolumnManage1)
@@ -740,12 +750,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
     def _OpenLoggingFolder(self):
         '''Open the logging folder'''
         self.Camera_dialog._OpenSaveFolder()
+
     def _startTemporaryLogging(self):
         '''Restart the temporary logging'''
         self.Ot_log_folder=self._restartlogging(self.temporary_video_folder)
+
     def _startFormalLogging(self):
         '''Restart the formal logging'''
         self.Ot_log_folder=self._restartlogging()
+
     def _TrainingStage(self):
         '''Change the parameters automatically based on training stage and task'''
         self.WarningLabel_SaveTrainingStage.setText('')
@@ -830,6 +843,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         
     def _SaveTraining(self):
         '''Save the training stage parameters'''
+        logging.info('Saving training stage parameters')
         # load the pre-stored training stage parameters
         self._LoadTrainingPar()
         # get the current training stage parameters
@@ -858,12 +872,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
         self.WarningLabel_SaveTrainingStage.setText('Training stage parameters were saved!')
         self.WarningLabel_SaveTrainingStage.setStyleSheet("color: red;")
         self.SaveTraining.setChecked(False)
+
     def _LoadTrainingPar(self):
         '''load the training stage parameters'''
+        logging.info('loading training stage parameters')
         self.TrainingStagePar={}
         if os.path.exists(self.TrainingStageFiles):
             with open(self.TrainingStageFiles, 'r') as f:
                 self.TrainingStagePar = json.load(f)
+
     def _Randomness(self):
         '''enable/disable some fields in the Block/Delay Period/ITI'''
         if self.Randomness.currentText()=='Exponential':
@@ -888,6 +905,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 border_style = "1px solid " + border_color
                 self.BlockBeta.setStyleSheet(f"color: gray;border:{border_style};background-color: rgba(0, 0, 0, 0);")
                 self.label_14.setStyleSheet("color: gray;background-color: rgba(0, 0, 0, 0);")
+
     def _AdvancedBlockAuto(self):
         '''enable/disable some fields in the AdvancedBlockAuto'''
         if self.AdvancedBlockAuto.currentText()=='off':
@@ -900,6 +918,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.label_60.setEnabled(True)
             self.SwitchThr.setEnabled(True)
             self.PointsInARow.setEnabled(True)
+
     def keyPressEvent(self, event=None):
         '''Enter press to allow change of parameters'''
         try:
@@ -1081,6 +1100,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 # Set an attribute in self with the name 'TP_' followed by the child's object name
                 # and store whether the child is checked or not
                 setattr(self, 'TP_'+child.objectName(), child.isChecked())
+
     def _Task(self):
         '''hide and show some fields based on the task type'''
         self.label_43.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
@@ -1308,15 +1328,18 @@ class Window(QMainWindow, Ui_ForagingGUI):
 
     def _Exit(self):
         '''Close the GUI'''
+        logging.info('closing the GUI')
         response = QMessageBox.question(self,'Save and Exit:', "Do you want to save the current result?", QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,QMessageBox.Yes)
         if response==QMessageBox.Yes:
             self._Save()
             self.close()
         elif response==QMessageBox.No:
             self.close()
+
     def _Snipping(self):
         '''Open the snipping tool'''
         os.system("start %windir%\system32\SnippingTool.exe") 
+
     def _Optogenetics(self):
         '''will be triggered when the optogenetics icon is pressed'''
         if self.OpenOptogenetics==0:
@@ -1326,6 +1349,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.Opto_dialog.show()
         else:
             self.Opto_dialog.hide()
+
     def _Camera(self):
         '''Open the camera. It's not available now'''
         if self.Camera==0:
@@ -1335,6 +1359,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.Camera_dialog.show()
         else:
             self.Camera_dialog.hide()
+
     def _Manipulator(self):
         if self.Manipulator==0:
             self.ManipulatoB_dialog = ManipulatorDialog(MainWindow=self)
@@ -1343,6 +1368,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.ManipulatoB_dialog.show()
         else:
             self.ManipulatoB_dialog.hide()
+
     def _WaterCalibration(self):
         if self.WaterCalibration==0:
             self.WaterCalibration_dialog = WaterCalibrationDialog(MainWindow=self)
@@ -1351,6 +1377,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.WaterCalibration_dialog.show()
         else:
             self.WaterCalibration_dialog.hide()
+
     def _LaserCalibration(self):
         if self.LaserCalibration==0:
             self.LaserCalibration_dialog = LaserCalibrationDialog(MainWindow=self)
@@ -1359,6 +1386,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.LaserCalibration_dialog.show()
         else:
             self.LaserCalibration_dialog.hide()
+
     def _MotorStage(self):
         if self.MotorStage==0:
             self.MotorStage_dialog = MotorStageDialog(MainWindow=self)
@@ -1443,6 +1471,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         )
    
     def _Save(self,ForceSave=0,SaveContinue=0):
+        logging.info('Saving current session, ForceSave={},SaveContinue={}'.format(ForceSave,SaveContinue))
         if ForceSave==0:
             self._StopCurrentSession() # stop the current session first
         if self.WeightBefore.text()=='' or self.WeightAfter.text()=='' or self.ExtraWater.text()=='':
@@ -1451,10 +1480,14 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 pass
                 self.WarningLabel.setText('Saving without weight or extra water!')
                 self.WarningLabel.setStyleSheet("color: red;")
+                logging.info('saving without weight or extra water')
             elif response==QMessageBox.No:
+                logging.info('saving declined by user')
                 return
             elif response==QMessageBox.Cancel:
+                logging.info('saving canceled by user')
                 return
+
         # this should be improved in the future. Need to get the last LeftRewardDeliveryTime and RightRewardDeliveryTime
         if hasattr(self, 'GeneratedTrials'):
             self.GeneratedTrials._GetLicks(self.Channel2)
@@ -1926,6 +1959,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         else:
             self.NextBlock.setStyleSheet("background-color : none")
     def _NewSession(self):
+        logging.info('starting new session')
         if self.NewSession.isChecked():
             if self.ToInitializeVisual==0: # Do not ask to save when no session starts running
                 reply = QMessageBox.question(self, 'New Session:', 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
@@ -2133,6 +2167,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 logging.error(str(e))
 
     def _StartTrialLoop(self,GeneratedTrials,worker1):
+        logging.info('starting trial loop')
         while self.Start.isChecked():
             QApplication.processEvents()
             if self.ANewTrial==1 and self.Start.isChecked() and self.finish_Timer==1: 
@@ -2166,6 +2201,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     GeneratedTrials._GenerateATrial(self.Channel4)     
 
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):
+        logging.info('starting trial loop 1')
         while self.Start.isChecked():
             QApplication.processEvents()
             if self.ANewTrial==1 and self.ToGenerateATrial==1 and self.Start.isChecked(): 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2291,9 +2291,16 @@ class Window(QMainWindow, Ui_ForagingGUI):
 
 if __name__ == "__main__":
     # Start logging
-    logging_filename= 'test_log.txt'
-    logging.basicConfig(filename=logging_filename, level=logging.DEBUG)
+
+    current_time = datetime.now()
+    formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
+    logging_filename = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs','gui_log_'+formatted_datetime+'.txt')
+    print(logging_filename)
+
+    logging.basicConfig(filename=logging_filename, level=logging.INFO)
     logging.info('Starting log')
+    print(sys.argv)
+    logging.info(sys.argv)
 
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -347,7 +347,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self._ConnectOSC()
                 self.InitializeBonsaiSuccessfully=1
             except Exception as e:
-                print('foraging._ConnectBonsai: Error ',str(e))
+                logging.error(str(e))
                 self.WarningLabelInitializeBonsai.setText('Please open bonsai!')
                 self.WarningLabelInitializeBonsai.setStyleSheet("color: red;")
                 self.InitializeBonsaiSuccessfully=0
@@ -475,7 +475,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.newscale_port_tower3=''
                 self.newscale_port_tower4=''
         except Exception as e:
-            print('foraging._GetSettings: Error ',str(e))
+            logging.error(str(e))
             self.default_saveFolder=os.path.join(os.path.expanduser("~"), "Documents")+'\\'
             self.current_box=''
             self.Teensy_COM=''
@@ -495,6 +495,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         index = self.Tower.findText(self.current_box)
         if index != -1:
             self.Tower.setCurrentIndex(index)
+
     def _InitializeBonsai(self):
         '''Initializing osc messages'''
         # open the bondai workflow and run
@@ -598,7 +599,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try:
             subprocess.Popen(['explorer', self.SettingFolder])
         except Exception as e:
-            print('foraging._OpenSettingFolder: Error ',str(e))
+            logging.error(str(e))
     def _ForceSave(self):
         '''Save whether the current trial is complete or not'''
         self._Save(ForceSave=1)
@@ -706,7 +707,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             elif direction==-1:
                 widget2.setValue((float(widget1.text())-self.latest_fitting[valve][1])/self.latest_fitting[valve][0])
         except Exception as e:
-            print('foraging._ValvetimeVolumnTransformation: Error ',str(e))
+            logging.error(str(e))
 
     def _GetLatestFitting(self,FittingResults):
         '''Get the latest fitting results from water calibration'''
@@ -729,12 +730,12 @@ class Window(QMainWindow, Ui_ForagingGUI):
             folder_name=os.path.dirname(self.SaveFileJson)
             subprocess.Popen(['explorer', folder_name])
         except Exception as e:
-            print('foraging._OpenBehaviorFolder: Error ',str(e))
+            logging.error(str(e))
             try:
                 AnimalFolder=os.path.join(self.default_saveFolder, self.Tower.currentText(),self.AnimalName.text())
                 subprocess.Popen(['explorer', AnimalFolder])
             except:
-                print('foraging._OpenBehaviorFolder,2: Error ',str(e))
+                logging.error(str(e))
 
     def _OpenLoggingFolder(self):
         '''Open the logging folder'''
@@ -772,7 +773,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         Tag=0
                     # sometimes we only have training parameters, no behavior parameters
                     except Exception as e:
-                        print('foraging._TrainingStage: Error ',str(e))
+                        logging.error(str(e))
                         value=self.TrainingStagePar[Task][CurrentTrainingStage][key]
                         Tag=1
                     if isinstance(widget, QtWidgets.QPushButton):
@@ -825,8 +826,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         widget.clear()
         except Exception as e:
             # Catch the exception and print error information
-            print("foraging._TrainingStage: Error ",str(e))
-            print(traceback.format_exc())
+            logging.error(str(e))
         
     def _SaveTraining(self):
         '''Save the training stage parameters'''
@@ -923,6 +923,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         if (event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter):
             # handle the return key press event here
             print("Parameter changes confirmed!")
+            logging.info('parameter changes confirmed')
             # prevent the default behavior of the return key press event
             event.accept()
             self.UpdateParameters=1 # Changes are allowed
@@ -951,6 +952,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         # it's valid float
                         float(child.text())
                     except Exception as e:
+                        logging.error(str(e))
                         print('foraging.keyPressEvent: Error ', str(e))
                         if isinstance(child, QtWidgets.QDoubleSpinBox):
                             child.setValue(float(getattr(Parameters, 'TP_'+child.objectName())))
@@ -1003,6 +1005,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                             self.UpdateParameters=0 # Changes are not allowed until press is typed
                         except Exception as e:
                             print('An error occurred when changing a parameter (Foraging.py):', str(e))
+                            logging.error(str(e))
                             # Invalid float. Do not change the parameter
                             if isinstance(child, QtWidgets.QDoubleSpinBox):
                                 child.setValue(float(getattr(Parameters, 'TP_'+child.objectName())))
@@ -1018,6 +1021,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         child.setStyleSheet('background-color: white;')
                 except Exception as e:
                     print('An error occured when changing a parameters (Foraging.py,2):',str(e))
+                    logging.error(str(e))
 
     def _CheckFormat(self,child):
         '''Check if the input format is correct'''
@@ -1028,7 +1032,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     self.RewardPairsN.setText(str(len(self.RewardFamilies[int(self.RewardFamily.text())-1])))
                 return 1
             except Exception as e:
-                print('foraging._CheckFormat: Error ', str(e))
+                logging.error(str(e))
                 return 0
         if child.objectName()=='RewardFamily' or child.objectName()=='RewardPairsN' or child.objectName()=='BaseRewardSum':
             try:
@@ -1038,7 +1042,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 else:
                     return 1
             except Exception as e: 
-                print('foraging._CheckFormat,2: Error ', str(e))
+                logging.error(str(e))
                 return 0
         if child.objectName()=='UncoupledReward':
             try:
@@ -1055,7 +1059,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.RewardProb=np.array(num_list)
                 return 1
             except Exception as e: 
-                print('foraging._CheckFormat,3: Error ', str(e))
+                logging.error(str(e))
                 return 0
         else:
             return 1
@@ -1269,7 +1273,8 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     self.ShowRewardPairs.setText('Reward pairs: '+str(np.round(self.RewardProb,2))+'\n\n'+'Current pair: ') 
         except Exception as e:
             # Catch the exception and print error information
-            print("An error occurred when plotting reward pairs (Foraging.py):",str(e))
+            logging.error(str(e))
+
     def closeEvent(self, event):
         # disable close icon
         self.setWindowFlag(QtCore.Qt.WindowCloseButtonHint, False)
@@ -1289,7 +1294,8 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.client3.close()
                 self.client4.close()
             self.Opto_dialog.close()
-            print('Window closed')
+            print('GUI Window closed')
+            logging.info('GUI Window closed')
         elif reply == QMessageBox.No:
             event.accept()
             self.Start.setChecked(False)
@@ -1298,7 +1304,8 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.client2.close()
                 self.client3.close()
                 self.client4.close()
-            print('Window closed')
+            print('GUI Window closed')
+            logging.info('GUI Window closed')
             self.Opto_dialog.close()
         else:
             event.ignore()
@@ -1394,7 +1401,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try:
             self.PlotTime._Update(self)
         except Exception as e:
-            print('foraging._TimeDistribution: Error', str(e))
+            logging.error(str(e))
 
     def _LickSta(self):
         '''Licks statistics'''
@@ -1425,7 +1432,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try:
             self.PlotLick._Update(GeneratedTrials=self.GeneratedTrials)
         except Exception as e:
-            print('foraging._LickSta: Error' , str(e))
+            logging.error(str(e))
 
     def _about(self):
         QMessageBox.about(
@@ -1463,6 +1470,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         if not os.path.exists(os.path.dirname(self.SaveFileJson)):
             os.makedirs(os.path.dirname(self.SaveFileJson))
             print(f"Created new folder: {os.path.dirname(self.SaveFileJson)}")
+            logging.info(f"Created new folder: {os.path.dirname(self.SaveFileJson)}")
         Names = QFileDialog.getSaveFileName(self, 'Save File',self.SaveFileJson,"JSON files (*.json);;MAT files (*.mat);;JSON parameters (*_par.json)")
         if Names[1]=='JSON parameters (*_par.json)':
             self.SaveFile=Names[0].replace('.json', '_par.json')
@@ -1509,7 +1517,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                                 else:
                                     Obj[attr_name]=Value
                             except Exception as e:
-                                print('foraging._save: Error, casting to nan', str(e))
+                                logging.error(str(e))
                                 Obj[attr_name]=Value
             # save other events, e.g. session start time
             for attr_name in dir(self):
@@ -1528,7 +1536,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 try:
                     Obj['LaserCalibrationResults']=self.LaserCalibrationResults
                 except Exception as e:
-                    print('foraging._Save: Error, LaserCalibrationResults ', str(e))
+                    logging.error(str(e))
 
             # save water calibration results
             if hasattr(self, 'WaterCalibrationResults'):
@@ -1536,7 +1544,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 try:
                     Obj['WaterCalibrationResults']=self.WaterCalibrationResults
                 except Exception as e:
-                    print('foraging._Save: Error, WaterCalibrationResults ',str(e))
+                    logging.error(str(e))
             # save ohter fields start with Ot_
             for attr_name in dir(self):
                 if attr_name.startswith('Ot_'):
@@ -1564,7 +1572,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 try:
                     self.Channel.StopLogging('s')
                 except Exception as e:
-                    print('foraging._Save: Error, StopLogging ', str(e))
+                    logging.error(str(e))
 
 
     def _GetSaveFolder(self,CTrainingFolder=1,CHarpFolder=1,CVideoFolder=1,CPhotometryFolder=1,CEphysFolder=1):
@@ -1591,22 +1599,27 @@ class Window(QMainWindow, Ui_ForagingGUI):
             if not os.path.exists(self.TrainingFolder):
                 os.makedirs(self.TrainingFolder)
                 print(f"Created new folder: {self.TrainingFolder}")
+                logging.info(f"Created new folder: {self.TrainingFolder}")
         if CHarpFolder==1:
             if not os.path.exists(self.HarpFolder):
                 os.makedirs(self.HarpFolder)
                 print(f"Created new folder: {self.HarpFolder}")
+                logging.info(f"Created new folder: {self.HarpFolder}")
         if CVideoFolder==1:
             if not os.path.exists(self.VideoFolder):
                 os.makedirs(self.VideoFolder)
                 print(f"Created new folder: {self.VideoFolder}")
+                logging.info(f"Created new folder: {self.VideoFolder}")
         if CPhotometryFolder==1:
             if not os.path.exists(self.PhotometryFolder):
                 os.makedirs(self.PhotometryFolder)
                 print(f"Created new folder: {self.PhotometryFolder}")
+                logging.info(f"Created new folder: {self.PhotometryFolder}")
         if CEphysFolder==1:
             if not os.path.exists(self.EphysFolder):
                 os.makedirs(self.EphysFolder)
                 print(f"Created new folder: {self.EphysFolder}")
+                logging.info(f"Created new folder: {self.EphysFolder}")
     def _GetSaveFileName(self):
         '''Get the name of the save file. This is an old data structure and has been deprecated.'''
         SaveFileMat = os.path.join(self.default_saveFolder, self.Tower.currentText(),self.AnimalName.text(), f'{self.AnimalName.text()}_{date.today()}.mat')
@@ -1615,6 +1628,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         if not os.path.exists(os.path.dirname(SaveFileJson)):
             os.makedirs(os.path.dirname(SaveFileJson))
             print(f"Created new folder: {os.path.dirname(SaveFileJson)}")
+            logging.info(f"Created new folder: {os.path.dirname(SaveFileJson)}")
         N=0
         while 1:
             if os.path.isfile(SaveFileMat) or os.path.isfile(SaveFileJson)or os.path.isfile(SaveFileParJson):
@@ -1696,7 +1710,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         else:
                             CurrentObj=Obj.copy()
                     except Exception as e:
-                        print('foraging._Open: Error,1 ',str(e))
+                        logging.error(str(e))
                         continue
                     if key in CurrentObj:
                         # skip some keys
@@ -1708,7 +1722,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                             value=np.array([CurrentObj['TP_'+key][-2]])
                             Tag=0
                         except: # sometimes we only have training parameters, no behavior parameters
-                            print('foraging._Open: Error,2 ',str(e))
+                            logging.error(str(e))
                             value=CurrentObj[key]
                             Tag=1
                         if isinstance(widget, QtWidgets.QPushButton):
@@ -1763,15 +1777,13 @@ class Window(QMainWindow, Ui_ForagingGUI):
                             widget.clear()
             except Exception as e:
                 # Catch the exception and print error information
-                print('foraging._Open: Error,3 ',str(e))
-                print(traceback.format_exc())
+                logging.error(str(e))
             try:
                 # visualization when loading the data
                 self._LoadVisualization()
             except Exception as e:
                 # Catch the exception and print error information
-                print("foraging._Open: Error,4 ",str(e))
-                print(traceback.format_exc())
+                logging.error(str(e))
                 # delete GeneratedTrials
                 del self.GeneratedTrials
             # show basic information
@@ -1788,7 +1800,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     try:
                         self.current_stage.move_absolute_3d(float(last_positions[0]),float(last_positions[1]),float(last_positions[2]))
                     except Exception as e:
-                        print('foraging._Open: Error,5 ',str(e))
+                        logging.error(str(e))
             else:
                 pass
                     
@@ -1815,7 +1827,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     # Set the attribute in the GeneratedTrials object
                     setattr(self.GeneratedTrials, attr_name, value)
                 except Exception as e:
-                    print('foraging._LoadVisualization: Error ', str(e))
+                    logging.error(str(e))
         if self.GeneratedTrials.B_AnimalResponseHistory.size==0:
             del self.GeneratedTrials
             return
@@ -1868,7 +1880,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.TeensyWarning.setText('Start excitation!')
                 self.TeensyWarning.setStyleSheet("color: red;")
             except Exception as e:
-                print('foraging._StartExcitation: Error ' ,str(e))
+                logging.error(str(e))
                 self.TeensyWarning.setText('Error: start excitation!')
                 self.TeensyWarning.setStyleSheet("color: red;")
         else:
@@ -1881,7 +1893,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.TeensyWarning.setText('Stop excitation!')
                 self.TeensyWarning.setStyleSheet("color: red;")
             except Exception as e:
-                print('foraging._StartExcitation: Error,1 ', str(e))
+                logging.error(str(e))
                 self.TeensyWarning.setText('Error: stop excitation!')
                 self.TeensyWarning.setStyleSheet("color: red;")
     
@@ -1896,7 +1908,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.TeensyWarning.setText('Start bleaching!')
                 self.TeensyWarning.setStyleSheet("color: red;")
             except Exception as e:
-                print('foraging._StartBleaching: Error ',str(e))
+                logging.error(str(e))
                 self.TeensyWarning.setText('Error: start bleaching!')
                 self.TeensyWarning.setStyleSheet("color: red;")
         else:
@@ -1909,7 +1921,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.TeensyWarning.setText('Stop bleaching!')
                 self.TeensyWarning.setStyleSheet("color: red;")
             except Exception as e:
-                print('foraging._StartBleaching: Error ',str(e))
+                logging.error(str(e))
                 self.TeensyWarning.setText('Error: stop bleaching!')
                 self.TeensyWarning.setStyleSheet("color: red;")
 
@@ -1940,8 +1952,8 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 try:
                     self.Channel.StopLogging('s')
                 except Exception as e:
-                    print('foraging._NewSession: Error ',str(e))
-                print('Saved')
+                    logging.error(str(e))
+                logging.info('The current session was saved')
             elif reply == QMessageBox.No:
                 self.NewSession.setStyleSheet("background-color : green;")
                 self.Start.setStyleSheet("background-color : none")
@@ -1952,7 +1964,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 try:
                     self.Channel.StopLogging('s')
                 except Exception as e:
-                    print('foraging._NewSession: Error ',str(e))
+                    logging.error(str(e))
             else:
                 self.NewSession.setChecked(False)
                 pass
@@ -1965,7 +1977,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         reply = QMessageBox.question(self, 'New Session:', 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
         if reply == QMessageBox.Yes:
             self._Save()
-            print('Saved')
+            logging.info('The current session was saved')
         elif reply == QMessageBox.No:
             pass
         else:
@@ -2128,22 +2140,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
             try:
                 self.PlotM._Update(GeneratedTrials=GeneratedTrials,Channel=self.Channel2)
             except Exception as e:
-                print('foraging._Start: Error ',str(e))
-                pass
-        '''
-        self.test=1
-        if self.test==1:
-            self._StartTrialLoop(GeneratedTrials,worker1,workerPlot,workerGenerateAtrial)
-        else:
-            self.threadpool5.start(workerStartTrialLoop) # I just found the QApplication.processEvents() was better to reduce delay time between trial end the the next trial start 
-        '''
+                logging.error(str(e))
+
     def _StartTrialLoop(self,GeneratedTrials,worker1):
         while self.Start.isChecked():
             QApplication.processEvents()
             if self.ANewTrial==1 and self.Start.isChecked() and self.finish_Timer==1: 
                 self.ANewTrial=0 # can start a new trial when we receive the trial end signal from Bonsai
                 GeneratedTrials.B_CurrentTrialN+=1
-                print('Current trial: '+str(GeneratedTrials.B_CurrentTrialN+1))
+                logging.info('Current trial: '+str(GeneratedTrials.B_CurrentTrialN+1))
                 if not (self.GeneratedTrials.TP_AutoReward  or int(self.GeneratedTrials.TP_BlockMinReward)>0):
                     # generate a new trial and get reward
                     self.NewTrialRewardOrder=1
@@ -2176,7 +2181,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             if self.ANewTrial==1 and self.ToGenerateATrial==1 and self.Start.isChecked(): 
                 self.ANewTrial=0 # can start a new trial when we receive the trial end signal from Bonsai
                 GeneratedTrials.B_CurrentTrialN+=1
-                print('Current trial: '+str(GeneratedTrials.B_CurrentTrialN+1))
+                logging.info('Current trial: '+str(GeneratedTrials.B_CurrentTrialN+1))
                 if not (self.GeneratedTrials.TP_AutoReward  or int(self.GeneratedTrials.TP_BlockMinReward)>0):
                     # generate new trial and get reward
                     self.NewTrialRewardOrder=1
@@ -2276,12 +2281,12 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     try:
                         self.SuggestedWater.setText(self.TotalWater.text())
                     except Exception as e:
-                        print('foraging._UpdateSuggestedWater: Error ',str(e))
+                        logging.error(str(e))
                 try:
                     self.B_SuggestedWater=float(self.TotalWater.text())-np.sum(self.ManualWaterVolume)
                     self.SuggestedWater.setText(str(np.round(self.B_SuggestedWater,3)))
                 except Exception as e:
-                    print('foraging._UpdateSuggestedWater: Error,2 ',str(e))
+                    logging.error(str(e))
 
 def start_gui_log_file():
     '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2319,6 +2319,7 @@ def start_gui_log_file():
         datefmt=log_datefmt
         )
     logging.info('Starting logfile!')
+    logging.captureWarnings(True)
 
 if __name__ == "__main__":
     # Start logging

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2317,10 +2317,18 @@ def start_gui_log_file():
     filename = 'tower_{}_gui_log_{}.txt'.format(tower_num,formatted_datetime)
     logging_filename = os.path.join(logging_folder,filename)
 
+    # Format the log file:
+    log_format = '%(asctime)s:%(levelname)s:%(filename)s:%(funcName)s:%(lineno)d:%(message)s'
+    log_datefmt = '%I:%M:%S %p'
+
     # Start the log file
     print('Starting a GUI log file at: ')
     print(logging_filename)
-    logging.basicConfig(filename=logging_filename, level=logging.INFO)
+    logging.basicConfig(format=log_format,
+        filename=logging_filename, 
+        level=logging.INFO,
+        datefmt=log_datefmt
+        )
     logging.info('Starting logfile!')
 
 if __name__ == "__main__":

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2314,7 +2314,7 @@ def start_gui_log_file():
         tower_num = 0
 
     # Build logfile name
-    filename = 'tower_{}_gui_log_{}.txt'.format(tower_num,formated_datetime)
+    filename = 'tower_{}_gui_log_{}.txt'.format(tower_num,formatted_datetime)
     logging_filename = os.path.join(logging_folder,filename)
 
     # Start the log file

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -64,13 +64,11 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try:
             self._GetLaserCalibration()
         except Exception as e:
-            print('foraging.Window.__init__: Could not load laser calibration file, continuing')
-            logging.error(str(e))
+            logging.error('Could not load laser calibration file: {}'.format(str(e)))
         try:
             self._GetWaterCalibration()
         except Exception as e:
-            logging.error(str(e))
-            print('foraging.Window.__init__: Could not load water calibration file, continuing')
+            logging.error('Could not load water calibration file: {}'.format(str(e)))
         self.StartANewSession=1 # to decide if should start a new session
         self.ToInitializeVisual=1
         self.FigureUpdateTooSlow=0 # if the FigureUpdateTooSlow is true, using different process to update figures
@@ -81,10 +79,8 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try: 
             self._InitializeBonsai()
             self.InitializeBonsaiSuccessfully=1
-            print('Bonsai started successfully')
             logging.info('Bonsai started successfully')
         except Exception as e:
-            print('foraging.Window.__init__: An error occurred while initializing Bonsai:', str(e))
             logging.error('Initializing Bonsai: {}'.format(str(e)))
             self.InitializeBonsaiSuccessfully=0
             self.WarningLabel_2.setText('Start without bonsai connected!')
@@ -235,8 +231,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 relative_postition=(0,0,step)
             self._UpdatePosition(current_position,relative_postition)
         except Exception as e:
-            print('foraging._Move(): Error ', str(e))
-            pass
+            logging.error(str(e))
 
     def _MoveXP(self):
         '''Move X positively'''
@@ -293,7 +288,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try:
             self.instances = NewScaleSerialY.get_instances()
         except Exception as e:
-            print('foraging._StageSerialNum: Error ',str(e))
+            logging.error(str(e))
         if hasattr(self,'current_stage'):
             curent_stage_name=self.current_stage.name
         else:
@@ -304,12 +299,12 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 try:
                     instance.io.close()
                 except Exception as e:
-                    print('foraging._StageSerialNum,2: Error ',str(e))
+                    logging.error(str(e))
                 if instance.sn==self.StageSerialNum.currentText():
                     if curent_stage_name!=instance.sn:
                         self._connect_stage(instance)
         except Exception as e:
-            print('foraging._StageSerialNum,3: Error ',str(e))
+            logging.error(str(e))
 
     def _InitianizeMotorStage(self):
         '''To initianize motor stage'''
@@ -325,8 +320,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     self.Warning_Newscale.setText('Default Newsacle not found!')
                     self.Warning_Newscale.setStyleSheet("color: red;")
         except Exception as e:
-            print('foraging._InitianizeMotorStage: Error ',str(e))
-            pass
+            logging.error('Initializing Motor stage: {}'.format(str(e)))
 
     def _scan_for_usb_stages(self):
         '''Scan available stages'''
@@ -337,7 +331,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.stage_names.append(instance.sn)
             self.StageSerialNum.addItems(self.stage_names)
         except Exception as e:
-            print('foraging._scan_for_usb_stages: Error ',str(e))
+            logging.error(str(e))
 
     def _connect_stage(self,instance):
         '''connect to a stage'''
@@ -2318,7 +2312,7 @@ def start_gui_log_file():
     logging_filename = os.path.join(logging_folder,filename)
 
     # Format the log file:
-    log_format = '%(asctime)s:%(levelname)s:%(filename)s:%(funcName)s:%(lineno)d:%(message)s'
+    log_format = '%(asctime)s:%(levelname)s:%(module)s:%(filename)s:%(funcName)s:line %(lineno)d:%(message)s'
     log_datefmt = '%I:%M:%S %p'
 
     # Start the log file

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -5,6 +5,7 @@ import json
 import time
 import subprocess
 import math
+import logging
 from datetime import date, datetime
 
 import serial 
@@ -2285,6 +2286,10 @@ class Window(QMainWindow, Ui_ForagingGUI):
                     print('foraging._UpdateSuggestedWater: Error,2 ',str(e))
 
 if __name__ == "__main__":
+    # Start logging
+    logging.basicConfig(filename=logging_filename, level=logging.DEBUG)
+    logging.info('Starting log')
+
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)
     QApplication.setAttribute(Qt.AA_DisableHighDpiScaling,False)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -744,7 +744,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             try:
                 AnimalFolder=os.path.join(self.default_saveFolder, self.Tower.currentText(),self.AnimalName.text())
                 subprocess.Popen(['explorer', AnimalFolder])
-            except:
+            except Exception as e:
                 logging.error(str(e))
 
     def _OpenLoggingFolder(self):
@@ -924,14 +924,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
         try:
             if self.actionTime_distribution.isChecked()==True:
                 self.PlotTime._Update(self)
-        except:
-            pass
+        except Exception as e:
+            logging.error(str(e))
+
         # move newscale stage
         if hasattr(self,'current_stage'):
             try:
                 self.current_stage.move_absolute_3d(float(self.PositionX.text()),float(self.PositionY.text()),float(self.PositionZ.text()))
-            except:
-                pass
+            except Exception as e:
+                logging.error(str(e))
         # Get the parameters before change
         if hasattr(self, 'GeneratedTrials') and self.ToInitializeVisual==0: # use the current GUI paramters when no session starts running
             Parameters=self.GeneratedTrials
@@ -1744,7 +1745,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                         try: # load the paramter used by last trial
                             value=np.array([CurrentObj['TP_'+key][-2]])
                             Tag=0
-                        except: # sometimes we only have training parameters, no behavior parameters
+                        except Exception as e: # sometimes we only have training parameters, no behavior parameters
                             logging.error(str(e))
                             value=CurrentObj[key]
                             Tag=1
@@ -2062,13 +2063,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.WarningLabel.setStyleSheet("color: none;")
         else:
             self.Start.setStyleSheet("background-color : none")
-            ''' # update graph when session is stopped
-            try:
-                time.sleep(self.GeneratedTrials.B_ITIHistory[-1]+3)
-                self.PlotM._Update(GeneratedTrials=self.GeneratedTrials)
-            except:
-                pass
-            '''
+
         # waiting for the finish of the last trial
         if self.StartANewSession==1 and self.ANewTrial==0:
             self.WarningLabel.setText('Waiting for the finish of the last trial!')

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -5,6 +5,7 @@ import time
 import sys
 from sys import platform as PLATFORM
 from datetime import datetime
+import logging
 
 import numpy as np
 from itertools import accumulate

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -155,8 +155,8 @@ class GenerateTrials():
             self.B_SelectedCondition.append(0)
             self.CurrentLaserAmplitude=[0,0]
             # Catch the exception and print error information
-            print("MyFunctions.PerformOptogenetics: ",str(e))
-            print(traceback.format_exc())
+            logging.error(str(e))
+
     def _CheckBaitPermitted(self):
         '''Check if bait is permitted of the current trial'''
         #For task rewardN, if this is the "initial N trials" of the active side, no bait will be be given.
@@ -472,7 +472,8 @@ class GenerateTrials():
                 # show current finished trial
                 B_RewardProHistory=self.B_RewardProHistory.copy() 
             else:
-                print('error: no next trial parameters generated')
+                logging.error('no next trial parameters generated')
+
         B_RewardedHistory=self.B_RewardedHistory.copy()
         if CountAutoWater==1:
             if self.TP_IncludeAutoReward=='yes':
@@ -531,7 +532,7 @@ class GenerateTrials():
                 float_value = float(s)
                 TP_LeftValue_volume.append(float_value)
             except ValueError as e:
-                print('MyFunctions.GetBasic,l: ',str(e))
+                logging.error(str(e))
                 TP_LeftValue_volume.append(0)
         TP_LeftValue_volume=np.array(TP_LeftValue_volume)
         TP_LeftValue_volume=TP_LeftValue_volume[0:len(B_RewardedHistory[0])]
@@ -542,7 +543,7 @@ class GenerateTrials():
                 float_value = float(s)
                 TP_RightValue_volume.append(float_value)
             except ValueError as e:
-                print('MyFunctions.GetBasic,r: ',str(e))
+                logging.error(str(e))
                 TP_RightValue_volume.append(0)
         TP_RightValue_volume=np.array(TP_RightValue_volume)
         TP_RightValue_volume=TP_RightValue_volume[0:len(B_RewardedHistory[1])]
@@ -777,7 +778,7 @@ class GenerateTrials():
             elif (self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']):
                 self.win.ShowRewardPairs.setText('Reward pairs: '+str(np.round(self.RewardProbPoolUncoupled,2))+'\n\n'+'Current pair: '+str(np.round(self.B_RewardProHistory[:,self.B_CurrentTrialN],2)))
         except Exception as e:
-            print('MyFunctions.ShowInformation: ',str(e))
+            logging.error(str(e))
         # session start time
         SessionStartTime=self.win.SessionStartTime
         self.win.CurrentTime=datetime.now()
@@ -1440,7 +1441,8 @@ class GenerateTrials():
         try:
             self.TP_log_folder=win.Ot_log_folder
         except Exception as e:
-            print('MyFunctions.GetTrainingParameters: ',str(e))
+            logging.error(str(e))
+
     def _SaveParameters(self):
         for attr_name in dir(self):
             if attr_name.startswith('TP_'):
@@ -1598,7 +1600,7 @@ class Worker(QtCore.QRunnable):
         except ValueError as e:
             exctype, value = sys.exc_info()[:2]
             self.signals.error.emit((exctype, value, traceback.format_exc()))
-            print('MyFunctions.run: ',str(e))
+            logging.error(str(e))
         else:
             self.signals.result.emit(result)  # Return the result of the processing
         finally:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -155,7 +155,7 @@ class GenerateTrials():
             self.B_SelectedCondition.append(0)
             self.CurrentLaserAmplitude=[0,0]
             # Catch the exception and print error information
-            print("An error occurred:",str(e))
+            print("MyFunctions.PerformOptogenetics: ",str(e))
             print(traceback.format_exc())
     def _CheckBaitPermitted(self):
         '''Check if bait is permitted of the current trial'''
@@ -530,7 +530,8 @@ class GenerateTrials():
             try:
                 float_value = float(s)
                 TP_LeftValue_volume.append(float_value)
-            except ValueError:
+            except ValueError as e:
+                print('MyFunctions.GetBasic,l: ',str(e))
                 TP_LeftValue_volume.append(0)
         TP_LeftValue_volume=np.array(TP_LeftValue_volume)
         TP_LeftValue_volume=TP_LeftValue_volume[0:len(B_RewardedHistory[0])]
@@ -540,7 +541,8 @@ class GenerateTrials():
             try:
                 float_value = float(s)
                 TP_RightValue_volume.append(float_value)
-            except ValueError:
+            except ValueError as e:
+                print('MyFunctions.GetBasic,r: ',str(e))
                 TP_RightValue_volume.append(0)
         TP_RightValue_volume=np.array(TP_RightValue_volume)
         TP_RightValue_volume=TP_RightValue_volume[0:len(B_RewardedHistory[1])]
@@ -775,8 +777,7 @@ class GenerateTrials():
             elif (self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']):
                 self.win.ShowRewardPairs.setText('Reward pairs: '+str(np.round(self.RewardProbPoolUncoupled,2))+'\n\n'+'Current pair: '+str(np.round(self.B_RewardProHistory[:,self.B_CurrentTrialN],2)))
         except Exception as e:
-            print('An error',str(e))
-            print('Can not show reward pairs')
+            print('MyFunctions.ShowInformation: ',str(e))
         # session start time
         SessionStartTime=self.win.SessionStartTime
         self.win.CurrentTime=datetime.now()
@@ -1438,8 +1439,8 @@ class GenerateTrials():
         # log folder
         try:
             self.TP_log_folder=win.Ot_log_folder
-        except:
-            pass
+        except Exception as e:
+            print('MyFunctions.GetTrainingParameters: ',str(e))
     def _SaveParameters(self):
         for attr_name in dir(self):
             if attr_name.startswith('TP_'):
@@ -1597,6 +1598,7 @@ class Worker(QtCore.QRunnable):
         except ValueError as e:
             exctype, value = sys.exc_info()[:2]
             self.signals.error.emit((exctype, value, traceback.format_exc()))
+            print('MyFunctions.run: ',str(e))
         else:
             self.signals.result.emit(result)  # Return the result of the processing
         finally:

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -5,6 +5,7 @@ import json
 import os
 import datetime
 from uuid import uuid4
+import logging
 
 import numpy as np
 from scipy.io import loadmat

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -29,7 +29,7 @@ if fname.endswith('.mat'):
                 try:
                     Value=Value.reshape(Value.shape[1],)
                 except Exception as e:
-                    print('TransferToNWB: ',str(e))
+                    logging.error(str(e))
             if Value.shape==(1,):
                 Obj[key]=Value.tolist()[0]
             else:
@@ -86,6 +86,7 @@ nwbfile.subject = Subject(
     weight=obj.WeightBefore,
 )
 print(nwbfile)
+logging.info(nwbfile)
 
 #######       Add trial     #######
 ## behavior events (including trial start/end time; left/right lick time; give left/right reward time) ##

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -28,8 +28,8 @@ if fname.endswith('.mat'):
             if Value.shape[0]==1:
                 try:
                     Value=Value.reshape(Value.shape[1],)
-                except:
-                    pass
+                except Exception as e:
+                    print('TransferToNWB: ',str(e))
             if Value.shape==(1,):
                 Obj[key]=Value.tolist()[0]
             else:

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 from scipy import stats
 from matplotlib.figure import Figure

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -61,13 +61,11 @@ class PlotV(FigureCanvas):
             self._PlotChoice()
             self._PlotLicks()
         except Exception as e:
-            print('visualization.PlotV: ', str(e))
-            pass
+            logging.error(str(e))
         try:
             self._PlotMatching()
         except Exception as e:
-            print('visualization.PlotV,2: ', str(e))
-            pass
+            logging.error(str(e))
         self.finish=1
     def _PlotBlockStructure(self):
         ax2=self.ax2
@@ -262,8 +260,7 @@ class PlotV(FigureCanvas):
             ax.set_xlim([fit_x.min()-2, fit_x.max()+2])
             ax.set_ylim([fit_y.min()-2, fit_y.max()+2])
         except Exception as e:
-            print('visualization.PlotMatching: ',str(e))
-            pass
+            logging.error(str(e))
         self.draw()
 
     def _PlotLicks(self):
@@ -294,6 +291,7 @@ class PlotWaterCalibration(FigureCanvas):
         self.water_win=water_win
         self.WaterCalibrationResults=self.water_win.WaterCalibrationResults
         self.FittingResults={}
+
     def _UpdateKeysSpecificCalibration(self):
         '''update the fields of specific calibration'''
         self.WaterCalibrationResults=self.water_win.WaterCalibrationResults
@@ -306,6 +304,7 @@ class PlotWaterCalibration(FigureCanvas):
         for i in range(self.water_win.showspecificcali.count()):
             if current_item==self.water_win.showspecificcali.itemText(i):
                 self.water_win.showspecificcali.setCurrentIndex(i)
+
     def _Update(self):
         '''update the calibration figure'''
         self.WaterCalibrationResults=self.water_win.WaterCalibrationResults
@@ -398,6 +397,7 @@ class PlotLickDistribution(FigureCanvas):
         self.ax5.set_yticks([])
         
         FigureCanvas.__init__(self, self.fig)
+
     def _Update(self,GeneratedTrials=None):
         self.ax1.cla()
         self.ax2.cla()

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -61,12 +61,12 @@ class PlotV(FigureCanvas):
             self._PlotChoice()
             self._PlotLicks()
         except Exception as e:
-            print('An error occurred:2', str(e))
+            print('visualization.PlotV: ', str(e))
             pass
         try:
             self._PlotMatching()
         except Exception as e:
-            print('An error occurred:3', str(e))
+            print('visualization.PlotV,2: ', str(e))
             pass
         self.finish=1
     def _PlotBlockStructure(self):
@@ -262,7 +262,7 @@ class PlotV(FigureCanvas):
             ax.set_xlim([fit_x.min()-2, fit_x.max()+2])
             ax.set_ylim([fit_y.min()-2, fit_y.max()+2])
         except Exception as e:
-            #print('An error occurred:5', str(e))
+            print('visualization.PlotMatching: ',str(e))
             pass
         self.draw()
 

--- a/src/foraging_gui/rigcontrol.py
+++ b/src/foraging_gui/rigcontrol.py
@@ -1,4 +1,5 @@
 import queue
+import logging
 
 from pyOSC3.OSC3 import OSCMessage
 

--- a/src/foraging_gui/rigcontrol.py
+++ b/src/foraging_gui/rigcontrol.py
@@ -13,7 +13,7 @@ class RigClient:
         msg = OSCMessage(address, args)
         CurrentMessage=[msg.address,args[1][0],msg.values()[2],msg.values()[3]]
         self.msgs.put([msg,args])
-        print(CurrentMessage)
+        logging.info(CurrentMessage)
 
     def send(self, address="", *args):
         message = OSCMessage(address, *args)


### PR DESCRIPTION
**What has changed**
Creates a logging system for warnings and errors from the foraging gui. 
- [x] One log is created for every time the GUI is started. 
- [x] The log is saved at `C:\Users\<username>\Documents\foraging_gui_logs\tower_<number>_gui_log_<time and date>.txt`
- [x] Each log entry contains the time, module, file, function, line number, and a message
- [x] pyOSC prints information to sys.stdout. I could capture stdout to log it, but that seems hacky and likely to cause other problems so I am letting pyOSC go to stdout. 
- [x] The logger captures warnings and adds to the log
- [x] This replaces my previous PR that added print statements to try/except blocks. Now those print statements are logged as errors. 
   - #46 
- [x] Resolves #43
- [ ] Tested on a rig

**Usage**
- To log an item, use `logging.info()`, or `logging.error()`
- More information: https://docs.python.org/3/library/logging.html#
- The log is stored in plain text 

**Expected change in behavior**
- These changes will not be noticeable to the experimenter.
- Instead of printing statements to the terminal window, errors will be logged