### PR TITLE
Documenting how to configure the newscale serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ A [Bonsai](https://bonsai-rx.org/) workflow for lick-based foraging experiments,
   - Change to the `dynamic-foraging-task\bonsai` folder
   - In the command prompt, type: `setup.cmd`
 - Update the firmware of the Harp Behavior Board by following the instructions [here](https://harp-tech.org/docs/articles/firmware.html).
+- Install the USBXpress software, for the newscale motor stage
+- Install the Spinnaker SDK, if a FLIR camera is being used
+- Install the NI-DAQ max driver if a NiDAQ is present (for optogenetics)
 - Create a `conda` environment, with python version 3.8
   - install `conda` [instructions here](https://docs.conda.io/projects/conda/en/latest/user-guide/install/windows/html)
   - Run `miniconda prompt`
@@ -70,6 +73,9 @@ A [Bonsai](https://bonsai-rx.org/) workflow for lick-based foraging experiments,
 - Use `pip` to install this repository:
   - From the top-level directory run `pip install .`
 - Copy `Settings_box1.csv` to `Users\<username>\Documents\ForagingSettings`
+- Configure the newscale device in `ForagingSettings.json`
+  - Open Newscale and hit `connect` to see the serial numbers of the newscale devices
+  - Edit `ForagingSettings.json` to add a line `"newscale_port_tower1":<serial number for rig 1>`
 
 #### To launch the software:
 - Run `foraging.bonsai` in `dynamic-foraging-task\src\workflows` to start Bonsai.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,18 @@ A [Bonsai](https://bonsai-rx.org/) workflow for lick-based foraging experiments,
 - Use `pip` to install this repository:
   - From the top-level directory run `pip install .`
 - Copy `Settings_box1.csv` to `Users\<username>\Documents\ForagingSettings`
-- Configure the newscale device in `ForagingSettings.json`
-  - Open Newscale and hit `connect` to see the serial numbers of the newscale devices
-  - Edit `ForagingSettings.json` to add a line `"newscale_port_tower1":<serial number for rig 1>`
+- Configure `ForagingSettings.json`
+  - Copy the template from `src\foraging_gui\ForagingSettings.json` to `Users\<username>\Documents\ForagingSettings\ForagingSettings.json`
+  - There are four fields that need to be set:
+    - "default_saveFolder": For example "E:\DynamicForagingGUI\BehaviorData\",
+    - "current_box": For example "Tower_EphysRig3", "Blue"
+    - "Teensy_COM": For example "COM10",
+    - "newscale_port_tower1": For example 46103
+      - Open Newscale and hit `connect` to see the serial numbers of the newscale devices
+      - Edit `ForagingSettings.json` to add a line `"newscale_port_tower1":<serial number for rig 1>`
+
+
+
 
 #### To launch the software:
 - Run `foraging.bonsai` in `dynamic-foraging-task\src\workflows` to start Bonsai.


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- [x] Adding documentation into the READme about configuring the newscale devices
- [x] Merging straight to `main` because its just the readme
- [x] More documentation about `ForagingSettings.json`
   
### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/135

### Describe the expected change in behavior from the perspective of the experimenter
Improved documentation in the readme for configuring rigs

### Describe the outcome of testing this update on a rig in 447
- No testing, just documentation




