### PR TITLE
Setting default values of GetLaserCalibration() if no calibration file is found

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -204,10 +204,7 @@ class OptogeneticsDialog(QDialog,Ui_Optogenetics):
             eval('self.OffsetEnd_'+str(Numb)+'.setEnabled('+str(True)+')')
     def _Laser(self,Numb):
         ''' enable/disable items based on laser (blue/green/orange/red/NA)'''
-        try:
-            self.LatestCalibrationDate.setText(self.MainWindow.RecentCalibrationDate)
-        except Exception as e:
-            logging.error(str(e))
+        self.LatestCalibrationDate.setText(self.MainWindow.RecentCalibrationDate)
         Inactlabel=range(2,17)
         if eval('self.Laser_'+str(Numb)+'.currentText()')=='NA':
             Label=False

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -395,12 +395,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
     
     def _GetLaserCalibration(self):
         '''Get the laser calibration results'''
+        print('here')
         if os.path.exists(self.LaserCalibrationFiles):
+            print('here2')
             with open(self.LaserCalibrationFiles, 'r') as f:
                 self.LaserCalibrationResults = json.load(f)
                 sorted_dates = sorted(self.LaserCalibrationResults.keys(), key=self._custom_sort_key)
                 self.RecentLaserCalibration=self.LaserCalibrationResults[sorted_dates[-1]]
                 self.RecentCalibrationDate=sorted_dates[-1]
+                print('here3')
 
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -63,11 +63,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.WaterCalibrationFiles=os.path.join(self.SettingFolder,'WaterCalibration_'+str(sys.argv[1])+'.json')
             self.WaterCalibrationParFiles=os.path.join(self.SettingFolder,'WaterCalibrationPar_'+str(sys.argv[1])+'.json')
             self.TrainingStageFiles=os.path.join(self.SettingFolder,'TrainingStagePar.json')
-        try:
-            self._GetLaserCalibration()
-            logging.info('Loaded Laser Calibration')
-        except Exception as e:
-            logging.error('Could not load laser calibration file: {}'.format(str(e)))
+        self._GetLaserCalibration()
         try:
             self._GetWaterCalibration()
             logging.info('Loaded Water Calibration')
@@ -394,15 +390,29 @@ class Window(QMainWindow, Ui_ForagingGUI):
         return log_folder
     
     def _GetLaserCalibration(self):
-        '''Get the laser calibration results'''
+        '''
+            Load the laser calibration file. 
+
+            If it exists, populate:
+                self.LaserCalibrationResults with the calibration json
+                self.RecentLaserCalibration with the last calibration
+                self.RecentCalibrationDate with the date of the last calibration
+
+            If it does not exist, populate
+                self.LaserCalibrationResults with an empty dictionary
+                self.RecentCalibrationDate with 'None'
+        '''
         if os.path.exists(self.LaserCalibrationFiles):
             with open(self.LaserCalibrationFiles, 'r') as f:
                 self.LaserCalibrationResults = json.load(f)
-                sorted_dates = sorted(self.LaserCalibrationResults.keys(), key=self._custom_sort_key)
+                sorted_dates = sorted(self.LaserCalibrationResults.keys(),key=self._custom_sort_key)
                 self.RecentLaserCalibration=self.LaserCalibrationResults[sorted_dates[-1]]
                 self.RecentCalibrationDate=sorted_dates[-1]
+            logging.info('Loaded Laser Calibration')
         else:
+            self.LaserCalibrationResults = {}
             self.RecentCalibrationDate='None'
+            logging.info('Did not find a recent laser calibration file')
  
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''
@@ -1564,13 +1574,11 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 for attr_name in dir(self.LaserCalibration_dialog):
                     if attr_name.startswith('LCM_'):
                         Obj[attr_name] = getattr(self.LaserCalibration_dialog, attr_name)
+
             # save laser calibration results from the json file
             if hasattr(self, 'LaserCalibrationResults'):
                 self._GetLaserCalibration()
-                try:
-                    Obj['LaserCalibrationResults']=self.LaserCalibrationResults
-                except Exception as e:
-                    logging.error(str(e))
+                Obj['LaserCalibrationResults']=self.LaserCalibrationResults
 
             # save water calibration results
             if hasattr(self, 'WaterCalibrationResults'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -395,16 +395,15 @@ class Window(QMainWindow, Ui_ForagingGUI):
     
     def _GetLaserCalibration(self):
         '''Get the laser calibration results'''
-        print('here')
+        print(self.LaserCalibrationFiles)
         if os.path.exists(self.LaserCalibrationFiles):
-            print('here2')
             with open(self.LaserCalibrationFiles, 'r') as f:
                 self.LaserCalibrationResults = json.load(f)
                 sorted_dates = sorted(self.LaserCalibrationResults.keys(), key=self._custom_sort_key)
                 self.RecentLaserCalibration=self.LaserCalibrationResults[sorted_dates[-1]]
                 self.RecentCalibrationDate=sorted_dates[-1]
-                print('here3')
-
+        self.RecentCalibrationDate='None'
+    
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''
         if os.path.exists(self.WaterCalibrationFiles):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -403,7 +403,8 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.RecentCalibrationDate=sorted_dates[-1]
         else:
             self.RecentCalibrationDate='None'
-    
+        print(self.Laser_)   
+ 
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''
         if os.path.exists(self.WaterCalibrationFiles):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -403,7 +403,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.RecentCalibrationDate=sorted_dates[-1]
         else:
             self.RecentCalibrationDate='None'
-        print(self.Laser_)   
+        print(self.Laser_1)   
  
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -395,14 +395,14 @@ class Window(QMainWindow, Ui_ForagingGUI):
     
     def _GetLaserCalibration(self):
         '''Get the laser calibration results'''
-        print(self.LaserCalibrationFiles)
         if os.path.exists(self.LaserCalibrationFiles):
             with open(self.LaserCalibrationFiles, 'r') as f:
                 self.LaserCalibrationResults = json.load(f)
                 sorted_dates = sorted(self.LaserCalibrationResults.keys(), key=self._custom_sort_key)
                 self.RecentLaserCalibration=self.LaserCalibrationResults[sorted_dates[-1]]
                 self.RecentCalibrationDate=sorted_dates[-1]
-        self.RecentCalibrationDate='None'
+        else:
+            self.RecentCalibrationDate='None'
     
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -403,7 +403,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 self.RecentCalibrationDate=sorted_dates[-1]
         else:
             self.RecentCalibrationDate='None'
-        print(self.Laser_1)   
  
     def _GetWaterCalibration(self):
         '''Get the laser calibration results'''


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- `Foraging._GetLaserCalibration` tries to load the laser calibration file. If none is found, it failed to set the RecentCalibrationDate. 
- Now I sets a default value for the recent calibration date as "None", this prevents an exception from being generated when that variable is accessed. It is used for display purposes only, so I see no downside to setting a default value
- Further, I set an empty dictionary as the value of LaserCalibrationResult, which is added to the `json` file. 
- I do not set a value of `RecentLaserCalibration` because the presence of this attribute is used as a conditional test in the OptogeneticsDialog. 
- After fixing this issue I removed two unnecessary try/except blocks

### What issues or discussions does this update address?
- [x] resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/80

### Describe the expected change in behavior from the perspective of the experimenter
- No changes for someone running a mouse
- The saved data will now always have a `LaserCalibrationResults` entry, and a `LatestCalibrationDate` entry

### Describe the outcome of testing this update on a rig in 447
- [x] Tested in 447 




