### PR TITLE
[do not merge] Updated Bonsai/GUI connections

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -547,6 +547,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         wait = 0
         while wait < max_wait:
             time.sleep(1)
+            wait += 1
             try:
                 self._ConnectOSC()
             except Exception as e:
@@ -555,6 +556,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 logging.info('Connected to Bonsai')               
                 self.InitializeBonsaiSuccessfully=1
                 logging.info('Bonsai started successfully')
+                return
         
         # Could not connect
         logging.info('Could not connect to bonsai with max wait time {} seconds'.format(max_wait))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -557,9 +557,10 @@ class Window(QMainWindow, Ui_ForagingGUI):
         # Test the connection until it completes or we time out
         wait = 0
         max_wait = 30
+        check_every = .5
         while wait < max_wait:
-            time.sleep(1)
-            wait += 1
+            time.sleep(check_every)
+            wait += check_every
             try:
                 self._ConnectOSC()
             except Exception as e:
@@ -567,7 +568,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
                 logging.info('Could not connect, total waiting time {} seconds: '.format(wait)+str(e))
             else:
                 # We could connect
-                logging.info('Connected to Bonsai')               
+                logging.info('Connected to Bonsai after {} seconds'.format(wait))               
                 self.InitializeBonsaiSuccessfully=1
                 logging.info('Bonsai started successfully')
                 return

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -551,7 +551,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             try:
                 self._ConnectOSC()
             except Exception as e:
-                logging.error(str(e))
+                logging.error('Could not connect: '+str(e))
             else:
                 logging.info('Connected to Bonsai')               
                 self.InitializeBonsaiSuccessfully=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -552,7 +552,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             except Exception as e:
                 logging.error(str(e))
             else:
-                logging.info('Connected to Bonsai'                
+                logging.info('Connected to Bonsai')               
                 self.InitializeBonsaiSuccessfully=1
                 logging.info('Bonsai started successfully')
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -77,15 +77,6 @@ class Window(QMainWindow, Ui_ForagingGUI):
         self.Visualization.setTitle(str(date.today()))
         self.loggingstarted=-1
         self._InitializeBonsai()
-        #try: 
-        #    self._InitializeBonsai()
-        #    self.InitializeBonsaiSuccessfully=1
-        #    logging.info('Bonsai started successfully')
-        #except Exception as e:
-        #    logging.error('Initializing Bonsai: {}'.format(str(e)))
-        #    self.InitializeBonsaiSuccessfully=0
-        #    self.WarningLabel_2.setText('Start without bonsai connected!')
-        #    self.WarningLabel_2.setStyleSheet("color: red;")
         self.threadpool=QThreadPool() # get animal response
         self.threadpool2=QThreadPool() # get animal lick
         self.threadpool3=QThreadPool() # visualization
@@ -2484,11 +2475,11 @@ if __name__ == "__main__":
 
     # Formating GUI graphics
     logging.info('Setting QApplication attributes')
-    #QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
-    #QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)
-    #QApplication.setAttribute(Qt.AA_DisableHighDpiScaling,False)
-    #QApplication.setAttribute(Qt.AA_Use96Dpi,False)
-    #QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
+    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)
+    QApplication.setAttribute(Qt.AA_DisableHighDpiScaling,False)
+    QApplication.setAttribute(Qt.AA_Use96Dpi,False)
+    QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     
     # Start Q, and Gui Window
     logging.info('Starting QApplication and Window')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -531,7 +531,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             
             We first attempt to connect, to see if Bonsai is already running. 
             If not, we start Bonsai and check the connection every 500ms.
-            If we wait more than 30 seconds without Bonsai connection we set 
+            If we wait more than 6 seconds without Bonsai connection we set 
             InitializeBonsaiSuccessfully=0 and return
     
         '''
@@ -557,7 +557,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
 
         # Test the connection until it completes or we time out
         wait = 0
-        max_wait = 10
+        max_wait = 6
         check_every = .5
         while wait < max_wait:
             time.sleep(check_every)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -526,39 +526,53 @@ class Window(QMainWindow, Ui_ForagingGUI):
             self.Tower.setCurrentIndex(index)
 
     def _InitializeBonsai(self):
-        '''Initializing osc messages'''
+        '''
+            Connect to Bonsai using OSC messages to establish a connection. 
+            
+            We first attempt to connect, to see if Bonsai is already running. 
+            If not, we start Bonsai and check the connection every 500ms.
+            If we wait more than 30 seconds without Bonsai connection we set 
+            InitializeBonsaiSuccessfully=0 and return
+    
+        '''
 
+        # Try to connect, to see if Bonsai is already runniny
         try: 
             logging.info('Trying to connect to already running Bonsai')
             self._ConnectOSC()
         except Exception as e:
+            # We couldn't connect, log as info, and move on
             logging.info('Could not connect: '+str(e))
         else:
+            # We could connect, set the indicator flag and return
             logging.info('Connected to already running Bonsai')
             self.InitializeBonsaiSuccessfully=1
             logging.info('Bonsai started successfully')
             return
 
-
+        # Start Bonsai
         logging.info('Starting Bonsai')
-        # open the bondai workflow and run
         self._OpenBonsaiWorkflow()
-        max_wait = 30
+
+        # Test the connection until it completes or we time out
         wait = 0
+        max_wait = 30
         while wait < max_wait:
             time.sleep(1)
             wait += 1
             try:
                 self._ConnectOSC()
             except Exception as e:
+                # We could not connect
                 logging.info('Could not connect, total waiting time {} seconds: '.format(wait)+str(e))
             else:
+                # We could connect
                 logging.info('Connected to Bonsai')               
                 self.InitializeBonsaiSuccessfully=1
                 logging.info('Bonsai started successfully')
                 return
         
-        # Could not connect
+        # Could not connect and we timed out
         logging.info('Could not connect to bonsai with max wait time {} seconds'.format(max_wait))
         self.InitializeBonsaiSuccessfully=0
         self.WarningLabel_2.setText('Started without bonsai connected!')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -551,7 +551,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
             try:
                 self._ConnectOSC()
             except Exception as e:
-                logging.error('Could not connect: '+str(e))
+                logging.info('Could not connect, total waiting time {} seconds: '.format(wait)+str(e))
             else:
                 logging.info('Connected to Bonsai')               
                 self.InitializeBonsaiSuccessfully=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -529,8 +529,11 @@ class Window(QMainWindow, Ui_ForagingGUI):
         logging.info('initializing Bonsai')
         # open the bondai workflow and run
         self._OpenBonsaiWorkflow()
+        logging.info('initializing Bonsai 1')
         time.sleep(3)
+        logging.info('initializing Bonsai 2')
         self._ConnectOSC()
+        logging.info('initializing Bonsai 3')
 
     def _ConnectOSC(self):
         '''Connect the GUI and Bonsai through OSC messages'''    
@@ -2437,11 +2440,11 @@ if __name__ == "__main__":
 
     # Formating GUI graphics
     logging.info('Setting QApplication attributes')
-    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
-    QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)
-    QApplication.setAttribute(Qt.AA_DisableHighDpiScaling,False)
-    QApplication.setAttribute(Qt.AA_Use96Dpi,False)
-    QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
+    #QApplication.setAttribute(Qt.AA_EnableHighDpiScaling,1)
+    #QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps,True)
+    #QApplication.setAttribute(Qt.AA_DisableHighDpiScaling,False)
+    #QApplication.setAttribute(Qt.AA_Use96Dpi,False)
+    #QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     
     # Start Q, and Gui Window
     logging.info('Starting QApplication and Window')


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Previously, when the GUI launched it would always start a new Bonsai instance, wait 3 seconds, then attempt to connect once. This had two problems, first if Bonsai was already running it would open Bonsai again. The second Bonsai instance would be blocked from accessing ports. Second, if Bonsai took longer than 3 seconds to open then the GUI would not connect and sets an internal flag `self.InitializeBonsaiSuccessfully=0`

Now, the GUI first attempts to connect to an already running Bonsai instance. If it cannot, then it launches Bonsai and checks the connection every 500ms until it connects. If it has not connected after 10 seconds, then it sets the internal flag `self.InitializeBonsaiSuccessfully=0`

### What issues or discussions does this update address?
- Resolves #107 

### Describe the expected change in behavior from the perspective of the experimenter
- The GUI should reliably connect to Bonsai every time it opens. 
- It should open slightly faster in general, and much faster if Bonsai is already running
- When an error is encountered, the best course of action is still to close both Bonsai and the GUI. 

### Describe the outcome of testing this update on a rig in 447
- [x] Tested in 447





