### PR TITLE
Removing the black console window

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -641,7 +641,7 @@ class Window(QMainWindow, Ui_ForagingGUI):
         SettingsBox = 'Settings_box{}.csv'.format(self.tower_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         if len(sys.argv) == 1:
-            subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
         else:
             if self.tower_number==1:
                 subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox,cwd=CWD,shell=True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -641,12 +641,12 @@ class Window(QMainWindow, Ui_ForagingGUI):
         SettingsBox = 'Settings_box{}.csv'.format(self.tower_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         if len(sys.argv) == 1:
-            subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start')
+            subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',shell=True)
         else:
             if self.tower_number==1:
-                subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox,cwd=CWD)
+                subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox,cwd=CWD,shell=True)
             else:
-                subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD)
+                subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging1.bat
+++ b/src/foraging_gui/Foraging1.bat
@@ -1,3 +1,8 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
+:: This version starts without a console window
 start "" pythonw Foraging.py 1
+:: This version starts with a console window
+:: start python Foraging.py 1
+
+

--- a/src/foraging_gui/Foraging1.bat
+++ b/src/foraging_gui/Foraging1.bat
@@ -1,3 +1,3 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
-start python Foraging.py 1
+start "" pythonw Foraging.py 1

--- a/src/foraging_gui/Foraging2.bat
+++ b/src/foraging_gui/Foraging2.bat
@@ -1,3 +1,3 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
-start python Foraging.py 2
+start "" pythonw Foraging.py 2

--- a/src/foraging_gui/Foraging2.bat
+++ b/src/foraging_gui/Foraging2.bat
@@ -1,3 +1,8 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
+:: This version starts without a console window
 start "" pythonw Foraging.py 2
+:: This version starts with a console window
+:: start python Foraging.py 2
+
+

--- a/src/foraging_gui/Foraging3.bat
+++ b/src/foraging_gui/Foraging3.bat
@@ -1,3 +1,3 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
-start python Foraging.py 3
+start "" pythonw Foraging.py 3

--- a/src/foraging_gui/Foraging3.bat
+++ b/src/foraging_gui/Foraging3.bat
@@ -1,3 +1,8 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
+:: This version starts without a console window
 start "" pythonw Foraging.py 3
+:: This version starts with a console window
+:: start python Foraging.py 3
+
+

--- a/src/foraging_gui/Foraging4.bat
+++ b/src/foraging_gui/Foraging4.bat
@@ -1,3 +1,8 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
+:: This version starts without a console window
 start "" pythonw Foraging.py 4
+:: This version starts with a console window
+:: start python Foraging.py 4
+
+

--- a/src/foraging_gui/Foraging4.bat
+++ b/src/foraging_gui/Foraging4.bat
@@ -1,3 +1,3 @@
 cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
 call conda activate Foraging
-start python Foraging.py 4
+start "" pythonw Foraging.py 4


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Stops the black console window from appearing when the GUI is launched. The console is window for debugging, but in operations it adds to visual clutter. 

Technical details: This is done by suppressing console generation at two steps.
- First, in the `.bat` file: 
    - `start python Foraging.py` is replaced with `start "" pythonw Foraging.py`
    - The double quotes uses the existing console for running
    - pythonw runs without generating console output
- Second, when we use `subprocess.popen` to launch bonsai
    -  We add a `shell=True` flag to suppress console generation

If you WANT to run the GUI with the console, (for debugging purposes), then you can open the `.bat` file and swap which line is commented out. 

### What issues or discussions does this update address?
- resolves #112 

### Describe the expected change in behavior from the perspective of the experimenter
When you launch the GUI, the black window will not appear. 

### Describe the outcome of testing this update on a rig in 447
- [x] Tested in 447
- [x] Tested interactions with multiple box numbers




