### PR TITLE
[skip email] Send a copy of log info to the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ To configure automatic updates consistent with the [update protocol](https://git
   - **ForagingSettings.json**: General settings. 
     - **default_saveFolder**: The default save location. The folder structure is `default_saveFolder\Rig\Animal\Animal_year-month-day_hour-minute-second\`. There are five additional folders: `EphysFolder`, `HarpFolder`, `PhotometryFolder`, `TrainingFolder`, and `VideoFolder` for saving different data sources. Default location: `Documents`
     - **current_box**: To define the rig name.
+    - **show_log_info_in_console**: If exists and equals `True`, a copy of log info is sent to the console.
   - **WaterCalibration.json**: The water calibration results.
   - **LaserCalibration.json**: The laser calibration results.
   - **TrainingStagePar.json**: The training stage parameters in a task-dependent manner.

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -481,7 +481,7 @@ class Window(QMainWindow):
             'newscale_port_tower2':'',
             'newscale_port_tower3':'',
             'newscale_port_tower4':'',
-            'enable_show_log_info_in_console':False,
+            'show_log_info_in_console':False,
         }
         
         # Try to load the settings file        
@@ -523,8 +523,8 @@ class Window(QMainWindow):
         self.newscale_port_tower4=Settings['newscale_port_tower4']
         
         # Also stream log info to the console if enabled
-        if ('enable_show_log_info_in_console' in Settings 
-            and Settings['enable_show_log_info_in_console']):
+        if ('show_log_info_in_console' in Settings 
+            and Settings['show_log_info_in_console']):
             logger = logging.getLogger()
             handler = logging.StreamHandler()
             # Using the same format and level as the root logger

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2458,11 +2458,15 @@ def start_gui_log_file(tower_number):
     # Start the log file
     print('Starting a GUI log file at: ')
     print(logging_filename)
-    logging.basicConfig(format=log_format,
-        filename=logging_filename, 
+    logging.basicConfig(
+        format=log_format,
         level=logging.INFO,
-        datefmt=log_datefmt
-        )
+        datefmt=log_datefmt,
+        handlers=[
+            logging.FileHandler(logging_filename),
+            logging.StreamHandler()
+        ]
+    )
     logging.info('Starting logfile!')
     logging.captureWarnings(True)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -480,7 +480,8 @@ class Window(QMainWindow):
             'newscale_port_tower1':'',
             'newscale_port_tower2':'',
             'newscale_port_tower3':'',
-            'newscale_port_tower4':''
+            'newscale_port_tower4':'',
+            'enable_show_log_info_in_console':False,
         }
         
         # Try to load the settings file        
@@ -520,6 +521,17 @@ class Window(QMainWindow):
         self.newscale_port_tower2=Settings['newscale_port_tower2']
         self.newscale_port_tower3=Settings['newscale_port_tower3']
         self.newscale_port_tower4=Settings['newscale_port_tower4']
+        
+        # Also stream log info to the console if enabled
+        if ('enable_show_log_info_in_console' in Settings 
+            and Settings['enable_show_log_info_in_console']):
+            logger = logging.getLogger()
+            handler = logging.StreamHandler()
+            # Using the same format and level as the root logger
+            handler.setFormatter(logging.root.handlers[0].formatter)
+            handler.setLevel(logging.root.level)            
+            logger.addHandler(handler)
+            
 
         # Determine box
         if self.current_box in ['Green','Blue','Red','Yellow']:
@@ -2464,7 +2476,6 @@ def start_gui_log_file(tower_number):
         datefmt=log_datefmt,
         handlers=[
             logging.FileHandler(logging_filename),
-            logging.StreamHandler()
         ]
     )
     logging.info('Starting logfile!')


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Send a copy of log info to the console, if necessary.

By default, this is turned off:

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/2134b0a2-4b87-43ac-a5d7-08a41502e053)

If the field `enable_show_log_info_in_console` exists in `ForagingSettings.json` and is set to `True`, we get verbose log info in the console.

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/f566abed-8f89-415d-859f-96d88a40afe4)

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/47297144-55f3-4610-ac6b-16366b6c9a01)


### What issues or discussions does this update address?
- https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/131#discussion_r1434625354

### Describe the expected change in behavior from the perspective of the experimenter
None. Only for debugging.

### Describe the outcome of testing this update on a rig in 447
Not yet. It should work.




