### PR TITLE
(to_han_develop) Set, lock, and save auto train parameters

### DIFF
--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -261,7 +261,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="label_curriculum_task">
+           <widget class="QLabel" name="label_curriculum_name">
             <property name="minimumSize">
              <size>
               <width>0</width>

--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -87,6 +87,9 @@
             <property name="text">
              <string>Apply &lt;stage&gt;</string>
             </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item row="2" column="1">
@@ -134,7 +137,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Override</string>
+             <string>Override curriculum</string>
             </property>
            </widget>
           </item>
@@ -160,7 +163,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Override</string>
+             <string>Override stage</string>
             </property>
            </widget>
           </item>
@@ -270,7 +273,7 @@
             </property>
             <property name="font">
              <font>
-              <pointsize>10</pointsize>
+              <pointsize>13</pointsize>
               <weight>75</weight>
               <bold>true</bold>
              </font>
@@ -684,6 +687,22 @@ QTableView {
     <hint type="destinationlabel">
      <x>504</x>
      <y>107</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_apply_auto_train_paras</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_override_stage</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>719</x>
+     <y>141</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>364</x>
+     <y>169</y>
     </hint>
    </hints>
   </connection>

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1762,7 +1762,7 @@ class AutoTrainDialog(QDialog):
             logger.info(f"No entry found in df_training_manager for subject_id: {self.selected_subject_id}")
             self.last_session = None
             self.label_session.setText('subject not found')
-            self.label_curriculum_task.setText('subject not found')
+            self.label_curriculum_name.setText('subject not found')
             self.label_last_actual_stage.setText('subject not found')
             self.label_next_stage_suggested.setText('subject not found')
             self.label_subject_id.setStyleSheet("color: red;")
@@ -1777,13 +1777,13 @@ class AutoTrainDialog(QDialog):
             self.last_session = self.df_this_mouse.iloc[0]  # The first row is the latest session
             # get curriculum in use
             self.curriculum_in_use = self.curriculum_manager.get_curriculum(
-                curriculum_task=self.last_session['curriculum_task'],
+                curriculum_name=self.last_session['curriculum_name'],
                 curriculum_schema_version=self.last_session['curriculum_schema_version'],
                 curriculum_version=self.last_session['curriculum_version'],
             )
             # update info
-            self.label_curriculum_task.setText(
-                f"{self.last_session['curriculum_task']} "
+            self.label_curriculum_name.setText(
+                f"{self.last_session['curriculum_name']} "
                 f"(v{self.last_session['curriculum_version']} "
                 f"@ schema v{self.last_session['curriculum_schema_version']})"
                 )
@@ -1841,7 +1841,7 @@ class AutoTrainDialog(QDialog):
                 ['subject_id',
                  'session',
                  'session_date',
-                 'curriculum_task', 
+                 'curriculum_name', 
                  'curriculum_version',
                  'task',
                  'current_stage_suggested',
@@ -1904,7 +1904,7 @@ class AutoTrainDialog(QDialog):
         # Get index of the latest session
         if self.last_session is not None:
             curriculum_index = self.df_curriculums.reset_index().index[
-                (self.df_curriculums['curriculum_task'] == self.last_session['curriculum_task']) &
+                (self.df_curriculums['curriculum_name'] == self.last_session['curriculum_name']) &
                 (self.df_curriculums['curriculum_version'] == self.last_session['curriculum_version']) &
                 (self.df_curriculums['curriculum_schema_version'] == self.last_session['curriculum_schema_version'])
             ][0]
@@ -1925,7 +1925,7 @@ class AutoTrainDialog(QDialog):
         selected_row = self.df_curriculums.iloc[row]
         logger.info(f"Selected curriculum: {selected_row.to_dict()}")
         self.selected_curriculum = self.curriculum_manager.get_curriculum(
-            curriculum_task=selected_row['curriculum_task'],
+            curriculum_name=selected_row['curriculum_name'],
             curriculum_schema_version=selected_row['curriculum_schema_version'],
             curriculum_version=selected_row['curriculum_version'],
         )
@@ -2033,8 +2033,9 @@ class AutoTrainDialog(QDialog):
                     widget.setChecked(bool(value))
                     self.MainWindow._AutoReward()            
             
+            self.MainWindow._keyPressEvent()  # Mimic an "ENTER" press event to update the parameters
             logger.info(f"{key} is set to {value}")
-        
+            
         return
         
     

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -69,6 +69,14 @@ class Window(QMainWindow):
         self.UpdateParameters=1 # permission to update parameters
         self.Visualization.setTitle(str(date.today()))
         self.loggingstarted=-1
+        
+        # Some global variables for auto training
+        self.auto_train_locked = False
+        self.widgets_locked_by_auto_train = []
+        self.stage_in_use = None
+        self.curriculum_in_use = None
+        self.checkBox_override_stage = False
+        self.comboBox_override_stage = None
 
         # Connect to Bonsai
         self._InitializeBonsai()
@@ -111,13 +119,6 @@ class Window(QMainWindow):
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
         
-        # Some global variables for auto training
-        self.auto_train_locked = False
-        self.widgets_locked_by_auto_train = []
-        self.stage_in_use = None
-        self.curriculum_in_use = None
-        self.checkBox_override_stage = None
-        self.comboBox_override_stage = None
         
         logging.info('Start up complete')
 
@@ -1196,6 +1197,23 @@ class Window(QMainWindow):
                 # Set an attribute in self with the name 'TP_' followed by the child's object name
                 # and store whether the child is checked or not
                 setattr(self, 'TP_'+child.objectName(), child.isChecked())
+                
+        # Manually attach auto training parameters (In general, we should find a better way...)
+        self.TP_auto_train_locked = self.auto_train_locked
+        if self.TP_auto_train_locked:
+            _curr = self.curriculum_in_use['curriculum']
+            self.TP_auto_train_curriculum_name = _curr.curriculum_name
+            self.TP_auto_train_curriculum_version = _curr.curriculum_version
+            self.TP_auto_train_curriculum_schema_version = _curr.curriculum_schema_version
+            self.TP_auto_train_stage = self.stage_in_use
+            self.TP_auto_train_stage_overridden = self.checkBox_override_stage
+        else:
+            self.TP_auto_train_curriculum_name = None
+            self.TP_auto_train_curriculum_version = None
+            self.TP_auto_train_curriculum_schema_version = None
+            self.TP_auto_train_stage = None
+            self.TP_auto_train_stage_overridden = None
+            
 
     def _Task(self):
         '''hide and show some fields based on the task type'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2455,8 +2455,38 @@ class Window(QMainWindow):
             
         # Connect to ID change in the mainwindow
         self.ID.returnPressed.connect(
-            lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text()))
-
+            lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text())
+        )
+        self.ID.returnPressed.connect(
+            lambda: self._update_auto_train_lock(locked=False)
+        )
+        
+    def _update_auto_train_lock(self, locked: bool):
+        """Update the auto train lock"""
+        if locked:
+            for widget in self.widgets_locked_by_auto_train:
+                widget.setEnabled(False)
+                # set the border color to green
+                widget.setStyleSheet("border: 2px solid rgb(170, 255, 0);")
+            self.TrainingParameters.setStyleSheet(
+                '''QGroupBox {
+                        border: 5px solid rgb(170, 255, 0)
+                    }
+                '''
+            )
+            # Update a global state
+            self.auto_train_locked = True
+        else:
+            # Unlock the previously locked widgets
+            for widget in self.widgets_locked_by_auto_train:
+                widget.setEnabled(True)
+                # clear style
+                widget.setStyleSheet("")
+            self.TrainingParameters.setStyleSheet("")
+            
+            # Update the global state
+            self.auto_train_locked = False
+            
 def start_gui_log_file(tower_number):
     '''
         Starts a log file for the gui.

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -111,6 +111,14 @@ class Window(QMainWindow):
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
         
+        # Some global variables for auto training
+        self.auto_train_locked = False
+        self.widgets_locked_by_auto_train = []
+        self.stage_in_use = None
+        self.curriculum_in_use = None
+        self.checkBox_override_stage = None
+        self.comboBox_override_stage = None
+        
         logging.info('Start up complete')
 
     def connectSignalsSlots(self):
@@ -2450,7 +2458,7 @@ class Window(QMainWindow):
     def _AutoTrain(self):
         """set up auto training"""
         if not hasattr(self, 'AutoTrain_dialog') or not self.AutoTrain_dialog.isVisible():
-            self.AutoTrain_dialog = AutoTrainDialog(MainWindow=self, parent=self)
+            self.AutoTrain_dialog = AutoTrainDialog(MainWindow=self, parent=None)
         self.AutoTrain_dialog.show()
             
         # Connect to ID change in the mainwindow

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2048,8 +2048,10 @@ class Window(QMainWindow):
     def _AutoReward(self):
         if self.AutoReward.isChecked():
             self.AutoReward.setStyleSheet("background-color : green;")
+            self.AutoReward.setText('On')
         else:
             self.AutoReward.setStyleSheet("background-color : none")
+            self.AutoReward.setText('Off')
     def _NextBlock(self):
         if self.NextBlock.isChecked():
             self.NextBlock.setStyleSheet("background-color : green;")

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1485,6 +1485,25 @@ class GenerateTrials():
             self.TP_log_folder=win.Ot_log_folder
         except Exception as e:
             logging.error(str(e))
+            
+        # TODO: this _GetTrainingParameters is redundant with the one in Foraging.gy...
+        # We should refactor this!
+        # Manually attach auto training parameters 
+        self.TP_auto_train_locked = win.auto_train_locked
+        if self.TP_auto_train_locked:
+            _curr = win.curriculum_in_use['curriculum']
+            self.TP_auto_train_curriculum_name = _curr.curriculum_name
+            self.TP_auto_train_curriculum_version = _curr.curriculum_version
+            self.TP_auto_train_curriculum_schema_version = _curr.curriculum_schema_version
+            self.TP_auto_train_stage = win.stage_in_use
+            self.TP_auto_train_stage_overridden = win.checkBox_override_stage
+        else:
+            self.TP_auto_train_curriculum_name = None
+            self.TP_auto_train_curriculum_version = None
+            self.TP_auto_train_curriculum_schema_version = None
+            self.TP_auto_train_stage = None
+            self.TP_auto_train_stage_overridden = None
+
 
     def _SaveParameters(self):
         for attr_name in dir(self):


### PR DESCRIPTION
### Note: This is a pull request to han_develop. I'm splitting the task into multiple PRs to han_develop just for the purpose of code review. After the first functioning version is ready, I'll issue a large PR from han_develop to production_test, with all descriptions combined.
  
### Describe changes:
- [x] Lock the auto training parameters (green boxes)

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/b2ff5251-3b30-47b5-98af-6629a14fdda9)

- [x] Save auto training paras, i.e., curriculum and stage. Now I'm using Xinxin's trial-by-trial saving mechanism. Ultimately they should be only saved once and fixed throughout the session.

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/e3b98290-9ec9-48d1-b90d-261bd22c3674)



