### PR TITLE
[skip email] Add waiting screen

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -523,8 +523,7 @@ class Window(QMainWindow):
         self.newscale_port_tower4=Settings['newscale_port_tower4']
         
         # Also stream log info to the console if enabled
-        if ('show_log_info_in_console' in Settings 
-            and Settings['show_log_info_in_console']):
+        if  Settings['show_log_info_in_console']:
             logger = logging.getLogger()
             handler = logging.StreamHandler()
             # Using the same format and level as the root logger

--- a/src/foraging_gui/Foraging1.bat
+++ b/src/foraging_gui/Foraging1.bat
@@ -2,6 +2,8 @@ cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\fora
 call conda activate Foraging
 :: This version starts without a console window
 start "" pythonw Foraging.py 1
+echo Starting the GUI and Bonsai, please wait. This window will close in 20 seconds
+timeout 20 >nul
 :: This version starts with a console window
 :: start python Foraging.py 1
 

--- a/src/foraging_gui/Foraging2.bat
+++ b/src/foraging_gui/Foraging2.bat
@@ -2,6 +2,8 @@ cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\fora
 call conda activate Foraging
 :: This version starts without a console window
 start "" pythonw Foraging.py 2
+echo Starting the GUI and Bonsai, please wait. This window will close in 20 seconds
+timeout 20 >nul
 :: This version starts with a console window
 :: start python Foraging.py 2
 

--- a/src/foraging_gui/Foraging3.bat
+++ b/src/foraging_gui/Foraging3.bat
@@ -2,6 +2,8 @@ cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\fora
 call conda activate Foraging
 :: This version starts without a console window
 start "" pythonw Foraging.py 3
+echo Starting the GUI and Bonsai, please wait. This window will close in 20 seconds
+timeout 20 >nul
 :: This version starts with a console window
 :: start python Foraging.py 3
 

--- a/src/foraging_gui/Foraging4.bat
+++ b/src/foraging_gui/Foraging4.bat
@@ -2,6 +2,8 @@ cd /d C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\src\fora
 call conda activate Foraging
 :: This version starts without a console window
 start "" pythonw Foraging.py 4
+echo Starting the GUI and Bonsai, please wait. This window will close in 20 seconds
+timeout 20 >nul
 :: This version starts with a console window
 :: start python Foraging.py 4
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Modifies the Foraging.bat scripts to add a note that the GUI is opening, and then the console window closes after 20 seconds.
- Streamlines the logic about show_log_info_in_settings. The setting always exists because its in the defaults

### What issues or discussions does this update address? 
- Previously the GUI was opening but its not clear whats happening.
 
### Describe the expected change in behavior from the perspective of the experimenter
A console window will stay open for 20 seconds saying the GUI is opening and to wait. 

### Describe the outcome of testing this update on a rig in 447
Just tested on my laptop




