### PR TITLE
(to han_develop) Handle the first session of a new mouse

### DIFF
--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1891</width>
-    <height>997</height>
+    <width>1779</width>
+    <height>1059</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -61,39 +61,28 @@
         </item>
         <item>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="5" rowspan="5">
-           <widget class="QPushButton" name="pushButton_apply_auto_train_paras">
+          <item row="5" column="1">
+           <widget class="QLabel" name="label_next_stage_suggested">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>20</horstretch>
+              <horstretch>10</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
             <property name="font">
              <font>
-              <pointsize>14</pointsize>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
              </font>
             </property>
-            <property name="styleSheet">
-             <string notr="true">background-color: rgb(170, 255, 0);
-</string>
-            </property>
             <property name="text">
-             <string>Apply &lt;stage&gt;</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
+             <string>Unknown</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="label_session">
+          <item row="3" column="1">
+           <widget class="QLabel" name="label_last_actual_stage">
             <property name="minimumSize">
              <size>
               <width>0</width>
@@ -112,35 +101,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>50</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="2" alignment="Qt::AlignRight">
-           <widget class="QCheckBox" name="checkBox_override_curriculum">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>10</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Override curriculum</string>
-            </property>
-           </widget>
-          </item>
           <item row="5" column="3">
            <widget class="QComboBox" name="comboBox_override_stage">
             <property name="enabled">
@@ -151,19 +111,6 @@
               <horstretch>10</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="2" alignment="Qt::AlignRight">
-           <widget class="QCheckBox" name="checkBox_override_stage">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>10</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Override stage</string>
             </property>
            </widget>
           </item>
@@ -187,41 +134,17 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QLabel" name="label_next_stage_suggested">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>10</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_8">
             <property name="font">
              <font>
-              <pointsize>13</pointsize>
-              <weight>75</weight>
-              <bold>true</bold>
+              <pointsize>10</pointsize>
              </font>
             </property>
             <property name="text">
-             <string>Unknown</string>
+             <string>Session finished:</string>
             </property>
            </widget>
-          </item>
-          <item row="1" column="6">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Preferred</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>100</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="0" column="1">
            <widget class="QLabel" name="label_subject_id">
@@ -240,6 +163,55 @@
             </property>
             <property name="text">
              <string>Unknown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Curriculum:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" alignment="Qt::AlignRight">
+           <widget class="QCheckBox" name="checkBox_override_curriculum">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>10</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Override curriculum</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2" alignment="Qt::AlignRight">
+           <widget class="QCheckBox" name="checkBox_override_stage">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>10</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Override stage</string>
             </property>
            </widget>
           </item>
@@ -283,14 +255,8 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_6">
             <property name="font">
              <font>
               <pointsize>10</pointsize>
@@ -299,12 +265,12 @@
              </font>
             </property>
             <property name="text">
-             <string>Curriculum:</string>
+             <string>Last stage (actual): </string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="label_last_actual_stage">
+          <item row="2" column="1">
+           <widget class="QLabel" name="label_session">
             <property name="minimumSize">
              <size>
               <width>0</width>
@@ -323,34 +289,56 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
+          <item row="3" column="4">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
-            <property name="text">
-             <string>Last stage (actual): </string>
+            <property name="sizeType">
+             <enum>QSizePolicy::Maximum</enum>
             </property>
-           </widget>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>50</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_8">
+          <item row="1" column="5" rowspan="5">
+           <widget class="QPushButton" name="pushButton_apply_auto_train_paras">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>20</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="font">
              <font>
-              <pointsize>10</pointsize>
+              <pointsize>14</pointsize>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(170, 255, 0);
+</string>
+            </property>
             <property name="text">
-             <string>Session finished:</string>
+             <string>Apply and lock
+&lt;stage&gt;</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
           <item row="1" column="3" rowspan="2">
-           <widget class="QPushButton" name="pushButton">
+           <widget class="QPushButton" name="pushButton_apply_curriculum">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -591,14 +579,7 @@
            <enum>Qt::StrongFocus</enum>
           </property>
           <property name="styleSheet">
-           <string notr="true">QTableView::item:selected {
-                background-color: lightblue;
-                color: black;
-            }
-
-QTableView {
-				border:7px solid rgb(255, 170, 255);
-}</string>
+           <string notr="true"/>
           </property>
           <property name="selectionMode">
            <enum>QAbstractItemView::SingleSelection</enum>
@@ -677,7 +658,7 @@ QTableView {
   <connection>
    <sender>checkBox_override_curriculum</sender>
    <signal>clicked(bool)</signal>
-   <receiver>pushButton</receiver>
+   <receiver>pushButton_apply_curriculum</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1759,7 +1759,6 @@ class AutoTrainDialog(QDialog):
         )
         
         if self.df_this_mouse.empty:
-            # TODO: create a new mouse here
             logger.info(f"No entry found in df_training_manager for subject_id: {self.selected_subject_id}")
             self.last_session = None
             self.label_session.setText('subject not found')
@@ -1775,12 +1774,16 @@ class AutoTrainDialog(QDialog):
             self.pushButton_apply_auto_train_paras.setEnabled(False)
             
             # prompt user to create a new mouse
-            QMessageBox.information(
-                self,
-                "Info",
-                f"The mouse {self.selected_subject_id} does not exist in the auto training manager!\n"
-                f"If it is a new mouse (not your typo), please select a curriculum to add it."
-            )
+            if self.MainWindow.AutoTrain_dialog.isVisible():
+                QMessageBox.information(
+                    self,
+                    "Info",
+                    f"The mouse {self.selected_subject_id} does not exist in the auto training manager!\n"
+                    f"If it is a new mouse (not your typo), please select a curriculum to add it."
+                )
+                
+            self.tableView_df_curriculum.clearSelection() # Unselect any curriculum
+            self.selected_curriculum = None
             self.pushButton_apply_curriculum.setEnabled(True)
             self._add_border_curriculum_selection()
 
@@ -2050,7 +2053,7 @@ class AutoTrainDialog(QDialog):
                 
     def _apply_curriculum(self):
         # Check if a curriculum is selected
-        if not hasattr(self, 'selected_curriculum'):
+        if not hasattr(self, 'selected_curriculum') or self.selected_curriculum is None:
             QMessageBox.critical(self, "Error", "Please select a curriculum!")
             return
         

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1721,6 +1721,12 @@ class AutoTrainDialog(QDialog):
         super().__init__(parent)
         uic.loadUi('AutoTrain.ui', self)
         self.MainWindow = MainWindow
+        
+        # Initializations
+        self.auto_train_engaged = False
+        self.widgets_locked_by_auto_train = []
+        self.stage_in_use = None
+        self.curriculum_in_use = None
 
         # Connect to Auto Training Manager and Curriculum Manager
         self._connect_auto_training_manager()
@@ -1743,7 +1749,7 @@ class AutoTrainDialog(QDialog):
             self._update_stage_to_apply
         )
         self.pushButton_apply_auto_train_paras.clicked.connect(
-            self._apply_auto_train_paras
+            self.update_auto_train_lock
         )
         self.pushButton_apply_curriculum.clicked.connect(
             self._apply_curriculum
@@ -1774,7 +1780,7 @@ class AutoTrainDialog(QDialog):
             self.pushButton_apply_auto_train_paras.setEnabled(False)
             
             # prompt user to create a new mouse
-            if self.MainWindow.AutoTrain_dialog.isVisible():
+            if self.isVisible():
                 QMessageBox.information(
                     self,
                     "Info",
@@ -1791,7 +1797,7 @@ class AutoTrainDialog(QDialog):
             # fetch last session
             self.last_session = self.df_this_mouse.iloc[0]  # The first row is the latest session
             # get curriculum in use
-            self.MainWindow.curriculum_in_use = self.curriculum_manager.get_curriculum(
+            self.curriculum_in_use = self.curriculum_manager.get_curriculum(
                 curriculum_name=self.last_session['curriculum_name'],
                 curriculum_schema_version=self.last_session['curriculum_schema_version'],
                 curriculum_version=self.last_session['curriculum_version'],
@@ -1813,25 +1819,6 @@ class AutoTrainDialog(QDialog):
             self.pushButton_apply_curriculum.setEnabled(False)
             self._remove_border_curriculum_selection()
 
-            
-            # Set pushButton_apply_auto_train_paras
-            if self.MainWindow.auto_train_locked:
-                # If auto train is locked when the user opens the dialog (again)
-                self.pushButton_apply_auto_train_paras.setChecked(True)
-                
-                # Disable override
-                self.checkBox_override_stage.setEnabled(False)
-                self.comboBox_override_stage.setEnabled(False)
-                
-                # Retrieve status of override_stage from the main window
-                self.checkBox_override_stage.setChecked(
-                    self.MainWindow.checkBox_override_stage
-                )
-            else:  
-                # If not locked, reset status of override_stage and apply button
-                self.pushButton_apply_auto_train_paras.setChecked(False)
-                self.checkBox_override_stage.setEnabled(True)
-                self.checkBox_override_stage.setChecked(False)
                     
         # Update UI
         self._update_available_training_stages()
@@ -1866,37 +1853,29 @@ class AutoTrainDialog(QDialog):
         )
                 
     def _connect_auto_training_manager(self):
-        if self.MainWindow.df_auto_train_manager is not None:
-            # Restore the cached auto_train_manager
-            self.df_training_manager = self.MainWindow.df_auto_train_manager
-            logger.info("Restored cached auto_train_manager")
-        else:
-            self.auto_train_manager = DynamicForagingAutoTrainManager(
-                manager_name='447_demo',
-                df_behavior_on_s3=dict(bucket='aind-behavior-data',
-                                    root='foraging_nwb_bonsai_processed/',
-                                    file_name='df_sessions.pkl'),
-                df_manager_root_on_s3=dict(bucket='aind-behavior-data',
-                                        root='foraging_auto_training/')
-            )
-            df_training_manager = self.auto_train_manager.df_manager
+        self.auto_train_manager = DynamicForagingAutoTrainManager(
+            manager_name='447_demo',
+            df_behavior_on_s3=dict(bucket='aind-behavior-data',
+                                root='foraging_nwb_bonsai_processed/',
+                                file_name='df_sessions.pkl'),
+            df_manager_root_on_s3=dict(bucket='aind-behavior-data',
+                                    root='foraging_auto_training/')
+        )
+        df_training_manager = self.auto_train_manager.df_manager
+        
+        # Format dataframe
+        df_training_manager['session'] = df_training_manager['session'].astype(int)
+        df_training_manager['foraging_efficiency'] = \
+            df_training_manager['foraging_efficiency'].round(3)
             
-            # Format dataframe
-            df_training_manager['session'] = df_training_manager['session'].astype(int)
-            df_training_manager['foraging_efficiency'] = \
-                df_training_manager['foraging_efficiency'].round(3)
-                
-            # Sort by subject_id and session
-            df_training_manager.sort_values(
-                by=['subject_id', 'session'],
-                ascending=[False, False],  # Newest sessions on the top,
-                inplace=True
-            )
-            self.df_training_manager = df_training_manager
+        # Sort by subject_id and session
+        df_training_manager.sort_values(
+            by=['subject_id', 'session'],
+            ascending=[False, False],  # Newest sessions on the top,
+            inplace=True
+        )
+        self.df_training_manager = df_training_manager
             
-            # Note: we don't sync back to the MainWindow here.
-            # We only update the MainWindow one when the user clicks "Apply stage" button.
-
     def _show_auto_training_manager(self):
         if_this_mouse_only = self.checkBox_show_this_mouse_only.isChecked()
         
@@ -2016,22 +1995,15 @@ class AutoTrainDialog(QDialog):
         layout.addWidget(svgWidget_paras)
         
     def _update_available_training_stages(self):
-        if self.MainWindow.curriculum_in_use is not None:
+        if self.curriculum_in_use is not None:
             available_training_stages = [v.name for v in 
-                                        self.MainWindow.curriculum_in_use['curriculum'].parameters.keys()]
+                                        self.curriculum_in_use['curriculum'].parameters.keys()]
         else:
             available_training_stages = []
             
         self.comboBox_override_stage.clear()
         self.comboBox_override_stage.addItems(available_training_stages)
-        
-        # Restore override_stage if auto train is locked
-        if self.MainWindow.auto_train_locked:
-            self.comboBox_override_stage.setCurrentIndex(
-                self.MainWindow.comboBox_override_stage
-            )
-            self.comboBox_override_stage.setEnabled(False)
-        
+                
     def _update_status_override_stage(self):
         if self.checkBox_override_stage.isChecked():
             self.comboBox_override_stage.setEnabled(True)
@@ -2041,14 +2013,14 @@ class AutoTrainDialog(QDialog):
             
     def _update_stage_to_apply(self):
         if self.checkBox_override_stage.isChecked():
-            self.MainWindow.stage_in_use = self.comboBox_override_stage.currentText()
+            self.stage_in_use = self.comboBox_override_stage.currentText()
         elif self.last_session is not None:
-            self.MainWindow.stage_in_use = self.last_session['next_stage_suggested']
+            self.stage_in_use = self.last_session['next_stage_suggested']
         else:
-            self.MainWindow.stage_in_use = 'unknown training stage'
+            self.stage_in_use = 'unknown training stage'
         
         self.pushButton_apply_auto_train_paras.setText(
-            f"Apply and lock\n{self.MainWindow.stage_in_use}"
+            f"Apply and lock\n{self.stage_in_use}"
         )
                 
     def _apply_curriculum(self):
@@ -2058,10 +2030,9 @@ class AutoTrainDialog(QDialog):
             return
         
         # Update global curriculum_in_use
-        self.MainWindow.curriculum_in_use = self.selected_curriculum
+        self.curriculum_in_use = self.selected_curriculum
         
         # Add a dummy entry to df_training_manager
-        # This will sync with MainWindow.df_training_manager when the "apply and lock" button is clicked
         self.df_training_manager = pd.concat(
             [self.df_training_manager, 
              pd.DataFrame.from_records([
@@ -2088,49 +2059,67 @@ class AutoTrainDialog(QDialog):
         # Refresh the GUI
         self.update_subject_id(subject_id=self.selected_subject_id)
             
-    def _apply_auto_train_paras(self, checked):
-        if checked:
+    def update_auto_train_lock(self, engaged):
+        if engaged:
+            # Update the flag
+            self.auto_train_engaged = True
+
             # Get parameter settings
-            paras = self.MainWindow.curriculum_in_use['curriculum'].parameters[
-                TrainingStage[self.MainWindow.stage_in_use]
+            paras = self.curriculum_in_use['curriculum'].parameters[
+                TrainingStage[self.stage_in_use]
             ]
             
             # Convert to GUI format and set the parameters
             paras_dict = paras.to_GUI_format()
-            # Attach to MainWindow for persistency
-            self.MainWindow.widgets_locked_by_auto_train = self._set_training_parameters(
+            self.widgets_locked_by_auto_train = self._set_training_parameters(
                 paras_dict=paras_dict,
                 if_press_enter=True
             )
             
-            # update the widgets that have been set by auto training 
-            self.MainWindow.widgets_locked_by_auto_train.extend(
+            if self.widgets_locked_by_auto_train == []:  # Error in setting parameters
+                self.update_auto_train_lock(engaged=False)  # Uncheck the "apply" button
+                return
+                
+            self.widgets_locked_by_auto_train.extend(
                 [self.MainWindow.TrainingStage,
                 self.MainWindow.SaveTraining]
                 )
-            
+
+            # lock the widgets that have been set by auto training 
+            for widget in self.widgets_locked_by_auto_train:
+                widget.setEnabled(False)
+                # set the border color to green
+                widget.setStyleSheet("border: 2px solid rgb(170, 255, 0);")
+            self.MainWindow.TrainingParameters.setStyleSheet(
+                '''QGroupBox {
+                        border: 5px solid rgb(170, 255, 0)
+                    }
+                '''
+            )
+
             # disable override
             self.checkBox_override_stage.setEnabled(False)
             self.comboBox_override_stage.setEnabled(False)
-            
-            # cache some status...
-            self.MainWindow.checkBox_override_stage = self.checkBox_override_stage.isChecked()
-            self.MainWindow.comboBox_override_stage = self.comboBox_override_stage.currentIndex()
+                                    
         else:
+            # Update the flag
+            self.auto_train_engaged = False
+            
+            # Uncheck the button (when this is called from the MainWindow, not from actual button click)
+            self.pushButton_apply_auto_train_paras.setChecked(False)
+
+            # Unlock the previously engaged widgets
+            for widget in self.widgets_locked_by_auto_train:
+                widget.setEnabled(True)
+                # clear style
+                widget.setStyleSheet("")
+            self.MainWindow.TrainingParameters.setStyleSheet("")
+
             # enable override
             self.checkBox_override_stage.setEnabled(True)
             self.comboBox_override_stage.setEnabled(self.checkBox_override_stage.isChecked())
-            
-        self.MainWindow._update_auto_train_lock(checked)
-        
-        # We sync back df_auto_train_manager here, meaning
-        #   1. for a new mouse, the added dummy entry will be persistent
-        #   2. if the user closes the AutoTrain dialog without clicking "Apply and lock",
-        #      the user can still change the curriculum
-        self.MainWindow.df_auto_train_manager = self.df_training_manager
 
 
-            
     def _set_training_parameters(self, paras_dict, if_press_enter=False):
         """Accepts a dictionary of parameters and set the GUI accordingly
         Trying to refactor Foraging.py's _TrainingStage() here.
@@ -2149,7 +2138,7 @@ class AutoTrainDialog(QDialog):
                 if task_ind < 0:
                     logger.error(f"Task {paras_dict['task']} not found!")
                     QMessageBox.critical(self, "Error", f'''Task "{paras_dict['task']}" not found. Check the curriculum!''')
-                    return  # Return without setting anything
+                    return [] # Return an empty list without setting anything
                 else:
                     widget_task.setCurrentIndex(task_ind)
                     logger.info(f"Task is set to {paras_dict['task']}")

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -71,6 +71,7 @@ class Window(QMainWindow):
         self.loggingstarted=-1
         
         # Some global variables for auto training
+        self.df_auto_train_manager = None
         self.auto_train_locked = False
         self.widgets_locked_by_auto_train = []
         self.stage_in_use = None

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -70,15 +70,6 @@ class Window(QMainWindow):
         self.Visualization.setTitle(str(date.today()))
         self.loggingstarted=-1
         
-        # Some global variables for auto training
-        self.df_auto_train_manager = None
-        self.auto_train_locked = False
-        self.widgets_locked_by_auto_train = []
-        self.stage_in_use = None
-        self.curriculum_in_use = None
-        self.checkBox_override_stage = False
-        self.comboBox_override_stage = None
-
         # Connect to Bonsai
         self._InitializeBonsai()
 
@@ -1198,23 +1189,7 @@ class Window(QMainWindow):
                 # Set an attribute in self with the name 'TP_' followed by the child's object name
                 # and store whether the child is checked or not
                 setattr(self, 'TP_'+child.objectName(), child.isChecked())
-                
-        # Manually attach auto training parameters (In general, we should find a better way...)
-        self.TP_auto_train_locked = self.auto_train_locked
-        if self.TP_auto_train_locked:
-            _curr = self.curriculum_in_use['curriculum']
-            self.TP_auto_train_curriculum_name = _curr.curriculum_name
-            self.TP_auto_train_curriculum_version = _curr.curriculum_version
-            self.TP_auto_train_curriculum_schema_version = _curr.curriculum_schema_version
-            self.TP_auto_train_stage = self.stage_in_use
-            self.TP_auto_train_stage_overridden = self.checkBox_override_stage
-        else:
-            self.TP_auto_train_curriculum_name = None
-            self.TP_auto_train_curriculum_version = None
-            self.TP_auto_train_curriculum_schema_version = None
-            self.TP_auto_train_stage = None
-            self.TP_auto_train_stage_overridden = None
-            
+                            
 
     def _Task(self):
         '''hide and show some fields based on the task type'''
@@ -2483,41 +2458,16 @@ class Window(QMainWindow):
                         
             # Connect to ID change in the mainwindow
             self.ID.returnPressed.connect(
-                lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text())
+                lambda: self.AutoTrain_dialog.update_auto_train_lock(engaged=False)
             )
             self.ID.returnPressed.connect(
-                lambda: self._update_auto_train_lock(locked=False)
+                lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text())
             )
+
             
         self.AutoTrain_dialog.show()
 
         
-    def _update_auto_train_lock(self, locked: bool):
-        """Update the auto train lock"""
-        if locked:
-            for widget in self.widgets_locked_by_auto_train:
-                widget.setEnabled(False)
-                # set the border color to green
-                widget.setStyleSheet("border: 2px solid rgb(170, 255, 0);")
-            self.TrainingParameters.setStyleSheet(
-                '''QGroupBox {
-                        border: 5px solid rgb(170, 255, 0)
-                    }
-                '''
-            )
-            # Update a global state
-            self.auto_train_locked = True
-        else:
-            # Unlock the previously locked widgets
-            for widget in self.widgets_locked_by_auto_train:
-                widget.setEnabled(True)
-                # clear style
-                widget.setStyleSheet("")
-            self.TrainingParameters.setStyleSheet("")
-            
-            # Update the global state
-            self.auto_train_locked = False
-            
 def start_gui_log_file(tower_number):
     '''
         Starts a log file for the gui.

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2476,17 +2476,21 @@ class Window(QMainWindow):
             
     def _AutoTrain(self):
         """set up auto training"""
-        if not hasattr(self, 'AutoTrain_dialog') or not self.AutoTrain_dialog.isVisible():
+        # Note: by only create one AutoTrainDialog, all objects associated with 
+        # AutoTrainDialog are now persistent!
+        if not hasattr(self, 'AutoTrain_dialog'):
             self.AutoTrain_dialog = AutoTrainDialog(MainWindow=self, parent=None)
-        self.AutoTrain_dialog.show()
+                        
+            # Connect to ID change in the mainwindow
+            self.ID.returnPressed.connect(
+                lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text())
+            )
+            self.ID.returnPressed.connect(
+                lambda: self._update_auto_train_lock(locked=False)
+            )
             
-        # Connect to ID change in the mainwindow
-        self.ID.returnPressed.connect(
-            lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text())
-        )
-        self.ID.returnPressed.connect(
-            lambda: self._update_auto_train_lock(locked=False)
-        )
+        self.AutoTrain_dialog.show()
+
         
     def _update_auto_train_lock(self, locked: bool):
         """Update the auto train lock"""

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1486,18 +1486,17 @@ class GenerateTrials():
         except Exception as e:
             logging.error(str(e))
             
-        # TODO: this _GetTrainingParameters is redundant with the one in Foraging.gy...
-        # We should refactor this!
         # Manually attach auto training parameters 
-        self.TP_auto_train_locked = win.auto_train_locked
-        if self.TP_auto_train_locked:
-            _curr = win.curriculum_in_use['curriculum']
+        if hasattr(win, 'AutoTrain_dialog') and win.AutoTrain_dialog.auto_train_engaged:
+            self.TP_auto_train_engaged = True
+            _curr = win.AutoTrain_dialog.curriculum_in_use['curriculum']
             self.TP_auto_train_curriculum_name = _curr.curriculum_name
             self.TP_auto_train_curriculum_version = _curr.curriculum_version
             self.TP_auto_train_curriculum_schema_version = _curr.curriculum_schema_version
-            self.TP_auto_train_stage = win.stage_in_use
-            self.TP_auto_train_stage_overridden = win.checkBox_override_stage
+            self.TP_auto_train_stage = win.AutoTrain_dialog.stage_in_use
+            self.TP_auto_train_stage_overridden = win.AutoTrain_dialog.checkBox_override_stage.isChecked()
         else:
+            self.TP_auto_train_engaged = False
             self.TP_auto_train_curriculum_name = None
             self.TP_auto_train_curriculum_version = None
             self.TP_auto_train_curriculum_schema_version = None


### PR DESCRIPTION
### Note: This is a pull request to han_develop. I'm splitting the task into multiple PRs to han_develop just for the purpose of code review. After the first functioning version is ready, I'll issue a large PR from han_develop to production_test, with all descriptions combined.

- [x] Once a new mouse is detected, add a dummy `session 0` to df_auto_train_manager so that 'Stage 1' is suggested by default.
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/f334dec0-c6c3-4d77-a242-acf36d993efe)
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/6b12d60a-66ff-4b78-98ee-97b54cf441da)

@XX-Yin, please use the condition `stage == 'STAGE_1'` and `session finished == 0` to trigger the initial L-R alternating protocol.

- [x] Some refactor simplying variable persistency (thanks to the fact that only one instance of Auto Train dialog is allowed now)