### PR TITLE
(to han_develop) allow overriding curriculum

### DIFF
--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -708,5 +708,21 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>checkBox_override_curriculum</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>pushButton_apply_auto_train_paras</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>520</x>
+     <y>92</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>828</x>
+     <y>128</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
 </ui>

--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -108,7 +108,7 @@
             </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>10</horstretch>
+              <horstretch>7</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
@@ -130,7 +130,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Next stage (suggested): </string>
+             <string>Stage suggested:</string>
             </property>
            </widget>
           </item>
@@ -142,7 +142,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Session finished:</string>
+             <string>Sessions finished:</string>
             </property>
            </widget>
           </item>
@@ -182,18 +182,18 @@
              </font>
             </property>
             <property name="text">
-             <string>Curriculum:</string>
+             <string>Curriculum in use:</string>
             </property>
            </widget>
           </item>
           <item row="1" column="2" alignment="Qt::AlignRight">
            <widget class="QCheckBox" name="checkBox_override_curriculum">
             <property name="enabled">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>10</horstretch>
+              <horstretch>8</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
@@ -265,7 +265,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Last stage (actual): </string>
+             <string>Stage of the last session: </string>
             </property>
            </widget>
           </item>
@@ -289,27 +289,11 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="4">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>50</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="1" column="5" rowspan="5">
            <widget class="QPushButton" name="pushButton_apply_auto_train_paras">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>20</horstretch>
+              <horstretch>15</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
@@ -321,7 +305,7 @@
             </property>
             <property name="font">
              <font>
-              <pointsize>14</pointsize>
+              <pointsize>12</pointsize>
              </font>
             </property>
             <property name="styleSheet">
@@ -337,7 +321,23 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="3" rowspan="2">
+          <item row="3" column="4">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Maximum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="3">
            <widget class="QPushButton" name="pushButton_apply_curriculum">
             <property name="enabled">
              <bool>false</bool>
@@ -348,12 +348,17 @@
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
             <property name="styleSheet">
              <string notr="true">background-color: rgb(255, 170, 255)
 </string>
             </property>
             <property name="text">
-             <string>Apply curriculum</string>
+             <string>Set curriculum</string>
             </property>
            </widget>
           </item>
@@ -550,7 +555,7 @@
         <item>
          <widget class="QTableView" name="tableView_df_curriculum">
           <property name="enabled">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -630,8 +635,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>236</x>
-     <y>987</y>
+     <x>245</x>
+     <y>1049</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -646,28 +651,12 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>304</x>
-     <y>987</y>
+     <x>313</x>
+     <y>1049</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkBox_override_curriculum</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>pushButton_apply_curriculum</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>403</x>
-     <y>92</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>504</x>
-     <y>107</y>
     </hint>
    </hints>
   </connection>
@@ -682,8 +671,40 @@
      <y>141</y>
     </hint>
     <hint type="destinationlabel">
-     <x>364</x>
-     <y>169</y>
+     <x>465</x>
+     <y>174</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_apply_auto_train_paras</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_override_curriculum</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>789</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>497</x>
+     <y>100</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_override_curriculum</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>tableView_df_curriculum</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>473</x>
+     <y>92</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1123</x>
+     <y>158</y>
     </hint>
    </hints>
   </connection>

--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -309,7 +309,7 @@
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">background-color: rgb(170, 255, 0);
+             <string notr="true">background-color:  rgb(0, 189, 22);
 </string>
             </property>
             <property name="text">

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1736,14 +1736,14 @@ class AutoTrainDialog(QDialog):
         self._setup_allbacks()
         
         # Sync selected subject_id
-        self.update_subject_id(self.MainWindow.ID.text())
+        self.update_auto_train_fields(subject_id=self.MainWindow.ID.text())
                 
     def _setup_allbacks(self):
         self.checkBox_show_this_mouse_only.stateChanged.connect(
             self._show_auto_training_manager
         )
         self.checkBox_override_stage.stateChanged.connect(
-            self._update_status_override_stage
+            self._override_stage_clicked
         )
         self.comboBox_override_stage.currentIndexChanged.connect(
             self._update_stage_to_apply
@@ -1751,11 +1751,14 @@ class AutoTrainDialog(QDialog):
         self.pushButton_apply_auto_train_paras.clicked.connect(
             self.update_auto_train_lock
         )
+        self.checkBox_override_curriculum.stateChanged.connect(
+            self._override_curriculum_clicked
+        )
         self.pushButton_apply_curriculum.clicked.connect(
             self._apply_curriculum
         )
     
-    def update_subject_id(self, subject_id: str):
+    def update_auto_train_fields(self, subject_id: str, curriculum_just_overridden: bool = False):
         self.selected_subject_id = subject_id
         self.label_subject_id.setText(self.selected_subject_id)
         
@@ -1767,6 +1770,7 @@ class AutoTrainDialog(QDialog):
         if self.df_this_mouse.empty:
             logger.info(f"No entry found in df_training_manager for subject_id: {self.selected_subject_id}")
             self.last_session = None
+            self.curriculum_in_use = None
             self.label_session.setText('subject not found')
             self.label_curriculum_name.setText('subject not found')
             self.label_last_actual_stage.setText('subject not found')
@@ -1778,6 +1782,10 @@ class AutoTrainDialog(QDialog):
             self.checkBox_override_stage.setEnabled(False)
             self._clear_layout(self.horizontalLayout_diagram)
             self.pushButton_apply_auto_train_paras.setEnabled(False)
+            
+            # override curriculum is checked by default and disabled
+            self.checkBox_override_curriculum.setChecked(True)
+            self.checkBox_override_curriculum.setEnabled(False)
             
             # prompt user to create a new mouse
             if self.isVisible():
@@ -1792,24 +1800,35 @@ class AutoTrainDialog(QDialog):
             self.selected_curriculum = None
             self.pushButton_apply_curriculum.setEnabled(True)
             self._add_border_curriculum_selection()
-
-        else:
-            # fetch last session
-            self.last_session = self.df_this_mouse.iloc[0]  # The first row is the latest session
-            # get curriculum in use
-            self.curriculum_in_use = self.curriculum_manager.get_curriculum(
-                curriculum_name=self.last_session['curriculum_name'],
-                curriculum_schema_version=self.last_session['curriculum_schema_version'],
-                curriculum_version=self.last_session['curriculum_version'],
-            )
-            # update info
+                        
+        else: # If the mouse exists in the auto_train_manager
+            # get curriculum in use from the last session, unless we just overrode it
+            if not curriculum_just_overridden:
+                # fetch last session
+                self.last_session = self.df_this_mouse.iloc[0]  # The first row is the latest session
+                self.curriculum_in_use = self.curriculum_manager.get_curriculum(
+                    curriculum_name=self.last_session['curriculum_name'],
+                    curriculum_schema_version=self.last_session['curriculum_schema_version'],
+                    curriculum_version=self.last_session['curriculum_version'],
+                )['curriculum']
+            
+                # update stage info
+                self.label_last_actual_stage.setText(str(self.last_session['current_stage_actual']))
+                self.label_next_stage_suggested.setText(str(self.last_session['next_stage_suggested']))
+                self.label_next_stage_suggested.setStyleSheet("color: black;")
+            else:
+                self.label_last_actual_stage.setText('irrelevant (curriculum overridden)')
+                self.label_next_stage_suggested.setText('irrelevant')
+                self.label_next_stage_suggested.setStyleSheet("color: red;")
+                
+                # Set override stage automatically
+                self.checkBox_override_stage.setChecked(True)
+            
+            # update more info
             self.label_curriculum_name.setText(
-                f"{self.last_session['curriculum_name']} "
-                f"(v{self.last_session['curriculum_version']})"
+                get_curriculum_string(self.curriculum_in_use)
                 )
             self.label_session.setText(str(self.last_session['session']))
-            self.label_last_actual_stage.setText(str(self.last_session['current_stage_actual']))
-            self.label_next_stage_suggested.setText(str(self.last_session['next_stage_suggested']))
             self.label_subject_id.setStyleSheet("color: black;")
             
             # enable apply training stage
@@ -1947,13 +1966,12 @@ class AutoTrainDialog(QDialog):
         # Add callback
         self.tableView_df_curriculum.clicked.connect(self._curriculum_selected)
         
-        # Auto select the curriculum of the latest session of selected mouse, if exists
-        # Get index of the latest session
-        if self.last_session is not None:
+        # Auto select the curriculum_in_use, if any
+        if self.curriculum_in_use is not None:
             curriculum_index = self.df_curriculums.reset_index().index[
-                (self.df_curriculums['curriculum_name'] == self.last_session['curriculum_name']) &
-                (self.df_curriculums['curriculum_version'] == self.last_session['curriculum_version']) &
-                (self.df_curriculums['curriculum_schema_version'] == self.last_session['curriculum_schema_version'])
+                (self.df_curriculums['curriculum_name'] == self.curriculum_in_use.curriculum_name) &
+                (self.df_curriculums['curriculum_version'] == self.curriculum_in_use.curriculum_version) &
+                (self.df_curriculums['curriculum_schema_version'] == self.curriculum_in_use.curriculum_schema_version)
             ][0]
 
             # Auto click the curriculum of the latest session
@@ -1997,19 +2015,27 @@ class AutoTrainDialog(QDialog):
     def _update_available_training_stages(self):
         if self.curriculum_in_use is not None:
             available_training_stages = [v.name for v in 
-                                        self.curriculum_in_use['curriculum'].parameters.keys()]
+                                        self.curriculum_in_use.parameters.keys()]
         else:
             available_training_stages = []
             
         self.comboBox_override_stage.clear()
         self.comboBox_override_stage.addItems(available_training_stages)
                 
-    def _update_status_override_stage(self):
-        if self.checkBox_override_stage.isChecked():
+    def _override_stage_clicked(self, state):
+        if state:
             self.comboBox_override_stage.setEnabled(True)
         else:
             self.comboBox_override_stage.setEnabled(False)
         self._update_stage_to_apply()
+        
+    def _override_curriculum_clicked(self, state):
+        if state:
+            self.pushButton_apply_curriculum.setEnabled(True)
+            self._add_border_curriculum_selection()
+        else:
+            self.pushButton_apply_curriculum.setEnabled(False)
+            self._remove_border_curriculum_selection()
             
     def _update_stage_to_apply(self):
         if self.checkBox_override_stage.isChecked():
@@ -2020,7 +2046,7 @@ class AutoTrainDialog(QDialog):
             self.stage_in_use = 'unknown training stage'
         
         self.pushButton_apply_auto_train_paras.setText(
-            f"Apply and lock\n{self.stage_in_use}"
+            f"Apply and lock\n{get_curriculum_string(self.curriculum_in_use)}\n{self.stage_in_use}"
         )
                 
     def _apply_curriculum(self):
@@ -2029,35 +2055,70 @@ class AutoTrainDialog(QDialog):
             QMessageBox.critical(self, "Error", "Please select a curriculum!")
             return
         
-        # Update global curriculum_in_use
-        self.curriculum_in_use = self.selected_curriculum
+        if self.df_this_mouse.empty:
+            # -- This is a new mouse, we add the first dummy session --
+            # Update global curriculum_in_use
+            self.curriculum_in_use = self.selected_curriculum
+            
+            # Add a dummy entry to df_training_manager
+            self.df_training_manager = pd.concat(
+                [self.df_training_manager, 
+                pd.DataFrame.from_records([
+                    dict(subject_id=self.selected_subject_id,
+                        session=0,
+                        session_date='unknown',
+                        curriculum_name=self.selected_curriculum['curriculum'].curriculum_name,
+                        curriculum_version=self.selected_curriculum['curriculum'].curriculum_version,
+                        curriculum_schema_version=self.selected_curriculum['curriculum'].curriculum_schema_version,
+                        task=None,
+                        current_stage_suggested=None,
+                        current_stage_actual=None,
+                        decision=None,
+                        next_stage_suggested='STAGE_1',
+                        if_closed_loop=None,
+                        if_overriden_by_trainer=None,
+                        finished_trials=None,
+                        foraging_efficiency=None,
+                        )
+                ])]
+            )
+            logger.info(f"Added a dummy session 0 for mouse {self.selected_subject_id} ")
+            
+            self.checkBox_override_curriculum.setChecked(False)
+            self.checkBox_override_curriculum.setEnabled(True)
         
-        # Add a dummy entry to df_training_manager
-        self.df_training_manager = pd.concat(
-            [self.df_training_manager, 
-             pd.DataFrame.from_records([
-                dict(subject_id=self.selected_subject_id,
-                    session=0,
-                    session_date='unknown',
-                    curriculum_name=self.selected_curriculum['curriculum'].curriculum_name,
-                    curriculum_version=self.selected_curriculum['curriculum'].curriculum_version,
-                    curriculum_schema_version=self.selected_curriculum['curriculum'].curriculum_schema_version,
-                    task=None,
-                    current_stage_suggested=None,
-                    current_stage_actual=None,
-                    decision=None,
-                    next_stage_suggested='STAGE_1',
-                    if_closed_loop=None,
-                    if_overriden_by_trainer=None,
-                    finished_trials=None,
-                    foraging_efficiency=None,
-                    )
-             ])]
-        )
-        logger.info(f"Added a dummy session 0 for mouse {self.selected_subject_id} ")
-        
-        # Refresh the GUI
-        self.update_subject_id(subject_id=self.selected_subject_id)
+            # Refresh the GUI
+            self.update_auto_train_fields(subject_id=self.selected_subject_id)
+
+        else:
+            # -- This is an existing mouse, we are changing the curriculum --
+            # Not sure whether we should leave this option open. But for now, I allow this freedom.            
+            self.checkBox_override_curriculum.setChecked(False)
+            self.pushButton_apply_curriculum.setEnabled(False)
+            self._remove_border_curriculum_selection() # Remove the highlight of curriculum table view
+            
+            if self.selected_curriculum['curriculum'] == self.curriculum_in_use:
+                # The selected curriculum is the same as the one in use
+                logger.info(f"Selected curriculum is the same as the one in use. No change is made.")
+                QMessageBox.information(self, "Info", "Selected curriculum is the same as the one in use. No change is made.")
+                return
+            else:
+                # Confirm with the user about overriding the curriculum
+                reply = QMessageBox.question(self, "Confirm",
+                                             f"Are you sure you want to override the curriculum?\n"
+                                             f"If yes, please also manually select a training stage.",
+                                             QMessageBox.Yes | QMessageBox.No,
+                                             QMessageBox.No)
+                if reply == QMessageBox.Yes:                
+                    # Update curriculum in use
+                    logger.info(f"Change curriculum from "
+                                f"{get_curriculum_string(self.curriculum_in_use)} to "
+                                f"{get_curriculum_string(self.selected_curriculum['curriculum'])}")
+                    self.curriculum_in_use = self.selected_curriculum['curriculum']
+                        
+            # Refresh the GUI
+            self.update_auto_train_fields(subject_id=self.selected_subject_id,
+                                          curriculum_just_overridden=reply == QMessageBox.Yes)
             
     def update_auto_train_lock(self, engaged):
         if engaged:
@@ -2065,7 +2126,7 @@ class AutoTrainDialog(QDialog):
             self.auto_train_engaged = True
 
             # Get parameter settings
-            paras = self.curriculum_in_use['curriculum'].parameters[
+            paras = self.curriculum_in_use.parameters[
                 TrainingStage[self.stage_in_use]
             ]
             
@@ -2193,7 +2254,13 @@ class AutoTrainDialog(QDialog):
         for i in reversed(range(layout.count())): 
             layout.itemAt(i).widget().setParent(None)
 
-                        
+def get_curriculum_string(curriculum):
+    if curriculum is None:
+        return "unknown curriculum"
+    else:
+        return (f"{curriculum.curriculum_name} "
+                f"(v{curriculum.curriculum_version}"
+                f"@{curriculum.curriculum_schema_version})")
         
         
 # --- Helpers ---

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2160,12 +2160,15 @@ class AutoTrainDialog(QDialog):
             for widget in self.widgets_locked_by_auto_train:
                 widget.setEnabled(False)
                 # set the border color to green
-                widget.setStyleSheet("border: 2px solid rgb(170, 255, 0);")
+                widget.setStyleSheet("border: 2px solid  rgb(0, 189, 22);")
             self.MainWindow.TrainingParameters.setStyleSheet(
                 '''QGroupBox {
-                        border: 5px solid rgb(170, 255, 0)
+                        border: 5px solid  rgb(0, 189, 22)
                     }
                 '''
+            )
+            self.MainWindow.label_auto_train_stage.setText(
+                f"{get_curriculum_string(self.curriculum_in_use)}\n{self.stage_in_use}"
             )
 
             # disable override
@@ -2185,6 +2188,8 @@ class AutoTrainDialog(QDialog):
                 # clear style
                 widget.setStyleSheet("")
             self.MainWindow.TrainingParameters.setStyleSheet("")
+            self.MainWindow.label_auto_train_stage.setText("")
+
 
             # enable override
             self.checkBox_override_stage.setEnabled(True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2474,7 +2474,7 @@ class Window(QMainWindow):
                 lambda: self.AutoTrain_dialog.update_auto_train_lock(engaged=False)
             )
             self.ID.returnPressed.connect(
-                lambda: self.AutoTrain_dialog.update_subject_id(subject_id=self.ID.text())
+                lambda: self.AutoTrain_dialog.update_auto_train_fields(subject_id=self.ID.text())
             )
 
             

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -3692,7 +3692,7 @@
    <widget class="QPushButton" name="StartExcitation">
     <property name="geometry">
      <rect>
-      <x>670</x>
+      <x>480</x>
       <y>871</y>
       <width>91</width>
       <height>21</height>
@@ -3714,7 +3714,7 @@
    <widget class="QPushButton" name="StartBleaching">
     <property name="geometry">
      <rect>
-      <x>780</x>
+      <x>590</x>
       <y>870</y>
       <width>91</width>
       <height>22</height>
@@ -4187,10 +4187,36 @@
      <bool>false</bool>
     </property>
     <property name="styleSheet">
-     <string notr="true">background-color: rgb(170, 255, 0);</string>
+     <string notr="true">background-color:  rgb(0, 189, 22);</string>
     </property>
     <property name="text">
      <string>Auto Train</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_auto_train_stage">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>830</y>
+      <width>421</width>
+      <height>81</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(0, 189, 22)</string>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
     </property>
    </widget>
    <zorder>infor</zorder>
@@ -4223,6 +4249,7 @@
    <zorder>TeensyWarning</zorder>
    <zorder>groupBox_3</zorder>
    <zorder>AutoTrain</zorder>
+   <zorder>label_auto_train_stage</zorder>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1489,7 +1489,7 @@ class GenerateTrials():
         # Manually attach auto training parameters 
         if hasattr(win, 'AutoTrain_dialog') and win.AutoTrain_dialog.auto_train_engaged:
             self.TP_auto_train_engaged = True
-            _curr = win.AutoTrain_dialog.curriculum_in_use['curriculum']
+            _curr = win.AutoTrain_dialog.curriculum_in_use
             self.TP_auto_train_curriculum_name = _curr.curriculum_name
             self.TP_auto_train_curriculum_version = _curr.curriculum_version
             self.TP_auto_train_curriculum_schema_version = _curr.curriculum_schema_version


### PR DESCRIPTION
### Note: This is a pull request to han_develop. I'm splitting the task into multiple PRs to han_develop just for the purpose of code review. After the first functioning version is ready, I'll issue a large PR from han_develop to production_test, with all descriptions combined.

- [x] Allow users to override the curriculum 

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/33d692b8-70c4-434b-9f1c-8b03b4fa51dc)




