### PR TITLE
Updating Reconnect Bonsai

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -485,7 +485,7 @@ class WaterCalibrationDialog(QDialog):
 
     def _StartCalibratingLeft(self):
         '''start the calibration loop of left valve'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.StartCalibratingLeft.isChecked():
@@ -649,7 +649,7 @@ class WaterCalibrationDialog(QDialog):
         self.StartCalibratingLeft.setChecked(False)
     def _StartCalibratingRight(self):
         '''start the calibration loop of right valve'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.StartCalibratingRight.isChecked():
@@ -866,7 +866,7 @@ class WaterCalibrationDialog(QDialog):
 
     def _OpenLeftForever(self):
         '''Open the left valve forever'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.OpenLeftForever.isChecked():
@@ -887,7 +887,7 @@ class WaterCalibrationDialog(QDialog):
 
     def _OpenRightForever(self):
         '''Open the right valve forever'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.OpenRightForever.isChecked():
@@ -908,7 +908,7 @@ class WaterCalibrationDialog(QDialog):
 
     def _OpenLeft(self):    
         '''Calibration of left valve in a different thread'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.OpenLeft.isChecked():
@@ -933,7 +933,7 @@ class WaterCalibrationDialog(QDialog):
         self.MainWindow.Channel.LeftValue(float(self.MainWindow.LeftValue.text())*1000)
     def _OpenRight(self):
         '''Calibration of right valve'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.OpenRight.isChecked():
@@ -986,7 +986,7 @@ class CameraDialog(QDialog):
 
     def _RestartLogging(self):
         '''Restart the logging (create a new logging folder)'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.CollectVideo.currentText()=='Yes':
@@ -1020,7 +1020,7 @@ class CameraDialog(QDialog):
             
     def _ClearTemporaryVideo(self):
         '''Clear temporary video files'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         try:
@@ -1035,7 +1035,7 @@ class CameraDialog(QDialog):
 
     def _StartCamera(self):
         '''Start/stop the camera'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
@@ -1188,30 +1188,30 @@ class LaserCalibrationDialog(QDialog):
         self.Flush_DO3.clicked.connect(self._FLush_DO3)
         self.Flush_Port2.clicked.connect(self._FLush_Port2)
     def _FLush_DO0(self):
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         self.MainWindow.Channel.DO0(int(1))
         self.MainWindow.Channel.receive()
     def _FLush_DO1(self):
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         self.MainWindow.Channel.DO1(int(1))
     def _FLush_DO2(self):
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         #self.MainWindow.Channel.DO2(int(1))
         self.MainWindow.Channel.receive()
     def _FLush_DO3(self):
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         self.MainWindow.Channel.DO3(int(1))
         self.MainWindow.Channel.receive()
     def _FLush_Port2(self):
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         self.MainWindow.Channel.Port2(int(1))
@@ -1683,7 +1683,7 @@ class LaserCalibrationDialog(QDialog):
         self.SleepComplete2=1
     def _Open(self):
         '''Open the laser only once'''
-        self.MainWindow._CheckBonsaiConnection()
+        self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
         if self.Open.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2154,10 +2154,8 @@ class Window(QMainWindow):
 
     def _CheckBonsaiConnection(self):
         '''Check if the Bonsai and GUI are connected'''
-        self._ConnectOSC()
-        #if self.InitializeBonsaiSuccessfully==0:
-        #    self._ConnectBonsai()
-        
+        if self.InitializeBonsaiSuccessfully==0:
+            self._ConnectBonsai() 
 
     def _Start(self):
         '''start trial loop'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2154,7 +2154,7 @@ class Window(QMainWindow):
 
     def _CheckBonsaiConnection(self):
         '''Check if the Bonsai and GUI are connected'''
-        self._ConnectBonsai()
+        self._ConnectOSC()
         #if self.InitializeBonsaiSuccessfully==0:
         #    self._ConnectBonsai()
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -364,7 +364,7 @@ class Window(QMainWindow):
                 self.WarningLabelInitializeBonsai.setStyleSheet("color: red;")
                 self.InitializeBonsaiSuccessfully=0
 
-    def _ReconnectBonsai(self):
+    def _ReconnectBonsai2(self):
         '''Reconnect bonsai'''
         try:
             logging.info('Attempting to close Bonsai connection')
@@ -380,7 +380,7 @@ class Window(QMainWindow):
         self.InitializeBonsaiSuccessfully=0
         self._ConnectBonsai()
 
-    def _RestartBonsai(self):
+    def _ReconnectBonsai(self):
         try:
             logging.info('Attempting to close Bonsai connection')
             self.client.close()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -371,7 +371,7 @@ class Window(QMainWindow):
             self.client2.close()
             self.client3.close()
             self.client4.close()
-        except Exception as e
+        except Exception as e:
             logging.info('could not close bonsai connection: {}'.format(str(e))) 
 
         #if self.InitializeBonsaiSuccessfully==1:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -365,11 +365,20 @@ class Window(QMainWindow):
 
     def _ReconnectBonsai(self):
         '''Reconnect bonsai'''
-        if self.InitializeBonsaiSuccessfully==1:
+        try:
+            logging.info('Attempting to close Bonsai connection')
             self.client.close()
             self.client2.close()
             self.client3.close()
             self.client4.close()
+        except Exception as e
+            logging.info('could not close bonsai connection: {}'.format(str(e))) 
+
+        #if self.InitializeBonsaiSuccessfully==1:
+        #    self.client.close()
+        #    self.client2.close()
+        #    self.client3.close()
+        #    self.client4.close()
         self.InitializeBonsaiSuccessfully=0
         self._ConnectBonsai()
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -364,25 +364,16 @@ class Window(QMainWindow):
                 self.WarningLabelInitializeBonsai.setStyleSheet("color: red;")
                 self.InitializeBonsaiSuccessfully=0
 
-    def _ReconnectBonsai2(self):
-        '''Reconnect bonsai'''
-        try:
-            logging.info('Attempting to close Bonsai connection')
-            self.client.close()
-            self.client2.close()
-            self.client3.close()
-            self.client4.close()
-        except Exception as e:
-            logging.info('could not close bonsai connection: {}'.format(str(e)))    
-        else:
-            logging.info('Bonsai connection closed')
-
-        self.InitializeBonsaiSuccessfully=0
-        self._ConnectBonsai()
-
     def _ReconnectBonsai(self):
+        '''
+            Reconnect bonsai
+            
+            First, it closes the connections with the clients. 
+            Then, it restarts the Bonsai workflow. If a bonsai instance is already running, 
+            then it will connect. Otherwise it will start a new bonsai instance
+        '''
         try:
-            logging.info('Attempting to close Bonsai connection')
+            logging.info('attempting to close bonsai connection')
             self.client.close()
             self.client2.close()
             self.client3.close()
@@ -390,8 +381,9 @@ class Window(QMainWindow):
         except Exception as e:
             logging.info('could not close bonsai connection: {}'.format(str(e)))    
         else:
-            logging.info('Bonsai connection closed')
-        logging.info('Attempting to restart bonsai')
+            logging.info('bonsai connection closed')
+
+        logging.info('attempting to restart bonsai')
         self.InitializeBonsaiSuccessfully=0       
         self._InitializeBonsai()
 
@@ -2162,8 +2154,10 @@ class Window(QMainWindow):
 
     def _CheckBonsaiConnection(self):
         '''Check if the Bonsai and GUI are connected'''
-        if self.InitializeBonsaiSuccessfully==0:
-            self._ConnectBonsai()
+        self._ConnectBonsai()
+        #if self.InitializeBonsaiSuccessfully==0:
+        #    self._ConnectBonsai()
+        
 
     def _Start(self):
         '''start trial loop'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -357,6 +357,7 @@ class Window(QMainWindow):
             try:
                 self._ConnectOSC()
                 self.InitializeBonsaiSuccessfully=1
+                logging.info('Connected to Bonsai')
             except Exception as e:
                 logging.error(str(e))
                 self.WarningLabelInitializeBonsai.setText('Please open bonsai!')
@@ -372,15 +373,27 @@ class Window(QMainWindow):
             self.client3.close()
             self.client4.close()
         except Exception as e:
-            logging.info('could not close bonsai connection: {}'.format(str(e))) 
+            logging.info('could not close bonsai connection: {}'.format(str(e)))    
+        else:
+            logging.info('Bonsai connection closed')
 
-        #if self.InitializeBonsaiSuccessfully==1:
-        #    self.client.close()
-        #    self.client2.close()
-        #    self.client3.close()
-        #    self.client4.close()
         self.InitializeBonsaiSuccessfully=0
         self._ConnectBonsai()
+
+    def _RestartBonsai(self):
+        try:
+            logging.info('Attempting to close Bonsai connection')
+            self.client.close()
+            self.client2.close()
+            self.client3.close()
+            self.client4.close()
+        except Exception as e:
+            logging.info('could not close bonsai connection: {}'.format(str(e)))    
+        else:
+            logging.info('Bonsai connection closed')
+        logging.info('Attempting to restart bonsai')
+        self.InitializeBonsaiSuccessfully=0       
+        self._InitializeBonsai()
 
     def _restartlogging(self,log_folder=None):
         '''Restarting logging'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2152,14 +2152,9 @@ class Window(QMainWindow):
         self.ID.setEnabled(enable)
         self.Experimenter.setEnabled(enable)
 
-    def _CheckBonsaiConnection(self):
-        '''Check if the Bonsai and GUI are connected'''
-        if self.InitializeBonsaiSuccessfully==0:
-            self._ConnectBonsai() 
-
     def _Start(self):
         '''start trial loop'''
-        self._CheckBonsaiConnection()
+        self.ConnectBonsai()
         if self.InitializeBonsaiSuccessfully==0:
             return
         self.WarningLabelInitializeBonsai.setText('')
@@ -2378,7 +2373,7 @@ class Window(QMainWindow):
             self.DelayMax.setEnabled(True)
     def _GiveLeft(self):
         '''manually give left water'''
-        self._CheckBonsaiConnection()
+        self.ConnectBonsai()
         if self.InitializeBonsaiSuccessfully==0:
             return
         self.Channel.LeftValue(float(self.TP_GiveWaterL)*1000)
@@ -2390,7 +2385,7 @@ class Window(QMainWindow):
     
     def _GiveRight(self):
         '''manually give right water'''
-        self._CheckBonsaiConnection()
+        self.ConnectBonsai()
         if self.InitializeBonsaiSuccessfully==0:
             return
         self.Channel.RightValue(float(self.TP_GiveWaterR)*1000)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2154,7 +2154,7 @@ class Window(QMainWindow):
 
     def _Start(self):
         '''start trial loop'''
-        self.ConnectBonsai()
+        self._ConnectBonsai()
         if self.InitializeBonsaiSuccessfully==0:
             return
         self.WarningLabelInitializeBonsai.setText('')
@@ -2373,7 +2373,7 @@ class Window(QMainWindow):
             self.DelayMax.setEnabled(True)
     def _GiveLeft(self):
         '''manually give left water'''
-        self.ConnectBonsai()
+        self._ConnectBonsai()
         if self.InitializeBonsaiSuccessfully==0:
             return
         self.Channel.LeftValue(float(self.TP_GiveWaterL)*1000)
@@ -2385,7 +2385,7 @@ class Window(QMainWindow):
     
     def _GiveRight(self):
         '''manually give right water'''
-        self.ConnectBonsai()
+        self._ConnectBonsai()
         if self.InitializeBonsaiSuccessfully==0:
             return
         self.Channel.RightValue(float(self.TP_GiveWaterR)*1000)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Previously "reconnect bonsai" closed the OSC connection, but would not start a bonsai instance if one was not open
- Now, "reconnect bonsai" closes the OSC connection, and when it reconnects will open a new bonsai instance if one is not running. 
- Removes the redundant function "_CheckBonsaiConnection". This function called `_ConnectBonsai`, but only if `self.InitializeBonsaiSuccessfully==0`, which is the same condition `_ConnectBonsai` uses before doing anything. I have replaced all calls to `_CheckBonsaiConnection` with `_ConnectBonsai`
- [x] 3x typos in Foraging.py. Should be `_ConnectBonsai`, not `ConnectBonsai`
- [x] Replace calls to `_CheckBonsaiConnection` in Dialogs.py

### What issues or discussions does this update address?
- resolves #111 

### Describe the expected change in behavior from the perspective of the experimenter
- Now if Bonsai crashes/closes, you can click on "Control", then "Reconnect Bonsai" and Bonsai will reopen
- Note that if bonsai crashes while the task is running the GUI will crash, this only helps when the task is not running. 

### Describe the outcome of testing this update on a rig in 447
- [x] tested




