### PR TITLE
[do not merge] Label bonsai IDE window with Box number

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -678,10 +678,15 @@ class Window(QMainWindow):
 
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
-        box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}'.format(self.box_number))
-        subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
-        logging.info('here') ##DEBUG
-        subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+        try:
+            box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}'.format(self.box_number))
+            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
+            logging.info('here') ##DEBUG
+        except Exception as e:
+            print(e)
+        #subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+        subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -679,7 +679,8 @@ class Window(QMainWindow):
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}'.format(self.box_number))
-        subprocess.call('cp {} {}'.format(self.bonsaiworkflow_path, box_path))
+        subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
+        logging.info('here') ##DEBUG
         subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
 
     def _OpenSettingFolder(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -678,12 +678,13 @@ class Window(QMainWindow):
 
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
+        
+        # Copy the bonsai workflow to a temporary location so we can rename it with the box
         box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
-        logging.info('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
         subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path, box_path),shell=True)
-        subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
-        #subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+        subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path+'.layout', box_path+'.layout'),shell=True)
 
+        subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -678,7 +678,9 @@ class Window(QMainWindow):
 
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
-        subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+        box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}'.format(self.box_number))
+        subprocess.call('cp {} {}'.format(self.bonsaiworkflow_path, box_path))
+        subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -680,6 +680,7 @@ class Window(QMainWindow):
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         try:
             box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}'.format(self.box_number))
+            print('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
             subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
             logging.info('here') ##DEBUG
         except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -681,7 +681,7 @@ class Window(QMainWindow):
         try:
             box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
             logging.info('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
-            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
+            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path),shell=True)
             logging.info('here') ##DEBUG
         except Exception as e:
             print(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -678,15 +678,11 @@ class Window(QMainWindow):
 
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
-        try:
-            box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
-            logging.info('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
-            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path),shell=True)
-            logging.info('here') ##DEBUG
-        except Exception as e:
-            print(e)
-        #subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
-        subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+        box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
+        logging.info('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
+        subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path, box_path),shell=True)
+        subprocess.Popen(self.bonsai_path+' '+box_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
+        #subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start',cwd=CWD,shell=True)
 
 
     def _OpenSettingFolder(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -679,9 +679,9 @@ class Window(QMainWindow):
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         try:
-            box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}'.format(self.box_number))
-            print('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
-            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
+            box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}.bonsai'.format(self.box_number))
+            logging.info('copy {} {}'.format(self.bonsaiworkflow_path, os.getcwd()))
+            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, os.getcwd()))
             logging.info('here') ##DEBUG
         except Exception as e:
             print(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -680,7 +680,7 @@ class Window(QMainWindow):
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         
         # Copy the bonsai workflow to a temporary location so we can rename it with the box
-        box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}".format(self.box_number))
+        box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
         subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path, box_path),shell=True)
         subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path+'.layout', box_path+'.layout'),shell=True)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -679,9 +679,9 @@ class Window(QMainWindow):
         SettingsBox = 'Settings_box{}.csv'.format(self.box_number)
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         try:
-            box_path = os.path.join(os.path.expanduser("~"), "Documents",'temporary_workflows','Box{}.bonsai'.format(self.box_number))
-            logging.info('copy {} {}'.format(self.bonsaiworkflow_path, os.getcwd()))
-            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, os.getcwd()))
+            box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
+            logging.info('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
+            subprocess.Popen('copy {} {}'.format(self.bonsaiworkflow_path, box_path))
             logging.info('here') ##DEBUG
         except Exception as e:
             print(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -680,7 +680,7 @@ class Window(QMainWindow):
         CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
         
         # Copy the bonsai workflow to a temporary location so we can rename it with the box
-        box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}.bonsai".format(self.box_number))
+        box_path = os.path.join(os.path.expanduser("~"), "Documents","temporary_workflows","Box{}".format(self.box_number))
         subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path, box_path),shell=True)
         subprocess.call('copy {} {}'.format(self.bonsaiworkflow_path+'.layout', box_path+'.layout'),shell=True)
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Labels the Bonsai IDE window with the box number. The window title is inherited from the workflow. So before opening the workflow I copy the workflow to a temporary directory, and rename it with the box.
- [ ] This is a temporary solution

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/85

### Describe the expected change in behavior from the perspective of the experimenter
- The bonsai window is labeled

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447
- [ ] manually updated the 447 computers to have the temp. directory
- [ ] Updated installation instructions to create temp. directory




