### PR TITLE
Fixed a crash bug

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1062,6 +1062,7 @@ class Window(QMainWindow):
                             child.setValue(int(getattr(Parameters, 'TP_'+child.objectName())))
                         else:
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
+                    '''
                     else:
                         # If this parameter changed, add the change to the log
                         old = getattr(Parameters,'TP_'+child.objectName())
@@ -1070,7 +1071,8 @@ class Window(QMainWindow):
                         new = float(child.text())
                         if new != old:
                             logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
-
+                    '''
+                    
             # update the current training parameters
             self._GetTrainingParameters()
  


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
I commented some lines related to a recent update. Specifically, the error was happening on line 1087 in the foraging.py (`old = getattr(Parameters,'TP_'+child.objectName())`) when we tried to change the baseline weight after stopping the GUI. 

### What issues or discussions does this update address?
Sue will submit an issue to describe the error information in more detail. 
### Describe the expected change in behavior from the perspective of the experimenter
No
### Describe the outcome of testing this update on a rig in 447
Tested in the ephys rig. 




