### PR TITLE
Check if parameter attribute exists before calling get attribute; log git status

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1086,7 +1086,7 @@ class Window(QMainWindow):
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                     else:
                         # If this parameter changed, add the change to the log
-                        logging.debug('debugging parameter error: "{}" '.format(child.objectName()))
+                        logging.info('debugging parameter error: "{}" '.format(child.objectName())) ##DEBUG
                         old = getattr(Parameters,'TP_'+child.objectName())
                         if old != '':
                             old = float(old)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1085,17 +1085,17 @@ class Window(QMainWindow):
                         else:
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
-
-                    if hasattr(Parameters, 'TP_'+child.objectName()):
-                        # If this parameter changed, add the change to the log
-                        old = getattr(Parameters,'TP_'+child.objectName())
-                        if old != '':
-                            old = float(old)
-                        new = float(child.text())
-                        if new != old:
-                            logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
                     else:
-                        logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
+                        if hasattr(Parameters, 'TP_'+child.objectName()):
+                            # If this parameter changed, add the change to the log
+                            old = getattr(Parameters,'TP_'+child.objectName())
+                            if old != '':
+                                old = float(old)
+                            new = float(child.text())
+                            if new != old:
+                                logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
+                        else:
+                            logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
                     
             # update the current training parameters
             self._GetTrainingParameters()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2712,8 +2712,12 @@ def start_gui_log_file(box_number):
     logging.captureWarnings(True)
 
 def log_git_hash():
-    git_hash = subprocess.check_output(['git','rev-parse','--short', 'HEAD']).decode('ascii').strip()
-    logging.info('Current git commit hash: {}'.format(git_hash))
+    try:
+        git_hash = subprocess.check_output(['git','rev-parse','--short', 'HEAD']).decode('ascii').strip()
+        git_branch = subprocess.check_output(['git','branch','--show-current'].decode('ascii').strip()
+        logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
+    except Exception as e:
+        logging.error('Could not log git branch and hash: {}'.format(str(e)))
 
 def excepthook(exc_type, exc_value, exc_tb):
     '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2736,7 +2736,7 @@ if __name__ == "__main__":
 
     # Start logging
     start_gui_log_file(box_number)
-    log_git_has()
+    log_git_hash()
 
     # Formating GUI graphics
     logging.info('Setting QApplication attributes')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2713,7 +2713,7 @@ def start_gui_log_file(box_number):
 
 def log_git_hash():
     git_hash = subprocess.check_output(['git','rev-parse','--short', 'HEAD']).decode('ascii').strip()
-    logging.info('Current git commit hash: {}'.format(git_has))
+    logging.info('Current git commit hash: {}'.format(git_hash))
 
 def excepthook(exc_type, exc_value, exc_tb):
     '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1084,16 +1084,15 @@ class Window(QMainWindow):
                             child.setValue(int(getattr(Parameters, 'TP_'+child.objectName())))
                         else:
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
-                    '''
                     else:
                         # If this parameter changed, add the change to the log
+                        logging.debug('debugging parameter error: "{}" '.format(child.objectName()))
                         old = getattr(Parameters,'TP_'+child.objectName())
                         if old != '':
                             old = float(old)
                         new = float(child.text())
                         if new != old:
                             logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
-                    '''
                     
             # update the current training parameters
             self._GetTrainingParameters()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1084,15 +1084,19 @@ class Window(QMainWindow):
                             child.setValue(int(getattr(Parameters, 'TP_'+child.objectName())))
                         else:
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
-                    else:
+                        continue
+
+                    try:
                         # If this parameter changed, add the change to the log
-                        logging.info('debugging parameter error: "{}" '.format(child.objectName())) ##DEBUG
                         old = getattr(Parameters,'TP_'+child.objectName())
                         if old != '':
                             old = float(old)
                         new = float(child.text())
                         if new != old:
                             logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
+                    except Exception as e:
+                        logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
+                        logging.error(str(e))
                     
             # update the current training parameters
             self._GetTrainingParameters()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2711,6 +2711,10 @@ def start_gui_log_file(box_number):
     logging.info('Starting logfile!')
     logging.captureWarnings(True)
 
+def log_git_hash():
+    git_hash = subprocess.check_output(['git','rev-parse','--short', 'HEAD']).decode('ascii').strip()
+    logging.info('Current git commit hash: {}'.format(git_has))
+
 def excepthook(exc_type, exc_value, exc_tb):
     '''
         excepthook will be called when the GUI encounters an uncaught exception
@@ -2732,6 +2736,7 @@ if __name__ == "__main__":
 
     # Start logging
     start_gui_log_file(box_number)
+    log_git_has()
 
     # Formating GUI graphics
     logging.info('Setting QApplication attributes')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2714,7 +2714,7 @@ def start_gui_log_file(box_number):
 def log_git_hash():
     try:
         git_hash = subprocess.check_output(['git','rev-parse','--short', 'HEAD']).decode('ascii').strip()
-        git_branch = subprocess.check_output(['git','branch','--show-current'].decode('ascii').strip()
+        git_branch = subprocess.check_output(['git','branch','--show-current']).decode('ascii').strip()
         logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
     except Exception as e:
         logging.error('Could not log git branch and hash: {}'.format(str(e)))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1085,14 +1085,6 @@ class Window(QMainWindow):
                         else:
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
-                    else:
-                        # If this parameter changed, add the change to the log
-                        old = getattr(Parameters,'TP_'+child.objectName())
-                        if old != '':
-                            old = float(old)
-                        new = float(child.text())
-                        if new != old:
-                            logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
 
                     if hasattr(Parameters, 'TP_'+child.objectName()):
                         # If this parameter changed, add the change to the log

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1085,8 +1085,7 @@ class Window(QMainWindow):
                         else:
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
-
-                    try:
+                    else:
                         # If this parameter changed, add the change to the log
                         old = getattr(Parameters,'TP_'+child.objectName())
                         if old != '':
@@ -1094,9 +1093,18 @@ class Window(QMainWindow):
                         new = float(child.text())
                         if new != old:
                             logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
-                    except Exception as e:
-                        logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
-                        logging.error(str(e))
+
+                    #try:
+                    #    # If this parameter changed, add the change to the log
+                    #    old = getattr(Parameters,'TP_'+child.objectName())
+                    #    if old != '':
+                    #        old = float(old)
+                    #    new = float(child.text())
+                    #    if new != old:
+                    #        logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
+                    #except Exception as e:
+                    #    logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
+                    #    logging.error(str(e))
                     
             # update the current training parameters
             self._GetTrainingParameters()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1094,17 +1094,16 @@ class Window(QMainWindow):
                         if new != old:
                             logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
 
-                    #try:
-                    #    # If this parameter changed, add the change to the log
-                    #    old = getattr(Parameters,'TP_'+child.objectName())
-                    #    if old != '':
-                    #        old = float(old)
-                    #    new = float(child.text())
-                    #    if new != old:
-                    #        logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
-                    #except Exception as e:
-                    #    logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
-                    #    logging.error(str(e))
+                    if hasattr(Parameters, 'TP_'+child.objectName()):
+                        # If this parameter changed, add the change to the log
+                        old = getattr(Parameters,'TP_'+child.objectName())
+                        if old != '':
+                            old = float(old)
+                        new = float(child.text())
+                        if new != old:
+                            logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
+                    else:
+                        logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
                     
             # update the current training parameters
             self._GetTrainingParameters()


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- When the keystroke event is processed we check which parameters change. This issue (https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/188) encountered an issue where the child had an empty string as a name, so the parameter `TP_` was queried, which raised an AttributeError. I'm not sure why this object had an empty name, but in general, its always good practice to check if the attribute exists before getting its value. I've also added a log entry when this happens so we can get more information. 
- Adds an entry into the log for the current git branch and commit hash. Does this in a try/except block for stability. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/188
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/190

### Describe the expected change in behavior from the perspective of the experimenter
- no changes

### Describe the outcome of testing this update on a rig in 447
- [x] Tested on the ephys rigs, specifically handles the error




