### PR TITLE
 Changed the codec

### DIFF
--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -7053,7 +7053,7 @@
                         <ffmpeg:Suffix>None</ffmpeg:Suffix>
                         <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
                         <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                        <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset medium -threads 10</ffmpeg:OutputArguments>
+                        <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset medium</ffmpeg:OutputArguments>
                       </Combinator>
                     </Expression>
                     <Expression xsi:type="SubscribeSubject">
@@ -7111,7 +7111,7 @@
                         <ffmpeg:Suffix>None</ffmpeg:Suffix>
                         <ffmpeg:Overwrite>false</ffmpeg:Overwrite>
                         <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                        <ffmpeg:OutputArguments>-vcodec libx264 -crf 23  -preset medium  -threads 10</ffmpeg:OutputArguments>
+                        <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset medium</ffmpeg:OutputArguments>
                       </Combinator>
                     </Expression>
                   </Nodes>

--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -7053,7 +7053,7 @@
                         <ffmpeg:Suffix>None</ffmpeg:Suffix>
                         <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
                         <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                        <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset medium</ffmpeg:OutputArguments>
+                        <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset fast</ffmpeg:OutputArguments>
                       </Combinator>
                     </Expression>
                     <Expression xsi:type="SubscribeSubject">
@@ -7109,9 +7109,9 @@
                       <Combinator xsi:type="ffmpeg:VideoWriter">
                         <ffmpeg:FileName>E:\DynamicForagingGUI\BehaviorData\Tower_EphysRig3\641733\641733_2023-12-08_15-48-06\HarpFolder/../VideoFolder/side_camera.avi</ffmpeg:FileName>
                         <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                        <ffmpeg:Overwrite>false</ffmpeg:Overwrite>
+                        <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
                         <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                        <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset medium</ffmpeg:OutputArguments>
+                        <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset fast</ffmpeg:OutputArguments>
                       </Combinator>
                     </Expression>
                   </Nodes>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Changed the codec used to compress video online in bonsai. 
before: -vcodec libx264 -crf 23 -preset medium -threads 10
after: -vcodec h264_nvenc -crf 23 -preset medium
### What issues or discussions does this update address?
Resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/189#event-11593005192

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe the outcome of testing this update on a rig in 447
Tested in the ephys rig. It was running without memory accumulation. 

- [ ] test the compression quality





