### PR TITLE
Select session for visualization

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -252,7 +252,7 @@ class Window(QMainWindow):
                 child.returnPressed.connect(self.keyPressEvent)
     
     def _session_list(self):
-        '''show all sessions of the current animal and load the selected session'''
+        '''show all sessions of the current animal and load the selected session by drop down list'''
         if not hasattr(self,'fname'):
             return 0
         # open the selected session
@@ -267,7 +267,7 @@ class Window(QMainWindow):
             self._connect_Sessionlist(connect=True)
 
     def _session_list_spin(self):
-        '''show all sessions of the current animal and load the selected session'''
+        '''show all sessions of the current animal and load the selected session by spin box'''
         if not hasattr(self,'fname'):
             return 0
         if self.SessionlistSpin.text()!='':
@@ -305,9 +305,7 @@ class Window(QMainWindow):
                 if not file_name.endswith('.json'):
                     continue
                 session_full_path_list.append(os.path.join(training_folder, file_name))
-                parts=os.path.splitext(file_name)[0].split('_')
-                session_path_list.append(parts[0]+'_'+parts[1])  # Remove the suffix
-        
+                session_path_list.append(session_folder) 
         sorted_indices = sorted(enumerate(session_path_list), key=lambda x: x[1], reverse=True)
         sorted_dates = [date for index, date in sorted_indices]
         # Extract just the indices
@@ -2235,9 +2233,8 @@ class Window(QMainWindow):
             # show session list related to that animal
             tag=self._show_sessions()
             if tag!=0:
-                fname_basename=os.path.basename(fname)
-                parts=os.path.splitext(fname_basename)[0].split('_')
-                Ind=self.Sessionlist.findText(parts[0]+'_'+parts[1])
+                fname_session_folder=os.path.basename(os.path.dirname(os.path.dirname(fname)))
+                Ind=self.Sessionlist.findText(fname_session_folder)
                 self._connect_Sessionlist(connect=False)
                 self.Sessionlist.setCurrentIndex(Ind)
                 self.SessionlistSpin.setValue(Ind+1)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2153,73 +2153,76 @@ class Window(QMainWindow):
                     break
         return mice  
 
-    def _Open(self,open_last = False):
+    def _Open(self,open_last = False,input_file = ''):
+        if input_file == '' or input_file == False:
+            # stop current session first
+            self._StopCurrentSession() 
 
-        # stop current session first
-        self._StopCurrentSession() 
-
-        # Start new session
-        new_session = self._NewSession()
-        if not new_session:
-            return
-
-        if open_last:
-            mice = self._Open_getListOfMice()
-            W = MouseSelectorDialog(self, mice)
-
-            ok, mouse_id = (
-                W.exec_() == QtWidgets.QDialog.Accepted, 
-                W.combo.currentText(),
-            )        
-
-            # Version 1, keeping it for the moment 
-            ### Prompt user to enter mouse ID, with auto-completion
-            ##dialog = QtWidgets.QInputDialog(self)
-            ##dialog.setWindowTitle('Box {}, Load mouse'.format(self.box_letter))
-            ##dialog.setLabelText('Enter the mouse ID')
-            ##dialog.setTextValue('')
-            ##lineEdit = dialog.findChild(QtWidgets.QLineEdit)
-        
-            ### Set auto complete
-            ##mice = self._Open_getListOfMice()
-            ##completer = QtWidgets.QCompleter(mice, lineEdit)
-            ##lineEdit.setCompleter(completer)
-            ##
-            ### Only accept integers
-            ##onlyInt = QtGui.QIntValidator()
-            ##onlyInt.setRange(0, 100000000)
-            ##lineEdit.setValidator(onlyInt)
-        
-            ### Get response
-            ##ok, mouse_id = (
-            ##    dialog.exec_() == QtWidgets.QDialog.Accepted, 
-            ##    dialog.textValue(),
-            ##)
-            if not ok: 
-                logging.info('Quick load failed, user hit cancel or X')
-                return                                
-            
-            # Mouse ID not in list of mice:
-            if mouse_id not in mice:
-                # figureout out new Mouse
-                logging.info('User entered the ID for a mouse with no data: {}'.format(mouse_id))
-                self._OpenNewMouse(mouse_id)
+            # Start new session
+            new_session = self._NewSession()
+            if not new_session:
                 return
- 
-            # attempt to load last session from mouse
-            good_load, fname = self._OpenLast_find_session(mouse_id)  
-            if not good_load:
-                logging.info('Quick load failed')
-                return        
-            logging.info('Quick load success: {}'.format(fname))
-        else:
-            # Open dialog box
-            fname, _ = QFileDialog.getOpenFileName(self, 'Open file', 
-                self.default_saveFolder+'\\'+self.current_box, 
-                "Behavior JSON files (*.json);;Behavior MAT files (*.mat);;JSON parameters (*_par.json)")
-            logging.info('User selected: {}'.format(fname))    
 
-        self.fname=fname
+            if open_last:
+                mice = self._Open_getListOfMice()
+                W = MouseSelectorDialog(self, mice)
+
+                ok, mouse_id = (
+                    W.exec_() == QtWidgets.QDialog.Accepted, 
+                    W.combo.currentText(),
+                )        
+
+                # Version 1, keeping it for the moment 
+                ### Prompt user to enter mouse ID, with auto-completion
+                ##dialog = QtWidgets.QInputDialog(self)
+                ##dialog.setWindowTitle('Box {}, Load mouse'.format(self.box_letter))
+                ##dialog.setLabelText('Enter the mouse ID')
+                ##dialog.setTextValue('')
+                ##lineEdit = dialog.findChild(QtWidgets.QLineEdit)
+            
+                ### Set auto complete
+                ##mice = self._Open_getListOfMice()
+                ##completer = QtWidgets.QCompleter(mice, lineEdit)
+                ##lineEdit.setCompleter(completer)
+                ##
+                ### Only accept integers
+                ##onlyInt = QtGui.QIntValidator()
+                ##onlyInt.setRange(0, 100000000)
+                ##lineEdit.setValidator(onlyInt)
+            
+                ### Get response
+                ##ok, mouse_id = (
+                ##    dialog.exec_() == QtWidgets.QDialog.Accepted, 
+                ##    dialog.textValue(),
+                ##)
+                if not ok: 
+                    logging.info('Quick load failed, user hit cancel or X')
+                    return                                
+                
+                # Mouse ID not in list of mice:
+                if mouse_id not in mice:
+                    # figureout out new Mouse
+                    logging.info('User entered the ID for a mouse with no data: {}'.format(mouse_id))
+                    self._OpenNewMouse(mouse_id)
+                    return
+    
+                # attempt to load last session from mouse
+                good_load, fname = self._OpenLast_find_session(mouse_id)  
+                if not good_load:
+                    logging.info('Quick load failed')
+                    return        
+                logging.info('Quick load success: {}'.format(fname))
+            else:
+                # Open dialog box
+                fname, _ = QFileDialog.getOpenFileName(self, 'Open file', 
+                    self.default_saveFolder+'\\'+self.current_box, 
+                    "Behavior JSON files (*.json);;Behavior MAT files (*.mat);;JSON parameters (*_par.json)")
+                logging.info('User selected: {}'.format(fname))    
+
+            self.fname=fname
+        else:
+            fname=input_file
+            self.fname=fname
         if fname:
             if fname.endswith('.mat'):
                 Obj = loadmat(fname)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2122,7 +2122,7 @@ class Window(QMainWindow):
         return mice  
 
     def _Open(self,open_last = False,input_file = ''):
-        if input_file == '' or input_file == False:
+        if input_file == '':
             # stop current session first
             self._StopCurrentSession() 
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -259,7 +259,6 @@ class Window(QMainWindow):
             self._connect_Sessionlist(connect=True)
             self._Open(input_file=fname)
 
-            
     def _connect_Sessionlist(self,connect=True):
         '''connect or disconnect the Sessionlist and SessionlistSpin'''
         if connect:
@@ -300,8 +299,6 @@ class Window(QMainWindow):
         self.Sessionlist.addItems(sorted_dates)
         self._connect_Sessionlist(connect=True)
         
-
-                
     def _warmup(self):
         '''warm up the session before starting.
             Use warm up with caution. Usually, it is only used for the first time training. 

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -113,15 +113,21 @@
        </widget>
       </item>
       <item>
-       <layout class="QGridLayout" name="gridLayout_5">
+       <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,0,0,0,0,0,0,0,0,0,0">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
         <property name="leftMargin">
-         <number>5</number>
+         <number>2</number>
+        </property>
+        <property name="topMargin">
+         <number>1</number>
         </property>
         <property name="rightMargin">
-         <number>5</number>
+         <number>4</number>
         </property>
-        <item row="0" column="1">
-         <widget class="QPushButton" name="Save">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="Load">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -129,7 +135,83 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Save</string>
+           <string>Load</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>100</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="6">
+         <widget class="QSpinBox" name="SessionlistSpin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maximum">
+           <number>100000</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+          <property name="displayIntegerBase">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="10">
+         <widget class="QPushButton" name="Clear">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="8" alignment="Qt::AlignRight">
+         <widget class="QPushButton" name="NewSession">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>New Session</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -158,59 +240,40 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="6">
-         <widget class="QPushButton" name="Clear">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Clear</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>500</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="4" alignment="Qt::AlignRight">
-         <widget class="QPushButton" name="NewSession">
+        <item row="0" column="4">
+         <widget class="QLabel" name="label_73">
           <property name="enabled">
            <bool>true</bool>
           </property>
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="text">
-           <string>New Session</string>
+           <string>session=</string>
           </property>
-          <property name="checkable">
-           <bool>true</bool>
+          <property name="textFormat">
+           <enum>Qt::AutoText</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QPushButton" name="Load">
+        <item row="0" column="5">
+         <widget class="QComboBox" name="Sessionlist">
+          <property name="minimumSize">
+           <size>
+            <width>130</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="Save">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -218,7 +281,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Load</string>
+           <string>Save</string>
           </property>
          </widget>
         </item>
@@ -816,7 +879,7 @@
             <string notr="true"/>
            </property>
            <property name="currentIndex">
-            <number>2</number>
+            <number>0</number>
            </property>
            <widget class="QWidget" name="tab_2">
             <attribute name="title">
@@ -2476,7 +2539,7 @@ Double dipping:
                 <property name="geometry">
                  <rect>
                   <x>0</x>
-                  <y>-152</y>
+                  <y>0</y>
                   <width>1077</width>
                   <height>460</height>
                  </rect>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -266,7 +266,7 @@
          <widget class="QComboBox" name="Sessionlist">
           <property name="minimumSize">
            <size>
-            <width>130</width>
+            <width>200</width>
             <height>0</height>
            </size>
           </property>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2843,7 +2843,7 @@
     <widget class="QLabel" name="label_73">
      <property name="geometry">
       <rect>
-       <x>250</x>
+       <x>210</x>
        <y>10</y>
        <width>121</width>
        <height>20</height>
@@ -2893,9 +2893,9 @@
     <widget class="QComboBox" name="Sessionlist">
      <property name="geometry">
       <rect>
-       <x>380</x>
+       <x>340</x>
        <y>10</y>
-       <width>151</width>
+       <width>191</width>
        <height>22</height>
       </rect>
      </property>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2667,7 +2667,7 @@
     <widget class="QLabel" name="label_69">
      <property name="geometry">
       <rect>
-       <x>295</x>
+       <x>585</x>
        <y>10</y>
        <width>121</width>
        <height>20</height>
@@ -2692,7 +2692,7 @@
     <widget class="QLabel" name="label_70">
      <property name="geometry">
       <rect>
-       <x>710</x>
+       <x>810</x>
        <y>10</y>
        <width>91</width>
        <height>20</height>
@@ -2717,7 +2717,7 @@
     <widget class="QLabel" name="label_71">
      <property name="geometry">
       <rect>
-       <x>860</x>
+       <x>960</x>
        <y>11</y>
        <width>66</width>
        <height>16</height>
@@ -2742,7 +2742,7 @@
     <widget class="QSpinBox" name="WindowSize">
      <property name="geometry">
       <rect>
-       <x>805</x>
+       <x>905</x>
        <y>10</y>
        <width>61</width>
        <height>22</height>
@@ -2767,7 +2767,7 @@
     <widget class="QSpinBox" name="RunLength">
      <property name="geometry">
       <rect>
-       <x>420</x>
+       <x>710</x>
        <y>10</y>
        <width>61</width>
        <height>22</height>
@@ -2792,7 +2792,7 @@
     <widget class="QSpinBox" name="StepSize">
      <property name="geometry">
       <rect>
-       <x>930</x>
+       <x>1030</x>
        <y>10</y>
        <width>61</width>
        <height>22</height>
@@ -2817,7 +2817,7 @@
     <widget class="QComboBox" name="MartchingType">
      <property name="geometry">
       <rect>
-       <x>1010</x>
+       <x>1110</x>
        <y>8</y>
        <width>71</width>
        <height>25</height>
@@ -2839,6 +2839,66 @@
        <string>fraction R</string>
       </property>
      </item>
+    </widget>
+    <widget class="QLabel" name="label_73">
+     <property name="geometry">
+      <rect>
+       <x>250</x>
+       <y>10</y>
+       <width>121</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>session=</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QSpinBox" name="SessionlistSpin">
+     <property name="geometry">
+      <rect>
+       <x>530</x>
+       <y>10</y>
+       <width>41</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximum">
+      <number>100000</number>
+     </property>
+     <property name="value">
+      <number>1</number>
+     </property>
+     <property name="displayIntegerBase">
+      <number>10</number>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="Sessionlist">
+     <property name="geometry">
+      <rect>
+       <x>380</x>
+       <y>10</y>
+       <width>151</width>
+       <height>22</height>
+      </rect>
+     </property>
     </widget>
    </widget>
    <widget class="QComboBox" name="OptogeneticsB">


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Added a combo box and spin box to show all sessions related to that animal. We can select a specific session for visualization. It's useful for navigating different sessions of one animal. 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/56b4923d-f6ee-4bf1-bef5-466c48968b25)
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/b6a34dde-2615-4e8a-8bc9-ffd54f63f579)

### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe the outcome of testing this update on a rig in 447
- [x] test on my own computer
- [x] test in ephys




