### PR TITLE
Fix timer issue with photometry baseline period

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -177,7 +177,7 @@ class Window(QMainWindow):
         self.NextBlock.clicked.connect(self._NextBlock)
         self.OptogeneticsB.activated.connect(self._OptogeneticsB) # turn on/off optogenetics
         self.OptogeneticsB.currentIndexChanged.connect(self._keyPressEvent)
-        self.PhtotometryB.currentIndexChanged.connect(self._keyPressEvent)
+        self.PhotometryB.currentIndexChanged.connect(self._keyPressEvent)
         self.AdvancedBlockAuto.currentIndexChanged.connect(self._keyPressEvent)
         self.AutoWaterType.currentIndexChanged.connect(self._keyPressEvent)
         self.UncoupledReward.textChanged.connect(self._ShowRewardPairs)
@@ -2150,6 +2150,7 @@ class Window(QMainWindow):
 
     def _StartExcitation(self):
         if self.StartExcitation.isChecked():
+            logging.info('StartExcitation is checked')
             self.StartExcitation.setStyleSheet("background-color : green;")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
@@ -2163,6 +2164,7 @@ class Window(QMainWindow):
                 self.TeensyWarning.setText('Error: start excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
         else:
+            logging.info('StartExcitation is unchecked')
             self.StartExcitation.setStyleSheet("background-color : none")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
@@ -2463,9 +2465,20 @@ class Window(QMainWindow):
             workerGenerateAtrial=self.workerGenerateAtrial
             workerStartTrialLoop=self.workerStartTrialLoop
             workerStartTrialLoop1=self.workerStartTrialLoop1
+
+        if self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
+            logging.warning('photometry is set to "on", but excitation is not running')
+            reply = QMessageBox.question(self, 'Start', 'photometry is set to on, but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
+            if reply == QMessageBox.Yes:
+                self._StartExcitation.setChecked(True)
+                self._StartExcitation()
+                logging.info('User selected to start excitation')
+            else:                   
+                logging.info('User selected not to start excitation')
+ 
         
         # collecting the base signal for photometry. Only run once
-        if self.PhtotometryB.currentText()=='on' and self.PhotometryRun==0:
+        if self.PhotometryB.currentText()=='on' and self.PhotometryRun==0:
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
@@ -2491,11 +2504,10 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 1#5*60  
+        stall_duration = 1*60#5*60 ##DEBUGGING CODE 
 
         while self.Start.isChecked():
             QApplication.processEvents()
-            current_time = time.time()
             if self.ANewTrial==1 and self.Start.isChecked() and self.finish_Timer==1:
 
                 # Reset stall timer
@@ -2559,11 +2571,11 @@ class Window(QMainWindow):
                 if self.NewTrialRewardOrder==1:
                     GeneratedTrials._GenerateATrial(self.Channel4)   
 
-            elif (current_time - last_trial_start) >stall_duration*stall_iteration:
+            elif (time.time() - last_trial_start) >stall_duration*stall_iteration:
                 # Elapsed time since last trial is more than tolerance
 
                 # Check if we are in the photometry baseline period.
-                if (self.finish_Timer==0) & ((current_time - last_trial_start) < (float(self.baselinetime.text())*60+10)):
+                if (self.finish_Timer==0) & ((time.time() - last_trial_start) < (float(self.baselinetime.text())*60+10)):
                     # Extra 10 seconds is to avoid any race conditions
                     # We are in the photometry baseline period
                     continue

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2165,6 +2165,9 @@ class Window(QMainWindow):
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
                 reply = QMessageBox.question(self, 'Start excitation:', 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
                 self.StartExcitation.setChecked(False)
+            else:
+                self.TeensyWarning.setText('')
+                self.TeensyWarning.setStyleSheet(self.default_warning_color)               
 
         else:
             logging.info('StartExcitation is unchecked')
@@ -2181,6 +2184,10 @@ class Window(QMainWindow):
                 self.TeensyWarning.setText('Error: stop excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
                 reply = QMessageBox.question(self, 'Start excitation:', 'error when stopping excitation: {}'.format(e), QMessageBox.Ok)
+            else:
+                self.TeensyWarning.setText('')
+                self.TeensyWarning.setStyleSheet(self.default_warning_color)               
+
     
     def _StartBleaching(self):
         if self.StartBleaching.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2163,6 +2163,8 @@ class Window(QMainWindow):
                 logging.error(str(e))
                 self.TeensyWarning.setText('Error: start excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
+                reply = QMessageBox.question(self, 'Start excitation:', 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
+
         else:
             logging.info('StartExcitation is unchecked')
             self.StartExcitation.setStyleSheet("background-color : none")
@@ -2177,6 +2179,7 @@ class Window(QMainWindow):
                 logging.error(str(e))
                 self.TeensyWarning.setText('Error: stop excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
+                reply = QMessageBox.question(self, 'Start excitation:', 'error when stopping excitation: {}'.format(e), QMessageBox.Ok)
     
     def _StartBleaching(self):
         if self.StartBleaching.isChecked():
@@ -2474,8 +2477,8 @@ class Window(QMainWindow):
             reply = QMessageBox.question(self, 'Start', 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:
                 self.StartExcitation.setChecked(True)
-                self._StartExcitation()
                 logging.info('User selected to start excitation')
+                self._StartExcitation()
             else:                   
                 logging.info('User selected not to start excitation')
   

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2473,7 +2473,7 @@ class Window(QMainWindow):
             logging.warning('photometry is set to "on", but excitation is not running')
             reply = QMessageBox.question(self, 'Start', 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:
-                self._StartExcitation.setChecked(True)
+                self.StartExcitation.setChecked(True)
                 self._StartExcitation()
                 logging.info('User selected to start excitation')
             else:                   

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2329,6 +2329,8 @@ class Window(QMainWindow):
         '''complete of _Timer'''
         self.finish_Timer=1
         logging.info('Finished photometry baseline timer')
+        self.WarningLabelStop.setText('')
+        self.WarningLabelStop.setStyleSheet(self.default_warning_color)
     
     def _Timer(self,Time):
         '''sleep some time'''
@@ -2466,17 +2468,17 @@ class Window(QMainWindow):
             workerStartTrialLoop=self.workerStartTrialLoop
             workerStartTrialLoop1=self.workerStartTrialLoop1
 
+        # Check if photometry excitation is running or not
         if self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
-            reply = QMessageBox.question(self, 'Start', 'photometry is set to on, but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
+            reply = QMessageBox.question(self, 'Start', 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:
                 self._StartExcitation.setChecked(True)
                 self._StartExcitation()
                 logging.info('User selected to start excitation')
             else:                   
                 logging.info('User selected not to start excitation')
- 
-        
+  
         # collecting the base signal for photometry. Only run once
         if self.PhotometryB.currentText()=='on' and self.PhotometryRun==0:
             logging.info('Starting photometry baseline timer')
@@ -2485,7 +2487,8 @@ class Window(QMainWindow):
             workertimer = Worker(self._Timer,float(self.baselinetime.text())*60)
             workertimer.signals.finished.connect(self._thread_complete_timer)
             self.threadpool_workertimer.start(workertimer)
-
+            self.WarningLabelStop.setText('Running photometry baseline')
+            self.WarningLabelStop.setStyleSheet(self.default_warning_color)
         
         self._StartTrialLoop(GeneratedTrials,worker1)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2562,7 +2562,7 @@ class Window(QMainWindow):
                 # Elapsed time since last trial is more than tolerance
 
                 # Check if we are in the photometry baseline period.
-                if (self.finish_Timer==0) & ((current_time - last_trial_start) < float(self.baselinetime.text())*60)):
+                if (self.finish_Timer==0) & ((current_time - last_trial_start) < float(self.baselinetime.text())*60):
                     # We are in the photometry baseline period
                     continue
                 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2491,7 +2491,7 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 5*60  
+        stall_duration = 1#5*60  
 
         while self.Start.isChecked():
             QApplication.processEvents()
@@ -2563,7 +2563,8 @@ class Window(QMainWindow):
                 # Elapsed time since last trial is more than tolerance
 
                 # Check if we are in the photometry baseline period.
-                if (self.finish_Timer==0) & ((current_time - last_trial_start) < float(self.baselinetime.text())*60):
+                if (self.finish_Timer==0) & ((current_time - last_trial_start) < (float(self.baselinetime.text())*60+10)):
+                    # Extra 10 seconds is to avoid any race conditions
                     # We are in the photometry baseline period
                     continue
                 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2326,6 +2326,7 @@ class Window(QMainWindow):
     def _thread_complete_timer(self):
         '''complete of _Timer'''
         self.finish_Timer=1
+        logging.info('Finished photometry baseline timer')
     
     def _Timer(self,Time):
         '''sleep some time'''
@@ -2471,7 +2472,7 @@ class Window(QMainWindow):
             workertimer = Worker(self._Timer,float(self.baselinetime.text())*60)
             workertimer.signals.finished.connect(self._thread_complete_timer)
             self.threadpool_workertimer.start(workertimer)
-            logging.info('Finished photometry baseline timer')
+
         
         self._StartTrialLoop(GeneratedTrials,worker1)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2494,6 +2494,7 @@ class Window(QMainWindow):
 
         while self.Start.isChecked():
             QApplication.processEvents()
+            current_time = time.time()
             if self.ANewTrial==1 and self.Start.isChecked() and self.finish_Timer==1:
 
                 # Reset stall timer
@@ -2555,10 +2556,15 @@ class Window(QMainWindow):
                     self.threadpool.start(worker1)
                 #generate a new trial
                 if self.NewTrialRewardOrder==1:
-                    GeneratedTrials._GenerateATrial(self.Channel4)  
- 
-            elif (time.time() - last_trial_start) >stall_duration*stall_iteration:
+                    GeneratedTrials._GenerateATrial(self.Channel4)   
+
+            elif (current_time - last_trial_start) >stall_duration*stall_iteration:
                 # Elapsed time since last trial is more than tolerance
+
+                # Check if we are in the photometry baseline period.
+                if (self.finish_Timer==0) & ((current_time - last_trial_start) < float(self.baselinetime.text())*60)):
+                    # We are in the photometry baseline period
+                    continue
                 
                 # Prompt user to stop trials
                 elapsed_time = int(np.floor(stall_duration*stall_iteration/60))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2469,7 +2469,7 @@ class Window(QMainWindow):
             workerStartTrialLoop1=self.workerStartTrialLoop1
 
         # Check if photometry excitation is running or not
-        if (not self.Start.isChecked()) and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
+        if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
             reply = QMessageBox.question(self, 'Start', 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2164,6 +2164,7 @@ class Window(QMainWindow):
                 self.TeensyWarning.setText('Error: start excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
                 reply = QMessageBox.question(self, 'Start excitation:', 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
+                self.StartExcitation.setChecked(False)
 
         else:
             logging.info('StartExcitation is unchecked')
@@ -2510,7 +2511,7 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 1*60#5*60 ##DEBUGGING CODE 
+        stall_duration = 5*60 
 
         while self.Start.isChecked():
             QApplication.processEvents()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2310,18 +2310,23 @@ class Window(QMainWindow):
         if self.NewTrialRewardOrder==0:
             self.GeneratedTrials._GenerateATrial(self.Channel4)
         self.ANewTrial=1
+    
     def _thread_complete2(self):
         '''complete of receive licks'''
         self.ToReceiveLicks=1
+    
     def _thread_complete3(self):
         '''complete of update figures'''
         self.ToUpdateFigure=1
+    
     def _thread_complete4(self):
         '''complete of generating a trial'''
         self.ToGenerateATrial=1
+    
     def _thread_complete_timer(self):
         '''complete of _Timer'''
         self.finish_Timer=1
+    
     def _Timer(self,Time):
         '''sleep some time'''
         time.sleep(Time)
@@ -2460,11 +2465,13 @@ class Window(QMainWindow):
         
         # collecting the base signal for photometry. Only run once
         if self.PhtotometryB.currentText()=='on' and self.PhotometryRun==0:
+            logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
             workertimer = Worker(self._Timer,float(self.baselinetime.text())*60)
             workertimer.signals.finished.connect(self._thread_complete_timer)
             self.threadpool_workertimer.start(workertimer)
+            logging.info('Finished photometry baseline timer')
         
         self._StartTrialLoop(GeneratedTrials,worker1)
 
@@ -2559,8 +2566,9 @@ class Window(QMainWindow):
                 reply = QMessageBox.question(self, 'Trial Generator', message,QMessageBox.Yes| QMessageBox.No )
                 if reply == QMessageBox.Yes:
                     # User stops trials
-                    logging.error('trial stalled {} minutes, user stopped trials'.format(elapsed_time))
-        
+                    err_msg = 'trial stalled {} minutes, user stopped trials. ANewTrial:{},Start:{},finish_Timer:{}'
+                    logging.error(err_msg.format(elapsed_time,self.ANewTrial,self.Start.isChecked(), self.finish_Timer))
+
                     # Set that the current trial ended, so we can save
                     self.ANewTrial=1
     

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2469,7 +2469,7 @@ class Window(QMainWindow):
             workerStartTrialLoop1=self.workerStartTrialLoop1
 
         # Check if photometry excitation is running or not
-        if self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
+        if (not self.Start.isChecked()) and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
             reply = QMessageBox.question(self, 'Start', 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4605,7 +4605,7 @@ Current pair:
                        </widget>
                       </item>
                       <item row="1" column="1" colspan="2">
-                       <widget class="QComboBox" name="PhtotometryB">
+                       <widget class="QComboBox" name="PhotometryB">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                           <horstretch>0</horstretch>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3737,7 +3737,7 @@
      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
     </property>
    </widget>
-   <widget class="QComboBox" name="PhtotometryB">
+   <widget class="QComboBox" name="PhotometryB">
     <property name="geometry">
      <rect>
       <x>89</x>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
The timer that checks if bonsai has stalled did not take into account that the photometry baseline period is longer than the stall detector. So, the user was being alerted that bonsai may have stalled, even when everything was running fine. 
- I added a condition that checks if the photometry baseline period is on-going, and if so, does not alert the user. 
- Alerts the user that we are in the photometry baseline period, with text in the warning box
- adds logging information about photometry period start/stop
- If `photometry=on`, and `start` is pressed, but `start excitation` is not checked, alerts user with a prompt to start the excitation, but allows the user to proceed without starting the excitation
- Fixes a misspelling of `PhtotometryB` in the GUI ui (fixed both versions)
- If start excitation fails, alerts the user with a prompt

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/234

### Describe the expected change in behavior from the perspective of the experimenter
- You will not see an alert that bonsai may have crashed during the photometry baseline period
- If you start the session when `photometry=on` without starting the excitation, you will get an alert. 
- During the photometry baseline period you will see a text displayed saying "Running photometry baseline"

### Describe the outcome of testing this update on a rig in 447
- [x] Tested in 447





