### PR TITLE
Fixed issue with base weight not loading.

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2002,6 +2002,9 @@ class Window(QMainWindow):
                             logging.error(str(e))
                             value=CurrentObj[key]
                             Tag=1
+                        if key=='BaseWeight':
+                            value=CurrentObj[key]
+                            Tag=1
                         if isinstance(widget, QtWidgets.QPushButton):
                             pass
                         if type(value)==bool:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
The GUI loaded parameters from the last trial. If you enter your base weight after training has stopped, it will not be loaded the next time you train. I changed to load the BaseWeight directly from the GUI line edit instead of loading from the last trial. 

### What issues or discussions does this update address?
Resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/232

### Describe the expected change in behavior from the perspective of the experimenter
No 

### Describe the outcome of testing this update on a rig in 447
No need. Tested on my computer




