### PR TITLE
Add notification for session stopping due to ignore trials, max trials, or max time

### DIFF
--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -14,6 +14,7 @@ from PyQt5 import QtWidgets
 from PyQt5 import QtCore
 
 
+
 if PLATFORM == 'win32':
     from newscale.usbxpress import USBXpressLib, USBXpressDevice
 VID_NEWSCALE = 0x10c4
@@ -1021,30 +1022,44 @@ class GenerateTrials():
         else:
             self.BS_CurrentRunningTime=0
 
+        stop = False
+        msg =''
+
+        # Make message box prompt
+        warning_label_text = ''
+        warning_label_color = 'color: gray;'        
+ 
         if np.shape(self.B_AnimalResponseHistory)[0]>=StopIgnore:
             if np.all(self.B_AnimalResponseHistory[-StopIgnore:]==2):
-                self.Stop=1
-                self.win.WarningLabelStop.setText('Stop because ignore trials exceed or equal: '+self.TP_StopIgnores)
-                self.win.WarningLabelStop.setStyleSheet(self.win.default_warning_color)
+                stop=True
+                msg = 'Stopping the session because the mouse has ignored at least {} consecutive trials'.format(self.TP_StopIgnores)
+                warning_label_text = 'Stop because ignore trials exceed or equal: '+self.TP_StopIgnores
+                warning_label_color = self.win.default_warning_color
             else:
-                self.Stop=0
-                self.win.WarningLabelStop.setText('')
-                self.win.WarningLabelStop.setStyleSheet("color: gray;")
+                stop=False
         elif self.B_CurrentTrialN>MaxTrial: 
-            self.Stop=1
-            self.win.WarningLabelStop.setText('Stop because maximum trials exceed or equal: '+self.TP_MaxTrial)
-            self.win.WarningLabelStop.setStyleSheet(self.win.default_warning_color)
+            stop=True
+            msg = 'Stopping the session because the mouse has reached the maximum trial count: {}'.format(self.TP_MaxTrial)
+            warning_label_text = 'Stop because maximum trials exceed or equal: '+self.TP_MaxTrial
+            warning_label_color = self.win.default_warning_color
         elif self.BS_CurrentRunningTime>MaxTime:
-            self.Stop=1
-            self.win.WarningLabelStop.setText('Stop because running time exceeds or equals: '+self.TP_MaxTime+'m')
-            self.win.WarningLabelStop.setStyleSheet(self.win.default_warning_color)
+            stop=True
+            msg = 'Stopping the session because the session running time has reached {} minutes'.format(self.TP_MaxTime)
+            warning_label_text = 'Stop because running time exceeds or equals: '+self.TP_MaxTime+'m'
+            warning_label_color = self.win.default_warning_color
         else:
-            self.Stop=0
-            self.win.WarningLabelStop.setText('')
-            self.win.WarningLabelStop.setStyleSheet("color: gray;")
-        if  self.Stop==1:           
+            stop=False
+
+        # Update the warning label text/color
+        self.win.WarningLabelStop.setText(warning_label_text)
+        self.win.WarningLabelStop.setStyleSheet(warning_label_color)
+    
+        # If we should stop trials, uncheck the start button
+        if stop:           
             self.win.Start.setStyleSheet("background-color : none")
-            self.win.Start.setChecked(False)
+            self.win.Start.setChecked(False)        
+            reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QMessageBox.Ok)
+    
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''
         if self.TP_AutoReward:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -14,7 +14,6 @@ from PyQt5 import QtWidgets
 from PyQt5 import QtCore
 
 
-
 if PLATFORM == 'win32':
     from newscale.usbxpress import USBXpressLib, USBXpressDevice
 VID_NEWSCALE = 0x10c4
@@ -1022,21 +1021,18 @@ class GenerateTrials():
         else:
             self.BS_CurrentRunningTime=0
 
+        # Make message box prompt
         stop = False
         msg =''
-
-        # Make message box prompt
         warning_label_text = ''
         warning_label_color = 'color: gray;'        
- 
-        if np.shape(self.B_AnimalResponseHistory)[0]>=StopIgnore:
-            if np.all(self.B_AnimalResponseHistory[-StopIgnore:]==2):
-                stop=True
-                msg = 'Stopping the session because the mouse has ignored at least {} consecutive trials'.format(self.TP_StopIgnores)
-                warning_label_text = 'Stop because ignore trials exceed or equal: '+self.TP_StopIgnores
-                warning_label_color = self.win.default_warning_color
-            else:
-                stop=False
+
+        # Check for reasons to stop early 
+        if (np.shape(self.B_AnimalResponseHistory)[0]>=StopIgnore) and (np.all(self.B_AnimalResponseHistory[-StopIgnore:]==2)):
+            stop=True
+            msg = 'Stopping the session because the mouse has ignored at least {} consecutive trials'.format(self.TP_StopIgnores)
+            warning_label_text = 'Stop because ignore trials exceed or equal: '+self.TP_StopIgnores
+            warning_label_color = self.win.default_warning_color
         elif self.B_CurrentTrialN>MaxTrial: 
             stop=True
             msg = 'Stopping the session because the mouse has reached the maximum trial count: {}'.format(self.TP_MaxTrial)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1058,7 +1058,7 @@ class GenerateTrials():
         if stop:           
             self.win.Start.setStyleSheet("background-color : none")
             self.win.Start.setChecked(False)        
-            reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QMessageBox.Ok)
+            reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
     
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- When the session stops generating trials due to any reason other than the user pressing "start", a notification window is generated alerting the user that the session has stopped and the reason. The user presses "OK". 
- The title of the window is "Box <box number>" to clarify which session has stopped.
- Cleans up the logic for checking for session ends
- Identifies and fixes a bug. If the response history is greater than StopIgnore, then the other stopping conditions will never be met. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/237

### Describe the expected change in behavior from the perspective of the experimenter
When the session stops generating trials due to any reason other than the user pressing "start", a notification window is generated alerting the user that the session has stopped and the reason. The user presses "OK". 

### Describe the outcome of testing this update on a rig in 447
- tested in 447




