### PR TITLE
changing paths to use windows USERNAME, adding Box number to all prompt windows

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1935,7 +1935,7 @@ class AutoTrainDialog(QDialog):
         except:
             logger.error("AWS connection failed!")
             QMessageBox.critical(self,
-                                 'Error',
+                                 'Box {}, Error'.format(self.MainWindow.box_letter),
                                  f'AWS connection failed!\n'
                                  f'Please check your AWS credentials at ~\.aws\credentials!')
             return False
@@ -2128,7 +2128,7 @@ class AutoTrainDialog(QDialog):
     def _apply_curriculum(self):
         # Check if a curriculum is selected
         if not hasattr(self, 'selected_curriculum') or self.selected_curriculum is None:
-            QMessageBox.critical(self, "Error", "Please select a curriculum!")
+            QMessageBox.critical(self, "Box {}, Error".format(self.MainWindow.box_letter), "Please select a curriculum!")
             return
         
         # Always enable override stage
@@ -2174,11 +2174,11 @@ class AutoTrainDialog(QDialog):
             if self.selected_curriculum['curriculum'] == self.curriculum_in_use:
                 # The selected curriculum is the same as the one in use
                 logger.info(f"Selected curriculum is the same as the one in use. No change is made.")
-                QMessageBox.information(self, "Info", "Selected curriculum is the same as the one in use. No change is made.")
+                QMessageBox.information(self, "Box {}, Info".format(self.MainWindow.box_letter), "Selected curriculum is the same as the one in use. No change is made.")
                 return
             else:
                 # Confirm with the user about overriding the curriculum
-                reply = QMessageBox.question(self, "Confirm",
+                reply = QMessageBox.question(self, "Box {}, Confirm".format(self.MainWindow.box_letter),
                                              f"Are you sure you want to override the curriculum?\n"
                                              f"If yes, please also manually select a training stage.",
                                              QMessageBox.Yes | QMessageBox.No,
@@ -2284,7 +2284,8 @@ class AutoTrainDialog(QDialog):
                 task_ind = widget_task.findText(paras_dict['task'])
                 if task_ind < 0:
                     logger.error(f"Task {paras_dict['task']} not found!")
-                    QMessageBox.critical(self, "Error", f'''Task "{paras_dict['task']}" not found. Check the curriculum!''')
+                    QMessageBox.critical(self, "Box {}, Error".format(self.MainWindow.box_letter), 
+                        f'''Task "{paras_dict['task']}" not found. Check the curriculum!''')
                     return [] # Return an empty list without setting anything
                 else:
                     widget_task.setCurrentIndex(task_ind)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -499,7 +499,7 @@ class Window(QMainWindow):
         '''   
         if self.InitializeBonsaiSuccessfully ==1 and hasattr(self, 'GeneratedTrials'):
             msg = 'Reconnected to Bonsai. Start a new session before running more trials'
-            reply = QMessageBox.question(self, 'Reconnect Bonsai', msg, QMessageBox.Ok )
+            reply = QMessageBox.question(self, 'Box {}, Reconnect Bonsai'.format(self.box_letter), msg, QMessageBox.Ok )
  
     def _restartlogging(self,log_folder=None):
         '''Restarting logging'''
@@ -1534,7 +1534,7 @@ class Window(QMainWindow):
          # enable close icon
         self.setWindowFlag(QtCore.Qt.WindowCloseButtonHint, True)
         self.show()
-        reply = QMessageBox.question(self, 'Foraging Close', 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
+        reply = QMessageBox.question(self, 'Box {}, Foraging Close'.format(self.box_letter), 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
         if reply == QMessageBox.Yes:
             self._Save()
             event.accept()
@@ -1564,7 +1564,7 @@ class Window(QMainWindow):
     def _Exit(self):
         '''Close the GUI'''
         logging.info('closing the GUI')
-        response = QMessageBox.question(self,'Save and Exit:', "Do you want to save the current result?", QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,QMessageBox.Yes)
+        response = QMessageBox.question(self,'Box {}, Save and Exit:'.format(self.box_letter), "Do you want to save the current result?", QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,QMessageBox.Yes)
         if response==QMessageBox.Yes:
             # close the camera
             if self.Camera_dialog.AutoControl.currentText()=='Yes':
@@ -1719,7 +1719,7 @@ class Window(QMainWindow):
         if ForceSave==0:
             self._StopCurrentSession() # stop the current session first
         if self.BaseWeight.text()=='' or self.WeightAfter.text()=='' or self.TargetRatio.text()=='':
-            response = QMessageBox.question(self,'Save without weight or extra water:', "Do you want to save without weight or extra water information provided?", QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,QMessageBox.Yes)
+            response = QMessageBox.question(self,'Box {}, Save without weight or extra water:'.format(self.box_letter), "Do you want to save without weight or extra water information provided?", QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,QMessageBox.Yes)
             if response==QMessageBox.Yes:
                 pass
                 self.WarningLabel.setText('Saving without weight or extra water!')
@@ -2150,7 +2150,7 @@ class Window(QMainWindow):
         PlotM._Update(GeneratedTrials=self.GeneratedTrials)
         self.PlotLick._Update(GeneratedTrials=self.GeneratedTrials)
     def _Clear(self):
-        reply = QMessageBox.question(self, 'Clear parameters:', 'Do you want to clear training parameters?',QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
+        reply = QMessageBox.question(self, 'Box {}, Clear parameters:'.format(self.box_letter), 'Do you want to clear training parameters?',QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
         if reply == QMessageBox.Yes:
             for child in self.TrainingParameters.findChildren(QtWidgets.QLineEdit)+ self.centralwidget.findChildren(QtWidgets.QLineEdit):
                 if child.isEnabled():
@@ -2176,7 +2176,7 @@ class Window(QMainWindow):
                 logging.error(str(e))
                 self.TeensyWarning.setText('Error: start excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
-                reply = QMessageBox.question(self, 'Start excitation:', 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
+                reply = QMessageBox.question(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
                 self.StartExcitation.setChecked(False)
             else:
                 self.TeensyWarning.setText('')
@@ -2196,7 +2196,7 @@ class Window(QMainWindow):
                 logging.error(str(e))
                 self.TeensyWarning.setText('Error: stop excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
-                reply = QMessageBox.question(self, 'Start excitation:', 'error when stopping excitation: {}'.format(e), QMessageBox.Ok)
+                reply = QMessageBox.question(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when stopping excitation: {}'.format(e), QMessageBox.Ok)
             else:
                 self.TeensyWarning.setText('')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)               
@@ -2251,7 +2251,7 @@ class Window(QMainWindow):
         logging.info('starting new session')
         if self.NewSession.isChecked():
             if self.ToInitializeVisual==0: # Do not ask to save when no session starts running
-                reply = QMessageBox.question(self, 'New Session:', 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
+                reply = QMessageBox.question(self, 'Box {}, New Session:'.format(self.box_letter), 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
             else:
                 reply=QMessageBox.No
             if reply == QMessageBox.Yes:
@@ -2287,7 +2287,7 @@ class Window(QMainWindow):
         return reply
 
     def _AskSave(self):
-        reply = QMessageBox.question(self, 'New Session:', 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
+        reply = QMessageBox.question(self, 'Box {}, New Session:'.format(self.box_letter), 'Do you want to save the current result?',QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes)
         if reply == QMessageBox.Yes:
             self._Save()
             logging.info('The current session was saved')
@@ -2320,7 +2320,7 @@ class Window(QMainWindow):
                 elif (time.time() - start_time) > stall_duration*stall_iteration:
                     elapsed_time = int(np.floor(stall_duration*stall_iteration/60))
                     message = '{} minutes have elapsed since trial stopped was initiated. Force stop?'.format(elapsed_time)
-                    reply = QMessageBox.question(self,'StopCurrentSession',message,QMessageBox.Yes|QMessageBox.No)
+                    reply = QMessageBox.question(self,'Box {}, StopCurrentSession'.format(self.box_letter),message,QMessageBox.Yes|QMessageBox.No)
                     if reply == QMessageBox.Yes:
                         logging.error('trial stalled {} minutes, user force stopped trials'.format(elapsed_time))
                         self.ANewTrial=1
@@ -2418,7 +2418,7 @@ class Window(QMainWindow):
                     self.Start.setChecked(False)
                     self.Start.setStyleSheet("background-color : none")
                     self.InitializeBonsaiSuccessfully=0
-                    reply = QMessageBox.question(self, 'Start', 'Cannot connect to Bonsai. Attempt reconnection?',QMessageBox.Yes | QMessageBox.No)
+                    reply = QMessageBox.question(self, 'Box {}, Start'.format(self.box_letter), 'Cannot connect to Bonsai. Attempt reconnection?',QMessageBox.Yes | QMessageBox.No)
                     if reply == QMessageBox.Yes:
                         self._ReconnectBonsai()
                         logging.info('User selected reconnect bonsai')
@@ -2495,7 +2495,7 @@ class Window(QMainWindow):
         # Check if photometry excitation is running or not
         if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
-            reply = QMessageBox.question(self, 'Start', 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
+            reply = QMessageBox.question(self, 'Box {}, Start'.format(self.box_letter), 'Photometry is set to "on", but excitation is not running. Start excitation now?',QMessageBox.Yes | QMessageBox.No)
             if reply == QMessageBox.Yes:
                 self.StartExcitation.setChecked(True)
                 logging.info('User selected to start excitation')
@@ -2564,7 +2564,7 @@ class Window(QMainWindow):
                         self.Start.setChecked(False)
                         self.Start.setStyleSheet("background-color : none")
                         self.InitializeBonsaiSuccessfully=0
-                        reply = QMessageBox.question(self, 'Start', 'Cannot connect to Bonsai. Attempt reconnection?',QMessageBox.Yes | QMessageBox.No)
+                        reply = QMessageBox.question(self, 'Box {}, Start'.format(self.box_letter), 'Cannot connect to Bonsai. Attempt reconnection?',QMessageBox.Yes | QMessageBox.No)
                         if reply == QMessageBox.Yes:
                             self._ReconnectBonsai()
                             logging.info('User selected reconnect bonsai')
@@ -2574,7 +2574,7 @@ class Window(QMainWindow):
 
                         break
                     else:
-                        reply = QMessageBox.question(self, 'Error', 'Encountered the following error: {}'.format(e),QMessageBox.Ok )
+                        reply = QMessageBox.question(self, 'Box {}, Error'.format(self.box_letter), 'Encountered the following error: {}'.format(e),QMessageBox.Ok )
                         logging.error('Caught this error: {}'.format(e))
                         self.ANewTrial=1
                         self.Start.setChecked(False)
@@ -2610,7 +2610,7 @@ class Window(QMainWindow):
                 # Prompt user to stop trials
                 elapsed_time = int(np.floor(stall_duration*stall_iteration/60))
                 message = '{} minutes have elapsed since the last trial started. Bonsai may have stopped. Stop trials?'.format(elapsed_time)
-                reply = QMessageBox.question(self, 'Trial Generator', message,QMessageBox.Yes| QMessageBox.No )
+                reply = QMessageBox.question(self, 'Box {}, Trial Generator'.format(self.box_letter), message,QMessageBox.Yes| QMessageBox.No )
                 if reply == QMessageBox.Yes:
                     # User stops trials
                     err_msg = 'trial stalled {} minutes, user stopped trials. ANewTrial:{},Start:{},finish_Timer:{}'

--- a/src/update_scripts/check_github_status.bat
+++ b/src/update_scripts/check_github_status.bat
@@ -1,5 +1,5 @@
-set "logfile=C:\Users\svc_aind_behavior\Documents\foraging_gui_logs\github_log.txt"
-set "repo=C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task"
+set "logfile=C:\Users\%USERNAME%\Documents\foraging_gui_logs\github_log.txt"
+set "repo=C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task"
 cd %repo%
 echo --------------------------- >>%logfile%
 echo %date% %time% >>%logfile%

--- a/src/update_scripts/update_from_github_to_main.bat
+++ b/src/update_scripts/update_from_github_to_main.bat
@@ -1,5 +1,5 @@
-set "logfile=C:\Users\svc_aind_behavior\Documents\foraging_gui_logs\github_log.txt"
-set "repo=C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task"
+set "logfile=C:\Users\%USERNAME%\Documents\foraging_gui_logs\github_log.txt"
+set "repo=C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task"
 set "branch=main"
 cd %repo%
 echo --------------------------- >>%logfile%

--- a/src/update_scripts/update_from_github_to_production_testing.bat
+++ b/src/update_scripts/update_from_github_to_production_testing.bat
@@ -1,5 +1,5 @@
-set "logfile=C:\Users\svc_aind_behavior\Documents\foraging_gui_logs\github_log.txt"
-set "repo=C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task"
+set "logfile=C:\Users\%USERNAME%\Documents\foraging_gui_logs\github_log.txt"
+set "repo=C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task"
 set "branch=production_testing"
 cd %repo%
 echo --------------------------- >>%logfile%


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- I changed the desktop shortcuts, and update scripts to use %USERNAME% instead of svc_aind_behavior, so they will work automatically on ephys computers. I did not alter the path in the ForagingSettings.json template file, since that path gets evaluated by python, not windows. 
- Changed the titles of all user prompt windows to be "Box <box>, <previous title>" so its always clear what box the alert is referring to. 

### What issues or discussions does this update address?
- resolves #220 
- resolves #217 

### Describe the expected change in behavior from the perspective of the experimenter
- When configuring the computers, the desktop shortcuts and update scripts will work automatically regardless of what computer you are configuring. 
- All windows that alert the user are labeled with the box number

### Describe the outcome of testing this update on a rig in 447
- [x] Tested in 447




