### PR TITLE
Label camera windows

### DIFF
--- a/src/desktop_shortcuts/BoxA no console.bat
+++ b/src/desktop_shortcuts/BoxA no console.bat
@@ -1,0 +1,5 @@
+cd /d C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
+call conda activate Foraging
+start "" C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\desktop_shortcuts\start_popup.bat
+start "" pythonw Foraging.py 1
+

--- a/src/desktop_shortcuts/BoxB no console.bat
+++ b/src/desktop_shortcuts/BoxB no console.bat
@@ -1,0 +1,5 @@
+cd /d C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
+call conda activate Foraging
+start "" C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\desktop_shortcuts\start_popup.bat
+start "" pythonw Foraging.py 2
+

--- a/src/desktop_shortcuts/BoxC no console.bat
+++ b/src/desktop_shortcuts/BoxC no console.bat
@@ -1,0 +1,5 @@
+cd /d C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
+call conda activate Foraging
+start "" C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\desktop_shortcuts\start_popup.bat
+start "" pythonw Foraging.py 3
+

--- a/src/desktop_shortcuts/BoxD no console.bat
+++ b/src/desktop_shortcuts/BoxD no console.bat
@@ -1,0 +1,5 @@
+cd /d C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\foraging_gui
+call conda activate Foraging
+start "" C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\src\desktop_shortcuts\start_popup.bat
+start "" pythonw Foraging.py 4
+

--- a/src/desktop_shortcuts/CameraA.bat
+++ b/src/desktop_shortcuts/CameraA.bat
@@ -1,3 +1,11 @@
 cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
-start /min C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxA.bonsai --no-editor 
+echo off
+mode 50,10
+cls
+start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxA.bonsai --no-editor 
+powershell -window minimized -command ""
+timeout 5 > NUL
+title CAMERA A
+echo This window controls camera A
+echo Close this window if camera A is whited out
 

--- a/src/desktop_shortcuts/CameraA.bat
+++ b/src/desktop_shortcuts/CameraA.bat
@@ -1,8 +1,8 @@
-cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
+cd /d C:\Users\%USERNAME%\Documents\camera_workflows
 echo off
 mode 50,10
 cls
-start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxA.bonsai --no-editor 
+start /B C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxA.bonsai --no-editor 
 powershell -window minimized -command ""
 timeout 5 > NUL
 title CAMERA A

--- a/src/desktop_shortcuts/CameraB.bat
+++ b/src/desktop_shortcuts/CameraB.bat
@@ -1,3 +1,11 @@
 cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
-start /min C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxB.bonsai --no-editor 
+echo off
+mode 50,10
+cls
+start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxB.bonsai --no-editor 
+powershell -window minimized -command ""
+timeout 5 > NUL
+title CAMERA B
+echo This window controls camera B
+echo Close this window if camera B is whited out
 

--- a/src/desktop_shortcuts/CameraB.bat
+++ b/src/desktop_shortcuts/CameraB.bat
@@ -1,8 +1,8 @@
-cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
+cd /d C:\Users\%USERNAME%\Documents\camera_workflows
 echo off
 mode 50,10
 cls
-start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxB.bonsai --no-editor 
+start /B C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxB.bonsai --no-editor 
 powershell -window minimized -command ""
 timeout 5 > NUL
 title CAMERA B

--- a/src/desktop_shortcuts/CameraC.bat
+++ b/src/desktop_shortcuts/CameraC.bat
@@ -1,8 +1,8 @@
-cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
+cd /d C:\Users\%USERNAME%\Documents\camera_workflows
 echo off
 mode 50,10
 cls
-start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxC.bonsai --no-editor 
+start /B C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxC.bonsai --no-editor 
 powershell -window minimized -command ""
 timeout 5 > NUL
 title CAMERA C

--- a/src/desktop_shortcuts/CameraC.bat
+++ b/src/desktop_shortcuts/CameraC.bat
@@ -1,3 +1,11 @@
 cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
-start /min C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxC.bonsai --no-editor 
+echo off
+mode 50,10
+cls
+start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxC.bonsai --no-editor 
+powershell -window minimized -command ""
+timeout 5 > NUL
+title CAMERA C
+echo This window controls camera C
+echo Close this window if camera C is whited out
 

--- a/src/desktop_shortcuts/CameraD.bat
+++ b/src/desktop_shortcuts/CameraD.bat
@@ -1,8 +1,8 @@
-cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
+cd /d C:\Users\%USERNAME%\Documents\camera_workflows
 echo off
 mode 50,10
 cls
-start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxD.bonsai --no-editor 
+start /B C:\Users\%USERNAME%\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxD.bonsai --no-editor 
 powershell -window minimized -command ""
 timeout 5 > NUL
 title CAMERA D

--- a/src/desktop_shortcuts/CameraD.bat
+++ b/src/desktop_shortcuts/CameraD.bat
@@ -1,3 +1,11 @@
 cd /d C:\Users\svc_aind_behavior\Documents\camera_workflows
-start /min C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxD.bonsai --no-editor 
+echo off
+mode 50,10
+cls
+start /B C:\Users\svc_aind_behavior\Documents\GitHub\dynamic-foraging-task\bonsai\bonsai Camera_boxD.bonsai --no-editor 
+powershell -window minimized -command ""
+timeout 5 > NUL
+title CAMERA D
+echo This window controls camera D
+echo Close this window if camera D is whited out
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Labels the title, and displays text in the black console window produced by the Camera workflows. This enables the RAs to easily figure out which window to close. 
- Adds back the desktop shortcuts for opening the GUI with the bonsai IDE, but no console. I figure its worth just keeping them in the repo even if we move to the GUI + minimized console (my preference, tbd on the RA feedback)

### What issues or discussions does this update address?
- addresses https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/239

### Describe the expected change in behavior from the perspective of the experimenter
The camera workflow will look like this:
![Camera_updates](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/3b66dcb3-8d74-409c-9bc3-09911b0af63e)


### Describe the outcome of testing this update on a rig in 447
- [x] tested in 447
- [x] manually updated links in 447
- [x] Enabled powershell execution in 447, and added a note on the wiki for computer configuration about how to do this




