### PR TITLE
[skip email] Move curriculum manager folder

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2009,7 +2009,8 @@ class AutoTrainDialog(QDialog):
                 bucket='aind-behavior-data',
                 root='foraging_auto_training/saved_curriculums/'
             ),
-            saved_curriculums_local=self.MainWindow.default_saveFolder + '/curriculum_manager/',
+            # saved to tmp folder under user's home directory
+            saved_curriculums_local=os.path.expanduser('~/.aind_auto_train/curriculum_manager/')
         )
 
     def _show_available_curriculums(self):


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Move the tmp folder for caching curriculums from `default_saveFolder` to `~/.aind_auto_train/curriculum_manager/`

### What issues or discussions does this update address?
- resolves #219   @kenta

### Describe the expected change in behavior from the perspective of the experimenter
None.

### Describe the outcome of testing this update on a rig in 447
- [x] tested on my PC
- [ ] The previous `curriculum_manager` folder in `default_saveFolder` can now be deleted.



