### PR TITLE
moving red color to default warning color

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -686,7 +686,7 @@ class Window(QMainWindow):
             logging.info('Bonsai started successfully')
             self.InitializeBonsaiSuccessfully=1
             self.WarningLabel.setText('')
-            self.WarningLabel.setStyleSheet("color: red;")
+            self.WarningLabel.setStyleSheet(self.default_warning_color)
             return
 
         # Start Bonsai
@@ -711,7 +711,7 @@ class Window(QMainWindow):
                 logging.info('Bonsai started successfully')
                 if self.WarningLabel.text() == 'Lost bonsai connection':
                     self.WarningLabel.setText('')
-                    self.WarningLabel.setStyleSheet("color: red;")
+                    self.WarningLabel.setStyleSheet(self.default_warning_color)
                 self.InitializeBonsaiSuccessfully=1
                 subprocess.Popen('title Box{}'.format(self.box_letter),shell=True)
                 return
@@ -2332,7 +2332,7 @@ class Window(QMainWindow):
                         logging.error('trial stalled {} minutes, user force stopped trials'.format(elapsed_time))
                         self.ANewTrial=1
                         self.WarningLabel.setText('')
-                        self.WarningLabel.setStyleSheet("color: red;")
+                        self.WarningLabel.setStyleSheet(self.default_warning_color)
                         break
                     else:
                         stall_iteration+=1
@@ -2423,7 +2423,7 @@ class Window(QMainWindow):
                 if 'ConnectionAbortedError' in str(e):
                     logging.info('lost bonsai connection: restartlogging()')
                     self.WarningLabel.setText('Lost bonsai connection')
-                    self.WarningLabel.setStyleSheet("color: red;")
+                    self.WarningLabel.setStyleSheet(self.default_warning_color)
                     self.Start.setChecked(False)
                     self.Start.setStyleSheet("background-color : none")
                     self.InitializeBonsaiSuccessfully=0
@@ -2569,7 +2569,7 @@ class Window(QMainWindow):
                     if 'ConnectionAbortedError' in str(e):
                         logging.info('lost bonsai connection: InitiateATrial')
                         self.WarningLabel.setText('Lost bonsai connection')
-                        self.WarningLabel.setStyleSheet("color: red;")
+                        self.WarningLabel.setStyleSheet(self.default_warning_color)
                         self.Start.setChecked(False)
                         self.Start.setStyleSheet("background-color : none")
                         self.InitializeBonsaiSuccessfully=0
@@ -2637,7 +2637,7 @@ class Window(QMainWindow):
                     
                     # Give warning to user
                     self.WarningLabel.setText('Trials stalled, recheck bonsai connection.')
-                    self.WarningLabel.setStyleSheet("color: red;")
+                    self.WarningLabel.setStyleSheet(self.default_warning_color)
                     break
                 else:
                     # User continues, wait another stall_duration and prompt again


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- fixes a few places where the warning color was set to red, instead of the default warning color

### What issues or discussions does this update address?
- resolves #227 

### Describe the expected change in behavior from the perspective of the experimenter
All the warning text should be the red-light visible purple

### Describe the outcome of testing this update on a rig in 447
- tested




