### PR TITLE
Finished warm up

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2407,6 +2407,7 @@ class Window(QMainWindow):
             # generate a new session id
             self.WarningLabel.setText('')
             self.WarningLabel.setStyleSheet("color: gray;")
+            self.win.WarmupWarning.setText('')
             # start a new logging
             try:
                 self.Ot_log_folder=self._restartlogging()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -256,6 +256,7 @@ class Window(QMainWindow):
             self.label_118.setEnabled(True)
 
             # set warm up default parameters
+            self.Task.setCurrentIndex(self.Task.findText('Coupled Baiting'))
             self.BaseRewardSum.setText('1')
             self.RewardFamily.setText('3')
             self.RewardPairsN.setText('1')
@@ -295,6 +296,7 @@ class Window(QMainWindow):
             if attr_name.startswith('WarmupBackup_') and attr_name!='WarmupBackup_' and attr_name!='WarmupBackup_warmup':
                 parameters[attr_name.replace('WarmupBackup_','')]=getattr(self,attr_name)
         widget_dict = {w.objectName(): w for w in self.TrainingParameters.findChildren((QtWidgets.QPushButton,QtWidgets.QLineEdit,QtWidgets.QTextEdit, QtWidgets.QComboBox,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox))}
+        widget_dict['Task']=self.Task
         try:
             for key in widget_dict.keys():
                 self._set_parameters(key,widget_dict,parameters)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2407,7 +2407,7 @@ class Window(QMainWindow):
             # generate a new session id
             self.WarningLabel.setText('')
             self.WarningLabel.setStyleSheet("color: gray;")
-            self.win.WarmupWarning.setText('')
+            self.WarmupWarning.setText('')
             # start a new logging
             try:
                 self.Ot_log_folder=self._restartlogging()

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -534,7 +534,7 @@
                       <x>0</x>
                       <y>-22</y>
                       <width>178</width>
-                      <height>184</height>
+                      <height>182</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout">
@@ -621,6 +621,11 @@
                      </item>
                      <item>
                       <widget class="QLabel" name="WarmupWarning">
+                       <property name="font">
+                        <font>
+                         <pointsize>7</pointsize>
+                        </font>
+                       </property>
                        <property name="text">
                         <string/>
                        </property>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -532,9 +532,9 @@
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>0</y>
+                      <y>-22</y>
                       <width>178</width>
-                      <height>165</height>
+                      <height>184</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout">
@@ -616,6 +616,13 @@
                        </property>
                        <property name="alignment">
                         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="WarmupWarning">
+                       <property name="text">
+                        <string/>
                        </property>
                       </widget>
                      </item>
@@ -2482,7 +2489,7 @@ Double dipping:
                 <property name="geometry">
                  <rect>
                   <x>0</x>
-                  <y>-152</y>
+                  <y>0</y>
                   <width>1077</width>
                   <height>460</height>
                  </rect>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3316,6 +3316,34 @@
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
      </property>
     </widget>
+    <widget class="QLabel" name="WarmupWarning">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>40</y>
+       <width>361</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
    </widget>
    <widget class="QGroupBox" name="groupBox_2">
     <property name="geometry">
@@ -4354,6 +4382,7 @@
      <string>Streamlit!</string>
     </property>
    </widget>
+   <zorder>PhotometryB</zorder>
    <zorder>infor</zorder>
    <zorder>line</zorder>
    <zorder>Task</zorder>
@@ -4375,7 +4404,6 @@
    <zorder>Experimenter</zorder>
    <zorder>WarningLabelCamera</zorder>
    <zorder>label_61</zorder>
-   <zorder>PhtotometryB</zorder>
    <zorder>label_47</zorder>
    <zorder>baselinetime</zorder>
    <zorder>StartExcitation</zorder>

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -174,6 +174,8 @@ class GenerateTrials():
             self.win.warmup.setCurrentIndex(index)
             self.win._warmup()
             self.win.keyPressEvent()
+            self.win.NextBlock.setChecked(True)
+            self.win._NextBlock()
             self.win.WarmupWarning.setText('Warm up is turned off')
 
     def _get_warmup_state(self):

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -197,6 +197,9 @@ class GenerateTrials():
         else:
             # turn on the warm up
             warmup=1
+        # show current metrics of the warm up
+        self.win.WarmupWarning.setText('Finish trial: '+str(round(finish_trial,2))+ ' Finish ratio: '+str(round(finish_ratio,2))+'; Choice ratio bias: '+str(round(abs(choice_ratio-0.5),2)))
+        self.win.WarmupWarning.setStyleSheet(self.win.default_warning_color)
         return warmup
         
     def _CheckBaitPermitted(self):

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -179,7 +179,7 @@ class GenerateTrials():
         '''calculate the metrics related to the warm up and decide if we should turn on the warm up'''
         TP_warm_windowsize=int(self.TP_warm_windowsize)
         B_AnimalResponseHistory_window=self.B_AnimalResponseHistory[-TP_warm_windowsize:]
-        finish_trial=B_AnimalResponseHistory_window.shape[0] # the warmup is only turned on at the beginning of the session, thus the number of finished trials is equal to the number of trials with warmup on
+        finish_trial=self.B_AnimalResponseHistory.shape[0] # the warmup is only turned on at the beginning of the session, thus the number of finished trials is equal to the number of trials with warmup on
         left_choices = np.count_nonzero(B_AnimalResponseHistory_window == 0)
         right_choices = np.count_nonzero(B_AnimalResponseHistory_window == 1)
         no_responses = np.count_nonzero(B_AnimalResponseHistory_window == 2)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -174,6 +174,7 @@ class GenerateTrials():
             self.win.warmup.setCurrentIndex(index)
             self.win._warmup()
             self.win.keyPressEvent()
+            self.win.WarmupWarning.setText('Warm up is turned off')
 
     def _get_warmup_state(self):
         '''calculate the metrics related to the warm up and decide if we should turn on the warm up'''
@@ -198,7 +199,7 @@ class GenerateTrials():
             # turn on the warm up
             warmup=1
         # show current metrics of the warm up
-        self.win.WarmupWarning.setText('Finish trial: '+str(round(finish_trial,2))+ ' Finish ratio: '+str(round(finish_ratio,2))+'; Choice ratio bias: '+str(round(abs(choice_ratio-0.5),2)))
+        self.win.WarmupWarning.setText('Finish trial: '+str(round(finish_trial,2))+ '; Finish ratio: '+str(round(finish_ratio,2))+'; Choice ratio bias: '+str(round(abs(choice_ratio-0.5),2)))
         self.win.WarmupWarning.setStyleSheet(self.win.default_warning_color)
         return warmup
         


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
1) Added warning to show metrics and state related to warm up. 
2) Fixed a bug related to the finish length. 

### What issues or discussions does this update address?
Resolves: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/213#issuecomment-1921951325
Resolves: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/177#issuecomment-1917698175

### Describe the expected change in behavior from the perspective of the experimenter
If the warmup is turned on (typically for the first session of a mouse), the session starts with previous Coupled-Baiting Stage 1.1

![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/946d06f6-1b6e-4f6c-a4f0-93c39cda419c)

After warmup termination criteria are met, goes back to normal training, i.e., parameters before warmup
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/73d2a644-9500-485f-906a-ce4bf63ce4bf)

 


### Describe the outcome of testing this update on a rig in 447
Tested on my own computer. 




