### PR TITLE
Adding a global exception hook and alerting users

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -146,7 +146,6 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
-        raise Exception('testing')
 
     def connectSignalsSlots(self):
         '''Define callbacks'''
@@ -2374,6 +2373,7 @@ class Window(QMainWindow):
         self.Experimenter.setEnabled(enable)
 
     def _Start(self):
+        raise Exception('testing')
         '''start trial loop'''
         # empty post weight
         self.WeightAfter.setText('')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2903,7 +2903,7 @@ def show_exception_box(log_msg):
         # Make a QWindow, wait for user response
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Box {}, Error'.format(box))
-        msg = '<span style="color:purple;font-weight:bold">An uncontrolled error occurred. If the error is related to newscale, you can try to continue. Otherwise, save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
+        msg = '<span style="color:purple;font-weight:bold">An uncontrolled error occurred. If the error is related to newscale or USBXpress, you can try to continue. Otherwise, save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
         errorbox.setText(msg)
         errorbox.exec_()
     else:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2903,7 +2903,7 @@ def show_exception_box(log_msg):
         # Make a QWindow, wait for user response
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Box {}, Error'.format(box))
-        msg = '<span style="color:purple;font-weight:bold">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
+        msg = '<span style="color:purple;font-weight:bold">An uncontrolled error occurred. If the error is related to newscale, you can try to continue. Otherwise, save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
         errorbox.setText(msg)
         errorbox.exec_()
     else:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2954,6 +2954,7 @@ if __name__ == "__main__":
     # Start Q, and Gui Window
     logging.info('Starting QApplication and Window')
     app = QApplication(sys.argv)
+    qt_exception_hook = UncaughtHook()
     win = Window(box_number=box_number,start_bonsai_ide=start_bonsai_ide)
     win.show()
     # Run your application's event loop and stop after closing all windows

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2903,7 +2903,7 @@ def show_exception_box(log_msg):
     if QtWidgets.QApplication.instance() is not None:
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Error')
-        errorbox.setText('An uncontrolled error occurred: \n{}\n Save any data and restart the GUI'.format(log_msg))
+        errorbox.setText('<span style="color:purple">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg))
         errorbox.exec_()
     else:
         logging.error('could not launch exception box')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2897,7 +2897,7 @@ def show_exception_box(log_msg):
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Box {}, Error'.format(box))
         msg = '<span style="color:purple;font-weight:bold">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
-        msg = msg.replace('call last):', 'call last):<br>')
+        #msg = msg.replace('call last):', 'call last):<br>')
         errorbox.setText(msg)
         errorbox.exec_()
     else:
@@ -2919,10 +2919,11 @@ class UncaughtHook(QtCore.QObject):
         self._exception_caught.connect(show_exception_box)
 
     def exception_hook(self, exc_type, exc_value, exc_traceback):
-        tb = ",,".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+        tb = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
         print('Encountered a fatal error: ')
         print(tb)
         logging.error('FATAL ERROR: \n{}'.format(tb))
+        tb = "<br>".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
         self._exception_caught.emit(self.box+tb)
 
 if __name__ == "__main__":

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2896,7 +2896,7 @@ def show_exception_box(log_msg):
 
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Box {}, Error'.format(box))
-        msg = '<span style="color:purple;font-weight:bold;size=20">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
+        msg = '<span style="color:purple;font-weight:bold">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
         msg = msg.replace('call last):', 'call last):<br>')
         errorbox.setText(msg)
         errorbox.exec_()
@@ -2919,7 +2919,7 @@ class UncaughtHook(QtCore.QObject):
         self._exception_caught.connect(show_exception_box)
 
     def exception_hook(self, exc_type, exc_value, exc_traceback):
-        tb = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+        tb = ",,".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
         print('Encountered a fatal error: ')
         print(tb)
         logging.error('FATAL ERROR: \n{}'.format(tb))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2906,7 +2906,9 @@ def show_exception_box(log_msg):
 
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Box {}, Error'.format(box))
-        errorbox.setText('<span style="color:purple;font-weight:bold">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg))
+        msg = '<span style="color:purple;font-weight:bold;size=10">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
+        msg = msg.replace('call last):', 'call last):<br>')
+        errorbox.setText(msg)
         errorbox.exec_()
     else:
         logging.error('could not launch exception box')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2902,7 +2902,8 @@ def excepthook(exc_type, exc_value, exc_tb):
 def show_exception_box(log_msg):
     if QtWidgets.QApplication.instance() is not None:
         errorbox = QtWidgets.QMessageBox()
-        errorbox.setText('Encountered a fatal error, the GUI will now close: \n{}'.format(log_msg))
+        errorbox.setWindowTitle('Error')
+        errorbox.setText('An uncontrolled error occurred: \n{}\n Save any data and restart the GUI'.format(log_msg))
         errorbox.exec_()
     else:
         logging.error('could not launch exception box')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -146,6 +146,7 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
+        raise Exception('testing')
 
     def connectSignalsSlots(self):
         '''Define callbacks'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1715,7 +1715,6 @@ class Window(QMainWindow):
         )
    
     def _Save(self,ForceSave=0,SaveContinue=0):
-        raise Exception('just trying something with a longer message')
         logging.info('Saving current session, ForceSave={},SaveContinue={}'.format(ForceSave,SaveContinue))
         if ForceSave==0:
             self._StopCurrentSession() # stop the current session first
@@ -2374,7 +2373,6 @@ class Window(QMainWindow):
         self.Experimenter.setEnabled(enable)
 
     def _Start(self):
-        raise Exception('testing')
         '''start trial loop'''
         # empty post weight
         self.WeightAfter.setText('')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2899,16 +2899,13 @@ def excepthook(exc_type, exc_value, exc_tb):
     logging.error('FATAL ERROR: \n{}'.format(tb))
     QtWidgets.QApplication.quit()
 
-def show_exception_box(box_number, log_msg):
+def show_exception_box(log_msg):
     if QtWidgets.QApplication.instance() is not None:
-        mapper = {
-            1:'A',
-            2:'B',
-            3:'C',
-            4:'D'
-            }
+        box = log_msg[0]
+        log_msg = log_msg[1:]
+
         errorbox = QtWidgets.QMessageBox()
-        errorbox.setWindowTitle('Box {}, Error'.format(mapper[box_number]))
+        errorbox.setWindowTitle('Box {}, Error'.format(box))
         errorbox.setText('<span style="color:purple;font-weight:bold">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg))
         errorbox.exec_()
     else:
@@ -2917,9 +2914,15 @@ def show_exception_box(box_number, log_msg):
 class UncaughtHook(QtCore.QObject):
     _exception_caught = QtCore.Signal(object)
     
-    def __init__(self, box_number, *args, **kwargs):
+    def __init__(self,box_number, *args, **kwargs):
         super(UncaughtHook, self).__init__(*args, **kwargs)
-        self.box_number = box_number 
+        mapper = {
+            1:'A',
+            2:'B',
+            3:'C',
+            4:'D'
+            }
+        self.box = mapper[box_number]
         sys.excepthook = self.exception_hook
         self._exception_caught.connect(show_exception_box)
 
@@ -2928,7 +2931,7 @@ class UncaughtHook(QtCore.QObject):
         print('Encountered a fatal error: ')
         print(tb)
         logging.error('FATAL ERROR: \n{}'.format(tb))
-        self._exception_caught.emit(box_number, tb)
+        self._exception_caught.emit(self.box+tb)
 
 if __name__ == "__main__":
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2917,7 +2917,7 @@ class UncaughtHook(QtCore.QObject):
         self._exception_caught.connect(show_exception_box)
 
     def exception_hook(self, exc_type, exc_value, exc_traceback):
-        tb = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+        tb = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
         print('Encountered a fatal error: ')
         print(tb)
         logging.error('FATAL ERROR: \n{}'.format(tb))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1715,6 +1715,7 @@ class Window(QMainWindow):
         )
    
     def _Save(self,ForceSave=0,SaveContinue=0):
+        raise Exception('just trying something with a longer message')
         logging.info('Saving current session, ForceSave={},SaveContinue={}'.format(ForceSave,SaveContinue))
         if ForceSave==0:
             self._StopCurrentSession() # stop the current session first
@@ -2888,17 +2889,6 @@ def log_git_hash():
     except Exception as e:
         logging.error('Could not log git branch and hash: {}'.format(str(e)))
 
-def excepthook(exc_type, exc_value, exc_tb):
-    '''
-        excepthook will be called when the GUI encounters an uncaught exception
-        We will log the error in the logfile, print the error to the console, then exit
-    '''
-    tb = ", ".join(traceback.format_exception(exc_type, exc_value, exc_tb))
-    print('Encountered a fatal error: ')
-    print(tb)
-    logging.error('FATAL ERROR: \n{}'.format(tb))
-    QtWidgets.QApplication.quit()
-
 def show_exception_box(log_msg):
     if QtWidgets.QApplication.instance() is not None:
         box = log_msg[0]
@@ -2906,7 +2896,7 @@ def show_exception_box(log_msg):
 
         errorbox = QtWidgets.QMessageBox()
         errorbox.setWindowTitle('Box {}, Error'.format(box))
-        msg = '<span style="color:purple;font-weight:bold;size=10">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
+        msg = '<span style="color:purple;font-weight:bold;size=20">An uncontrolled error occurred. Save any data and restart the GUI. </span> <br><br>{}'.format(log_msg)
         msg = msg.replace('call last):', 'call last):<br>')
         errorbox.setText(msg)
         errorbox.exec_()
@@ -2960,16 +2950,14 @@ if __name__ == "__main__":
     QApplication.setAttribute(Qt.AA_Use96Dpi,False)
     QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
    
-    ## Set excepthook, so we can log uncaught exceptions
-    #sys.excepthook=excepthook
-
     # Start Q, and Gui Window
     logging.info('Starting QApplication and Window')
     app = QApplication(sys.argv)
     qt_exception_hook = UncaughtHook(box_number)
     win = Window(box_number=box_number,start_bonsai_ide=start_bonsai_ide)
     win.show()
-    # Run your application's event loop and stop after closing all windows
+   
+     # Run your application's event loop and stop after closing all windows
     sys.exit(app.exec())
 
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Right now when an uncontrolled (fatal) error happens the information gets added to the log, and the GUI stalls. The user may be unaware that anything has happened. 
- I have added an exception hook that will generate an alert to the user. It *should* allow the user to save the data, and then close the GUI. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/199


### Describe the expected change in behavior from the perspective of the experimenter
When an uncontrolled error happens, the user will see this alert. They should save the data and restart the GUI. 
<img width="294" alt="MicrosoftTeams-image009af78297012472ac46740d91e297bc09138adeea00f0edd131e43fd380ed6c" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/c485dfe8-3c84-4ede-b49c-8284f3539207">

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




