### PR TITLE
Streamlined newscale control logic

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1153,10 +1153,10 @@ def is_file_in_use(file_path):
         except OSError as e:
             return True
 
-class ManipulatorDialog(QDialog):
-    def __init__(self, MainWindow, parent=None):
-        super().__init__(parent)
-        uic.loadUi('Manipulator.ui', self)
+#class ManipulatorDialog(QDialog):
+#    def __init__(self, MainWindow, parent=None):
+#        super().__init__(parent)
+#        uic.loadUi('Manipulator.ui', self)
 
 #class MotorStageDialog(QDialog):
 #    def __init__(self, MainWindow, parent=None):

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1158,12 +1158,12 @@ class ManipulatorDialog(QDialog):
         super().__init__(parent)
         uic.loadUi('Manipulator.ui', self)
 
-class MotorStageDialog(QDialog):
-    def __init__(self, MainWindow, parent=None):
-        super().__init__(parent)
-        uic.loadUi('MotorStage.ui', self)
-        
-        self.MainWindow=MainWindow
+#class MotorStageDialog(QDialog):
+#    def __init__(self, MainWindow, parent=None):
+#        super().__init__(parent)
+#        uic.loadUi('MotorStage.ui', self)
+#        
+#        self.MainWindow=MainWindow
 
 class LaserCalibrationDialog(QDialog):
     def __init__(self, MainWindow, parent=None):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -126,7 +126,7 @@ class Window(QMainWindow):
         self._WaterVolumnManage2()
         self._LickSta()
         self._InitializeMotorStage()
-        self._StageSerialNum()
+        #self._StageSerialNum()
         self._warmup()
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
@@ -412,38 +412,41 @@ class Window(QMainWindow):
         self.PositionY.setText(str(NewPositions[1]))
         self.PositionZ.setText(str(NewPositions[2]))
 
-    def _StageSerialNum(self):
-        '''connect to a stage'''
-        # scan stages
-        try:
-            self.instances = NewScaleSerialY.get_instances()
-        except Exception as e:
-            logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
-            return
-        else:
-            logging.info('Found newscale stage instances')
+    #def _StageSerialNum(self):
+    #    '''connect to a stage'''
+    #    # scan stages
+    #    #try:
+    #    #    self.instances = NewScaleSerialY.get_instances()
+    #    #except Exception as e:
+    #    #    logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
+    #    #    return
+    #    #else:
+    #    #    logging.info('Found newscale stage instances')
 
-        if hasattr(self,'current_stage'):
-            curent_stage_name=self.current_stage.name
-        else:
-            curent_stage_name=''
-        # connect to one stage
-        for instance in self.instances:
-            try:
-                instance.io.close()
-            except Exception as e:
-                pass
-            try:
-                if (instance.sn==self.StageSerialNum.currentText())&\
-                    (curent_stage_name!=instance.sn):
-                    self._connect_stage(instance)
-            except Exception as e:
-                logging.error(str(e))
+    #    if hasattr(self,'current_stage'):
+    #        curent_stage_name=self.current_stage.name
+    #    else:
+    #        curent_stage_name=''
+    #    # connect to one stage
+    #    for instance in self.instances:
+    #        try:
+    #            instance.io.close()
+    #        except Exception as e:
+    #            pass
+    #        try:
+    #            if (instance.sn==self.StageSerialNum.currentText())&\
+    #                (curent_stage_name!=instance.sn):
+    #                self._connect_stage(instance)
+    #        except Exception as e:
+    #            logging.error(str(e))
 
     def _InitializeMotorStage(self):
         '''To initialize motor stage'''
+    
+        # find available newscale stages
         self._scan_for_usb_stages()
-        # use the default newscale stage
+
+        # use the newscale stage in the settings file
         try:
             self.newscale_serial_num=eval('self.newscale_serial_num_box'+str(self.box_number))
             if self.newscale_serial_num!='':
@@ -454,11 +457,34 @@ class Window(QMainWindow):
                     self.Warning_Newscale.setText('Newscale not found!')
                     self.Warning_Newscale.setStyleSheet(self.default_warning_color)
                     logging.error('Could not find newscale with serial number: {}'.format(self.newscale_serial_num))
+                    return
+            else:
+                logging.info('No newscale serial number in settings file')
+                return
         except Exception as e:
             logging.error(str(e))
 
+        # connect to the Stage
+        if hasattr(self,'current_stage'):
+            current_stage_name=self.current_stage.name
+        else:
+            current_stage_name=''
+        for instance in self.instances:
+            try:
+                instance.io.close()
+            except Exception as e:
+                pass
+            try:
+                if (instance.sn==self.StageSerialNum.currentText())&\
+                    (current_stage_name!=instance.sn):
+                    self._connect_stage(instance)
+            except Exception as e:
+                logging.error(str(e))
+
+
     def _scan_for_usb_stages(self):
         '''Scan available stages'''
+        logging.info('Scanning for newscale stages')
         try:
             self.instances = NewScaleSerialY.get_instances()
         except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -124,6 +124,7 @@ class Window(QMainWindow):
         self._WaterVolumnManage2()
         self._LickSta()
         self._InitializeMotorStage()
+        self._GetPositions()
         self._warmup()
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
@@ -408,7 +409,12 @@ class Window(QMainWindow):
 
     def _InitializeMotorStage(self):
         '''To initialize motor stage'''
-    
+        ## TODO
+        # Remove Manipulator, and MotorStage from UI files
+        # Remove "Stage" from UI file in Motorstage section
+        # Check this still works on a computer with multiple stages  
+        # Remove all notion of "self.StageSerialNum" 
+ 
         # find available newscale stages
         logging.info('Scanning for newscale stages')
         try:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -318,24 +318,32 @@ class Window(QMainWindow):
         self.keyPressEvent()
 
     def _CheckStageConnection(self):
+        print('here1')
         if hasattr(self,'current_stage'):
             try:
+                print('here2')
                 self.current_stage.get_position()
+                print('here3')
             except Exception as e:
+                print('here4')
                 logging.error('could not connect to newscale stage')
                 self.Warning_Newscale.setText('Lost newscale stage connection')
                 self.Warning_Newscale.setStyleSheet(self.default_warning_color)
                 return False
             else:
+                print('here5')
                 self.Warning_Newscale.setText('')
                 self.Warning_Newscale.setStyleSheet(self.default_warning_color)
                 return True 
         else:
+            print('here6')
             return False
 
     def _GetPositions(self):
         '''get the current position of the stage'''
+        print('here7')
         if hasattr(self, 'current_stage') & self._CheckStageConnection():
+            print('here8')
             logging.info('Grabbing current stage position')
             current_stage=self.current_stage
             current_position=current_stage.get_position()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -445,9 +445,10 @@ class Window(QMainWindow):
 
         # See if the serial num from settings is in the instances we found
         stage_index = 0
-        stage_names = [str(instance.sn) for instance in self.instances]
+        stage_names = np.array([str(instance.sn) for instance in self.instances])
         print(stage_names)
         index = np.where(stage_names == str(self.newscale_serial_num))[0]
+        print(index)
         if len(index) == 0:
             self.Warning_Newscale.setText('Newscale not found!')
             self.Warning_Newscale.setStyleSheet(self.default_warning_color)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -324,7 +324,7 @@ class Window(QMainWindow):
                 print('here2')
                 self.current_stage.get_position()
                 print('here3')
-            except Exception as e:
+            except:
                 print('here4')
                 logging.error('could not connect to newscale stage')
                 self.Warning_Newscale.setText('Lost newscale stage connection')
@@ -3054,7 +3054,7 @@ if __name__ == "__main__":
     QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
    
     # Set excepthook, so we can log uncaught exceptions
-    #sys.excepthook=excepthook ##DEBUGGING
+    sys.excepthook=excepthook
 
     # Start Q, and Gui Window
     logging.info('Starting QApplication and Window')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -317,22 +317,6 @@ class Window(QMainWindow):
         # press enter to confirm parameters change
         self.keyPressEvent()
 
-    def _CheckStageConnection(self):
-        if hasattr(self,'current_stage'):
-            try:
-                self.current_stage.get_position()
-            except:
-                logging.error('could not connect to newscale stage')
-                self.Warning_Newscale.setText('Lost newscale stage connection')
-                self.Warning_Newscale.setStyleSheet(self.default_warning_color)
-                return False
-            else:
-                self.Warning_Newscale.setText('')
-                self.Warning_Newscale.setStyleSheet(self.default_warning_color)
-                return True 
-        else:
-            return False
-
     def _GetPositions(self):
         '''get the current position of the stage'''
         if hasattr(self, 'current_stage'):
@@ -493,20 +477,6 @@ class Window(QMainWindow):
         '''
         self.Warning_Newscale.setText('Newscale stage not connected')
         self.Warning_Newscale.setStyleSheet(self.default_warning_color)
-
-    def _disconnect_stage(self, instance):
-        '''
-            disconnects from the newscale stage instace.
-            python-newscale will print an "SI_INVALID_HANDLE" error if the instance
-            does not have an open connection
-        '''
-        try:
-            instance.io.close()
-        except Exception as e:
-            logging.info('Could not disconnect newscale stage instance, this is probably fine')
-            pass
-        else:
-            logging.info('disconnected newscale stage instance')
      
     def _connect_stage(self,instance):
         '''connect to a stage'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -462,7 +462,7 @@ class Window(QMainWindow):
    
         # Setup connection
         newscale_stage_instance = self.instances[stage_index]
-        self._disconnect_stage(newscale_stage_instance)  
+        #self._disconnect_stage(newscale_stage_instance)  
         self._connect_stage(newscale_stage_instance)
 
     def _no_stage(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -414,6 +414,7 @@ class Window(QMainWindow):
         # Remove "Stage" from UI file in Motorstage section
         # Check this still works on a computer with multiple stages  
         # Remove all notion of "self.StageSerialNum" 
+            # Ask XX about whether we need this functionality
  
         # find available newscale stages
         logging.info('Scanning for newscale stages')
@@ -455,30 +456,31 @@ class Window(QMainWindow):
             logging.error(str(e))
             return
 
+        # Setup connection
         newscale_stage_instance = self.instances[stage_index]
-        # Double check a connection isnt already open
+        self._disconnect_stage(newscale_stage_instance)  
+        self._connect_stage(newscale_stage_instance)
+
+    def _disconnect_stage(self, instance):
         try:
-            newscale_stage_instance.io.close()
+            instance.io.close()
         except Exception as e:
             logging.info('Could not disconnect newscale stage instance, this is probably fine')
             pass
         else:
             logging.info('disconnected newscale stage instance')
-        
-        # connect to the Stage
-        try:
-            self._connect_stage(newscale_stage_instance)
-        except Exception as e:
-            logging.error(str(e))
-        else:
-            logging.info('Successfully connected to newscale stage')       
      
     def _connect_stage(self,instance):
         '''connect to a stage'''
-        instance.io.open()
-        instance.set_timeout(1)
-        instance.set_baudrate(250000)
-        self.current_stage=Stage(serial=instance)
+        try:       
+            instance.io.open()
+            instance.set_timeout(1)
+            instance.set_baudrate(250000)
+            self.current_stage=Stage(serial=instance)
+        except Exception as e:
+            logging.error(str(e))
+        else:
+            logging.info('Successfully connected to newscale stage: {}'.format(instance.sn))       
 
     def _ConnectBonsai(self):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -415,6 +415,9 @@ class Window(QMainWindow):
         # Check this still works on a computer with multiple stages  
         # Remove all notion of "self.StageSerialNum" 
             # Ask XX about whether we need this functionality
+        # Make some updates to the python-newscale package, determine if issues are from NEWSCALE, or python-newscale
+            # At least change prints to logging
+            # Figure out why we are on a branch!?!?
  
         # find available newscale stages
         logging.info('Scanning for newscale stages')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -408,7 +408,14 @@ class Window(QMainWindow):
         self.PositionZ.setText(str(NewPositions[2]))
 
     def _InitializeMotorStage(self):
-        '''To initialize motor stage'''
+        '''
+            Scans for available newscale stages. Attempts to connect to the newscale stage
+            defined by the serial number in the settings file. If it cannot connect for any reason
+            it displays a warning in the motor stage box, and returns. 
+            
+            Failure modes include: an error in scanning for stages, no stages found, no stage defined
+            in the settings file, the defined stage not found, an error in connecting to the stage 
+        '''
         ## TODO
         # Remove Manipulator, and MotorStage from UI files
         # Remove "Stage" from UI file in Motorstage section
@@ -462,14 +469,21 @@ class Window(QMainWindow):
    
         # Setup connection
         newscale_stage_instance = self.instances[stage_index]
-        #self._disconnect_stage(newscale_stage_instance)  
         self._connect_stage(newscale_stage_instance)
 
     def _no_stage(self):
+        '''
+            Display a warrning message that the newscale stage is not connected
+        '''
         self.Warning_Newscale.setText('Newscale stage not connected')
         self.Warning_Newscale.setStyleSheet(self.default_warning_color)
 
     def _disconnect_stage(self, instance):
+        '''
+            disconnects from the newscale stage instace.
+            python-newscale will print an "SI_INVALID_HANDLE" error if the instance
+            does not have an open connection
+        '''
         try:
             instance.io.close()
         except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2976,7 +2976,7 @@ def start_gui_log_file(box_number):
     print(logging_filename)
     logging.basicConfig(
         format=log_format,
-        level=logging.INFO,
+        level=logging.DEBUG,#logging.INFO,
         datefmt=log_datefmt,
         handlers=[
             logging.FileHandler(logging_filename),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -435,7 +435,7 @@ class Window(QMainWindow):
         logging.info('found {} newscale stages'.format(len(self.instances)))
 
         # Get the serial num from settings
-        if not hasattr(self, 'newscale_serial_num_box'):
+        if not hasattr(self, 'newscale_serial_num_box{}'.format(self.box_number)):
             logging.error('Cannot determine newscale serial num')
             return
         self.newscale_serial_num=eval('self.newscale_serial_num_box'+str(self.box_number))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -446,6 +446,7 @@ class Window(QMainWindow):
         # See if the serial num from settings is in the instances we found
         stage_index = 0
         stage_names = [str(instance.sn) for instance in self.instances]
+        print(stage_names)
         index = np.where(stage_names == str(self.newscale_serial_num))[0]
         if len(index) == 0:
             self.Warning_Newscale.setText('Newscale not found!')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -23,7 +23,7 @@ import webbrowser
 import foraging_gui.rigcontrol as rigcontrol
 from foraging_gui.Visualization import PlotV,PlotLickDistribution,PlotTimeDistribution
 from foraging_gui.Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
-from foraging_gui.Dialogs import ManipulatorDialog,MotorStageDialog,LaserCalibrationDialog
+from foraging_gui.Dialogs import ManipulatorDialog,LaserCalibrationDialog
 from foraging_gui.Dialogs import LickStaDialog,TimeDistributionDialog
 from foraging_gui.Dialogs import AutoTrainDialog
 from foraging_gui.MyFunctions import GenerateTrials, Worker,NewScaleSerialY
@@ -102,7 +102,7 @@ class Window(QMainWindow):
         self.WaterCalibration=0
         self.LaserCalibration=0
         self.Camera=0
-        self.MotorStage=0
+        #self.MotorStage=0
         self.Manipulator=0
         self.NewTrialRewardOrder=0
         self.LickSta=0
@@ -168,7 +168,7 @@ class Window(QMainWindow):
         self.action_Camera.triggered.connect(self._Camera)
         self.action_Optogenetics.triggered.connect(self._Optogenetics)
         self.action_Manipulator.triggered.connect(self._Manipulator)
-        self.action_MotorStage.triggered.connect(self._MotorStage)
+        #self.action_MotorStage.triggered.connect(self._MotorStage)
         self.actionLicks_sta.triggered.connect(self._LickSta)
         self.actionTime_distribution.triggered.connect(self._TimeDistribution)
         self.action_Calibration.triggered.connect(self._WaterCalibration)
@@ -180,7 +180,6 @@ class Window(QMainWindow):
         self.SaveContinue.triggered.connect(self._SaveContinue)
         self.action_Exit.triggered.connect(self._Exit)
         self.action_New.triggered.connect(self._New)
-        #self.actionScan_stages.triggered.connect(self._scan_for_usb_stages)
         self.action_Clear.triggered.connect(self._Clear)
         self.action_Start.triggered.connect(self.Start.click)
         self.action_NewSession.triggered.connect(self.NewSession.click)
@@ -1655,14 +1654,14 @@ class Window(QMainWindow):
         else:
             self.LaserCalibration_dialog.hide()
 
-    def _MotorStage(self):
-        if self.MotorStage==0:
-            self.MotorStage_dialog = MotorStageDialog(MainWindow=self)
-            self.MotorStage=1
-        if self.action_MotorStage.isChecked()==True:
-            self.MotorStage_dialog.show()
-        else:
-            self.MotorStage_dialog.hide()
+    #def _MotorStage(self):
+    #    if self.MotorStage==0:
+    #        self.MotorStage_dialog = MotorStageDialog(MainWindow=self)
+    #        self.MotorStage=1
+    #    if self.action_MotorStage.isChecked()==True:
+    #        self.MotorStage_dialog.show()
+    #    else:
+    #        self.MotorStage_dialog.hide()
 
     def _TimeDistribution(self):
         '''Plot simulated ITI/delay/block distribution'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -406,7 +406,7 @@ class Window(QMainWindow):
             logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
             return
         else:
-            logging.info('Foound newscale stage instances')
+            logging.info('Found newscale stage instances')
 
         if hasattr(self,'current_stage'):
             curent_stage_name=self.current_stage.name
@@ -436,8 +436,9 @@ class Window(QMainWindow):
                 if index != -1:
                     self.StageSerialNum.setCurrentIndex(index)
                 else:
-                    self.Warning_Newscale.setText('Default Newscale not found!')
+                    self.Warning_Newscale.setText('Newscale not found!')
                     self.Warning_Newscale.setStyleSheet(self.default_warning_color)
+                    logging.error('Could not find newscale with serial number: {}'.format(self.newscale_serial_num))
         except Exception as e:
             logging.error(str(e))
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -310,21 +310,29 @@ class Window(QMainWindow):
     def _GetPositions(self):
         '''get the current position of the stage'''
         if hasattr(self, 'current_stage'):
+            logging.info('Grabbing current stage position')
             current_stage=self.current_stage
             current_position=current_stage.get_position()
             self._UpdatePosition(current_position,(0,0,0))
+        else:
+            logging.info('GetPositions pressed, but no current stage')
                                 
     def _StageStop(self):
         '''Halt the stage'''
         if hasattr(self, 'current_stage'):
+            logging.info('Stopping stage movement')
             current_stage=self.current_stage
             current_stage.halt()
+        else:
+            logging.info('StageStop pressed, but no current stage')
 
     def _Move(self,axis,step):
         '''Move stage'''
         try:
             if not hasattr(self, 'current_stage'):
+                logging.info('Move Stage pressed, but no current stage')
                 return
+            logging.info('Moving stage')
             self.StageStop.click
             current_stage=self.current_stage
             current_position=current_stage.get_position()
@@ -397,6 +405,8 @@ class Window(QMainWindow):
         except Exception as e:
             logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
             return
+        else:
+            logging.info('Foound newscale stage instances')
 
         if hasattr(self,'current_stage'):
             curent_stage_name=self.current_stage.name

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3054,7 +3054,7 @@ if __name__ == "__main__":
     QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
    
     # Set excepthook, so we can log uncaught exceptions
-    sys.excepthook=excepthook
+    #sys.excepthook=excepthook ##DEBUGGING
 
     # Start Q, and Gui Window
     logging.info('Starting QApplication and Window')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -318,32 +318,24 @@ class Window(QMainWindow):
         self.keyPressEvent()
 
     def _CheckStageConnection(self):
-        print('here1')
         if hasattr(self,'current_stage'):
             try:
-                print('here2')
                 self.current_stage.get_position()
-                print('here3')
             except:
-                print('here4')
                 logging.error('could not connect to newscale stage')
                 self.Warning_Newscale.setText('Lost newscale stage connection')
                 self.Warning_Newscale.setStyleSheet(self.default_warning_color)
                 return False
             else:
-                print('here5')
                 self.Warning_Newscale.setText('')
                 self.Warning_Newscale.setStyleSheet(self.default_warning_color)
                 return True 
         else:
-            print('here6')
             return False
 
     def _GetPositions(self):
         '''get the current position of the stage'''
-        print('here7')
-        if hasattr(self, 'current_stage') & self._CheckStageConnection():
-            print('here8')
+        if hasattr(self, 'current_stage'):
             logging.info('Grabbing current stage position')
             current_stage=self.current_stage
             current_position=current_stage.get_position()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -425,11 +425,13 @@ class Window(QMainWindow):
             self.instances = NewScaleSerialY.get_instances()
         except Exception as e:
             logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
+            self._no_stage()
             return
        
         # If we can't find any stages, return 
         if len(self.instances) == 0:
             logging.warning('Could not find any instances of NewScale Stage')
+            self._no_stage()
             return               
     
         logging.info('found {} newscale stages'.format(len(self.instances)))
@@ -437,21 +439,20 @@ class Window(QMainWindow):
         # Get the serial num from settings
         if not hasattr(self, 'newscale_serial_num_box{}'.format(self.box_number)):
             logging.error('Cannot determine newscale serial num')
+            self._no_stage()
             return
         self.newscale_serial_num=eval('self.newscale_serial_num_box'+str(self.box_number))
         if self.newscale_serial_num == '':
             logging.warning('No newscale serial number in settings file')
+            self._no_stage()
             return
 
         # See if the serial num from settings is in the instances we found
         stage_index = 0
         stage_names = np.array([str(instance.sn) for instance in self.instances])
-        print(stage_names)
         index = np.where(stage_names == str(self.newscale_serial_num))[0]
-        print(index)
         if len(index) == 0:
-            self.Warning_Newscale.setText('Newscale not found!')
-            self.Warning_Newscale.setStyleSheet(self.default_warning_color)
+            self._no_stage()
             msg = 'Could not find newscale with serial number: {}'
             logging.error(msg.format(self.newscale_serial_num))
             return
@@ -463,6 +464,10 @@ class Window(QMainWindow):
         newscale_stage_instance = self.instances[stage_index]
         self._disconnect_stage(newscale_stage_instance)  
         self._connect_stage(newscale_stage_instance)
+
+    def _no_stage(self):
+        self.Warning_Newscale.setText('Newscale stage not connected')
+        self.Warning_Newscale.setStyleSheet(self.default_warning_color)
 
     def _disconnect_stage(self, instance):
         try:
@@ -482,6 +487,7 @@ class Window(QMainWindow):
             self.current_stage=Stage(serial=instance)
         except Exception as e:
             logging.error(str(e))
+            self._no_stage()
         else:
             logging.info('Successfully connected to newscale stage: {}'.format(instance.sn))       
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -317,9 +317,25 @@ class Window(QMainWindow):
         # press enter to confirm parameters change
         self.keyPressEvent()
 
+    def _CheckStageConnection(self):
+        if hasattr(self,'current_stage'):
+            try:
+                self.current_stage.get_position()
+            except Exception as e:
+                logging.error('could not connect to newscale stage')
+                self.Warning_Newscale.setText('Lost newscale stage connection')
+                self.Warning_Newscale.setStyleSheet(self.default_warning_color)
+                return False
+            else:
+                self.Warning_Newscale.setText('')
+                self.Warning_Newscale.setStyleSheet(self.default_warning_color)
+                return True 
+        else:
+            return False
+
     def _GetPositions(self):
         '''get the current position of the stage'''
-        if hasattr(self, 'current_stage'):
+        if hasattr(self, 'current_stage') & self._CheckStageConnection():
             logging.info('Grabbing current stage position')
             current_stage=self.current_stage
             current_position=current_stage.get_position()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -418,7 +418,7 @@ class Window(QMainWindow):
             return
         else:
             if len(self.instances) == 0:
-                logging.info('Could not find instances of NewScale Stage: {}'.format(str(e)))
+                logging.info('Could not find any instances of NewScale Stage')
                 return               
     
             logging.info('found {} newscale stages'.format(len(self.instances)))
@@ -449,12 +449,17 @@ class Window(QMainWindow):
             logging.error(str(e))
             return
 
-        # connect to the Stage
         newscale_stage_instance = self.instances[stage_index]
+        # Double check a connection isnt already open
         try:
             newscale_stage_instance.io.close()
         except Exception as e:
+            logging.info('Could not disconnect newscale stage instance, this is probably fine')
             pass
+        else:
+            logging.info('disconnected newscale stage instance')
+        
+        # connect to the Stage
         try:
             self._connect_stage(newscale_stage_instance)
         except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -45,7 +45,7 @@ class Window(QMainWindow):
         logging.info('Creating Window')
         super().__init__(parent)
         
-        
+        # Process inputs        
         self.box_number=box_number
         mapper = {
             1:'A',
@@ -70,42 +70,34 @@ class Window(QMainWindow):
         # Load Laser and Water Calibration Files
         self._GetLaserCalibration()
         self._GetWaterCalibration()
-        
-        uic.loadUi(self.default_ui, self)
-        if self.default_ui=='ForagingGUI.ui':
-            self.label_date.setText(str(date.today()))
-            self.default_warning_color="color: purple;"
-            self.default_text_color='color: purple;'
-            self.default_text_background_color='background-color: purple;'
-        elif self.default_ui=='ForagingGUI_Ephys.ui':
-            self.Visualization.setTitle(str(date.today()))
-            self.default_warning_color="color: red;"
-            self.default_text_color='color: red;'
-            self.default_text_background_color='background-color: red;'
-        else:
-            self.default_warning_color="color: red;"
-            self.default_text_color='color: red;'
-            self.default_text_background_color='background-color: red;'
+       
+        # Load User interface 
+        self._LoadUI()
+
         # set window title
         self.setWindowTitle(self.window_title)
         logging.info('Setting Window title: {}'.format(self.window_title))
 
-        self.StartANewSession=1 # to decide if should start a new session
-        self.ToInitializeVisual=1
-        self.FigureUpdateTooSlow=0 # if the FigureUpdateTooSlow is true, using different process to update figures
-        self.ANewTrial=1 # permission to start a new trial
-        self.UpdateParameters=1 # permission to update parameters
-        self.loggingstarted=-1
+        # Set up parameters
+        self.StartANewSession = 1   # to decide if should start a new session
+        self.ToInitializeVisual = 1 # Should we visualize performance
+        self.FigureUpdateTooSlow = 0# if the FigureUpdateTooSlow is true, using different process to update figures
+        self.ANewTrial = 1          # permission to start a new trial
+        self.UpdateParameters = 1   # permission to update parameters
+        self.loggingstarted = -1    # Have we started trial logging
         
         # Connect to Bonsai
         self._InitializeBonsai()
 
+        # Set up threads 
         self.threadpool=QThreadPool() # get animal response
         self.threadpool2=QThreadPool() # get animal lick
         self.threadpool3=QThreadPool() # visualization
         self.threadpool4=QThreadPool() # for generating a new trial
         self.threadpool5=QThreadPool() # for starting the trial loop
         self.threadpool_workertimer=QThreadPool() # for timing
+
+        # Set up more parameters
         self.OpenOptogenetics=0
         self.WaterCalibration=0
         self.LaserCalibration=0
@@ -117,11 +109,11 @@ class Window(QMainWindow):
         self.LickSta_ToInitializeVisual=1
         self.TimeDistribution=0
         self.TimeDistribution_ToInitializeVisual=1
-        self.finish_Timer=1 # for photometry baseline recordings
-        self.PhotometryRun=0 # 1. Photometry has been run; 0. Photometry has not been carried out.
-        self._Optogenetics()     # open the optogenetics panel 
-        self._LaserCalibration() # to open the laser calibration panel
-        self._WaterCalibration() # to open the water calibration panel
+        self.finish_Timer=1     # for photometry baseline recordings
+        self.PhotometryRun=0    # 1. Photometry has been run; 0. Photometry has not been carried out.
+        self._Optogenetics()    # open the optogenetics panel 
+        self._LaserCalibration()# to open the laser calibration panel
+        self._WaterCalibration()# to open the water calibration panel
         self._Camera()
         self.RewardFamilies=[[[8,1],[6, 1],[3, 1],[1, 1]],[[8, 1], [1, 1]],[[1,0],[.9,.1],[.8,.2],[.7,.3],[.6,.4],[.5,.5]],[[6, 1],[3, 1],[1, 1]]]
         self.WaterPerRewardedTrial=0.005 
@@ -147,6 +139,29 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
+    
+    def _LoadUI(self):
+        '''
+            Determine which user interface to use
+        '''
+        uic.loadUi(self.default_ui, self)
+        if self.default_ui=='ForagingGUI.ui':
+            logging.info('Using ForagingGUI.ui interface')
+            self.label_date.setText(str(date.today()))
+            self.default_warning_color="color: purple;"
+            self.default_text_color='color: purple;'
+            self.default_text_background_color='background-color: purple;'
+        elif self.default_ui=='ForagingGUI_Ephys.ui':
+            logging.info('Using ForagingGUI_Ephys.ui interface')
+            self.Visualization.setTitle(str(date.today()))
+            self.default_warning_color="color: red;"
+            self.default_text_color='color: red;'
+            self.default_text_background_color='background-color: red;'
+        else:
+            logging.info('Using ForagingGUI.ui interface')
+            self.default_warning_color="color: red;"
+            self.default_text_color='color: red;'
+            self.default_text_background_color='background-color: red;'
 
     def connectSignalsSlots(self):
         '''Define callbacks'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2976,7 +2976,7 @@ def start_gui_log_file(box_number):
     print(logging_filename)
     logging.basicConfig(
         format=log_format,
-        level=logging.DEBUG,#logging.INFO,
+        level=logging.INFO,
         datefmt=log_datefmt,
         handlers=[
             logging.FileHandler(logging_filename),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -422,6 +422,7 @@ class Window(QMainWindow):
             logging.info('Could not find instances of NewScale Stage: {}'.format(str(e)))
             return
         else:
+            logging.info('found {} newscale stages'.format(len(self.instances)))
             self.stage_names=[]
             for instance in self.instances:
                 self.stage_names.append(instance.sn)
@@ -456,6 +457,8 @@ class Window(QMainWindow):
                     self._connect_stage(instance)
             except Exception as e:
                 logging.error(str(e))
+            else:
+                logging.info('Successfully connected to newscale stage')
 
 
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -416,15 +416,6 @@ class Window(QMainWindow):
             Failure modes include: an error in scanning for stages, no stages found, no stage defined
             in the settings file, the defined stage not found, an error in connecting to the stage 
         '''
-        ## TODO
-        # Remove Manipulator, and MotorStage from UI files
-        # Remove "Stage" from UI file in Motorstage section
-        # Check this still works on a computer with multiple stages  
-        # Remove all notion of "self.StageSerialNum" 
-            # Ask XX about whether we need this functionality
-        # Make some updates to the python-newscale package, determine if issues are from NEWSCALE, or python-newscale
-            # At least change prints to logging
-            # Figure out why we are on a branch!?!?
  
         # find available newscale stages
         logging.info('Scanning for newscale stages')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -126,7 +126,6 @@ class Window(QMainWindow):
         self._WaterVolumnManage2()
         self._LickSta()
         self._InitializeMotorStage()
-        #self._StageSerialNum()
         self._warmup()
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
@@ -181,7 +180,7 @@ class Window(QMainWindow):
         self.SaveContinue.triggered.connect(self._SaveContinue)
         self.action_Exit.triggered.connect(self._Exit)
         self.action_New.triggered.connect(self._New)
-        self.actionScan_stages.triggered.connect(self._scan_for_usb_stages)
+        #self.actionScan_stages.triggered.connect(self._scan_for_usb_stages)
         self.action_Clear.triggered.connect(self._Clear)
         self.action_Start.triggered.connect(self.Start.click)
         self.action_NewSession.triggered.connect(self.NewSession.click)
@@ -412,39 +411,21 @@ class Window(QMainWindow):
         self.PositionY.setText(str(NewPositions[1]))
         self.PositionZ.setText(str(NewPositions[2]))
 
-    #def _StageSerialNum(self):
-    #    '''connect to a stage'''
-    #    # scan stages
-    #    #try:
-    #    #    self.instances = NewScaleSerialY.get_instances()
-    #    #except Exception as e:
-    #    #    logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
-    #    #    return
-    #    #else:
-    #    #    logging.info('Found newscale stage instances')
-
-    #    if hasattr(self,'current_stage'):
-    #        curent_stage_name=self.current_stage.name
-    #    else:
-    #        curent_stage_name=''
-    #    # connect to one stage
-    #    for instance in self.instances:
-    #        try:
-    #            instance.io.close()
-    #        except Exception as e:
-    #            pass
-    #        try:
-    #            if (instance.sn==self.StageSerialNum.currentText())&\
-    #                (curent_stage_name!=instance.sn):
-    #                self._connect_stage(instance)
-    #        except Exception as e:
-    #            logging.error(str(e))
-
     def _InitializeMotorStage(self):
         '''To initialize motor stage'''
     
         # find available newscale stages
-        self._scan_for_usb_stages()
+        logging.info('Scanning for newscale stages')
+        try:
+            self.instances = NewScaleSerialY.get_instances()
+        except Exception as e:
+            logging.info('Could not find instances of NewScale Stage: {}'.format(str(e)))
+            return
+        else:
+            self.stage_names=[]
+            for instance in self.instances:
+                self.stage_names.append(instance.sn)
+            self.StageSerialNum.addItems(self.stage_names)
 
         # use the newscale stage in the settings file
         try:
@@ -465,35 +446,19 @@ class Window(QMainWindow):
             logging.error(str(e))
 
         # connect to the Stage
-        if hasattr(self,'current_stage'):
-            current_stage_name=self.current_stage.name
-        else:
-            current_stage_name=''
         for instance in self.instances:
             try:
                 instance.io.close()
             except Exception as e:
                 pass
             try:
-                if (instance.sn==self.StageSerialNum.currentText())&\
-                    (current_stage_name!=instance.sn):
+                if (instance.sn==self.newscale_serial_num):
                     self._connect_stage(instance)
             except Exception as e:
                 logging.error(str(e))
 
 
-    def _scan_for_usb_stages(self):
-        '''Scan available stages'''
-        logging.info('Scanning for newscale stages')
-        try:
-            self.instances = NewScaleSerialY.get_instances()
-        except Exception as e:
-            logging.error('Could not find instances of NewScale Stage: {}'.format(str(e)))
-        else:
-            self.stage_names=[]
-            for instance in self.instances:
-                self.stage_names.append(instance.sn)
-            self.StageSerialNum.addItems(self.stage_names)
+
     
     def _connect_stage(self,instance):
         '''connect to a stage'''

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -1171,6 +1171,7 @@
                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                            </property>
                           </widget>
+                         </item>
                          <item row="7" column="0" colspan="6">
                           <widget class="QLabel" name="Warning_Newscale">
                            <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -1071,25 +1071,6 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="2" column="0">
-                          <widget class="QLabel" name="label_88">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Stage:</string>
-                           </property>
-                           <property name="textFormat">
-                            <enum>Qt::AutoText</enum>
-                           </property>
-                           <property name="alignment">
-                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                           </property>
-                          </widget>
-                         </item>
                          <item row="3" column="2">
                           <widget class="QPushButton" name="MoveXN">
                            <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4857,8 +4857,6 @@ Current pair:
     </widget>
     <addaction name="action_Optogenetics"/>
     <addaction name="action_Camera"/>
-    <addaction name="action_MotorStage"/>
-    <addaction name="action_Manipulator"/>
     <addaction name="action_Start"/>
     <addaction name="action_NewSession"/>
     <addaction name="actionConnectBonsai"/>
@@ -4934,8 +4932,6 @@ Current pair:
     <bool>false</bool>
    </attribute>
    <addaction name="action_Camera"/>
-   <addaction name="action_MotorStage"/>
-   <addaction name="action_Manipulator"/>
   </widget>
   <widget class="QToolBar" name="toolBar_3">
    <property name="sizePolicy">
@@ -5071,30 +5067,6 @@ Current pair:
    </property>
    <property name="priority">
     <enum>QAction::NormalPriority</enum>
-   </property>
-  </action>
-  <action name="action_MotorStage">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset>
-     <normaloff>resources/Motor.png</normaloff>resources/Motor.png</iconset>
-   </property>
-   <property name="text">
-    <string>Motor stage</string>
-   </property>
-  </action>
-  <action name="action_Manipulator">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset>
-     <normaloff>resources/Manipulator.png</normaloff>resources/Manipulator.png</iconset>
-   </property>
-   <property name="text">
-    <string>Manipulator</string>
    </property>
   </action>
   <action name="actionOpenSettingFolder">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4866,7 +4866,6 @@ Current pair:
     <addaction name="actionRestartLogging_2"/>
     <addaction name="actionOpen_behavior_folder"/>
     <addaction name="actionOpen_logging_folder"/>
-    <addaction name="actionScan_stages"/>
    </widget>
    <widget class="QMenu" name="menuSettings">
     <property name="sizePolicy">
@@ -5208,11 +5207,6 @@ Current pair:
    </property>
    <property name="text">
     <string>Time distribution</string>
-   </property>
-  </action>
-  <action name="actionScan_stages">
-   <property name="text">
-    <string>Scan stages</string>
    </property>
   </action>
   <action name="actionReconnect_bonsai">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -1171,14 +1171,6 @@
                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                            </property>
                           </widget>
-                         </item>
-                         <item row="2" column="1" colspan="2">
-                          <widget class="QComboBox" name="StageSerialNum">
-                           <property name="enabled">
-                            <bool>false</bool>
-                           </property>
-                          </widget>
-                         </item>
                          <item row="7" column="0" colspan="6">
                           <widget class="QLabel" name="Warning_Newscale">
                            <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4454,8 +4454,6 @@
     </widget>
     <addaction name="action_Optogenetics"/>
     <addaction name="action_Camera"/>
-    <addaction name="action_MotorStage"/>
-    <addaction name="action_Manipulator"/>
     <addaction name="action_Start"/>
     <addaction name="action_NewSession"/>
     <addaction name="actionConnectBonsai"/>
@@ -4531,8 +4529,6 @@
     <bool>false</bool>
    </attribute>
    <addaction name="action_Camera"/>
-   <addaction name="action_MotorStage"/>
-   <addaction name="action_Manipulator"/>
   </widget>
   <widget class="QToolBar" name="toolBar_3">
    <property name="sizePolicy">
@@ -4668,30 +4664,6 @@
    </property>
    <property name="priority">
     <enum>QAction::NormalPriority</enum>
-   </property>
-  </action>
-  <action name="action_MotorStage">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset>
-     <normaloff>resources/Motor.png</normaloff>resources/Motor.png</iconset>
-   </property>
-   <property name="text">
-    <string>Motor stage</string>
-   </property>
-  </action>
-  <action name="action_Manipulator">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset>
-     <normaloff>resources/Manipulator.png</normaloff>resources/Manipulator.png</iconset>
-   </property>
-   <property name="text">
-    <string>Manipulator</string>
    </property>
   </action>
   <action name="actionOpenSettingFolder">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3897,31 +3897,6 @@
     <property name="title">
      <string>Motor stage</string>
     </property>
-    <widget class="QLabel" name="label_88">
-     <property name="geometry">
-      <rect>
-       <x>-20</x>
-       <y>30</y>
-       <width>61</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Stage:</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget> 
     <widget class="QPushButton" name="GetPositions">
      <property name="geometry">
       <rect>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3921,20 +3921,7 @@
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
-    </widget>
-    <widget class="QComboBox" name="StageSerialNum">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="geometry">
-      <rect>
-       <x>50</x>
-       <y>30</y>
-       <width>111</width>
-       <height>22</height>
-      </rect>
-     </property>
-    </widget>
+    </widget> 
     <widget class="QPushButton" name="GetPositions">
      <property name="geometry">
       <rect>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4463,7 +4463,6 @@
     <addaction name="actionRestartLogging_2"/>
     <addaction name="actionOpen_behavior_folder"/>
     <addaction name="actionOpen_logging_folder"/>
-    <addaction name="actionScan_stages"/>
    </widget>
    <widget class="QMenu" name="menuSettings">
     <property name="sizePolicy">
@@ -4805,11 +4804,6 @@
    </property>
    <property name="text">
     <string>Time distribution</string>
-   </property>
-  </action>
-  <action name="actionScan_stages">
-   <property name="text">
-    <string>Scan stages</string>
    </property>
   </action>
   <action name="actionReconnect_bonsai">

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1745,6 +1745,7 @@ class NewScaleSerialY():
                 data += c
                 if (c == '\r'): break
         return data
+
 class WorkerSignals(QtCore.QObject):
     '''
     Defines the signals available from a running worker thread.

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -1,6 +1,5 @@
 import queue
 import time
-import logging
 
 from PyQt5.QtCore import QObject, pyqtSignal, QThread
 

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -23,28 +23,25 @@ class IOWorker(QObject):
         self.halt_requested = False
 
     def run(self):
-        try:
-            while True:
-                while not self.qslow.empty() and not self.halt_requested:
-                    cmd = self.qslow.get()
-                    cmd.execute()
-                    if not cmd.blocking:
-                        while not cmd.done() and not self.halt_requested:
-                            while not self.qfast.empty() and not self.halt_requested:
-                                fc = self.qfast.get()
-                                fc.execute()
-                            time.sleep(TIME_SLEEP)
-                while not self.qfast.empty() and not self.halt_requested:
-                    fc = self.qfast.get()
-                    fc.execute()
-                if self.halt_requested:
-                    self.device.halt()
-                    self.clear_queues()
-                    self.halt_requested = False
-                time.sleep(TIME_SLEEP)
-            self.finished.emit()
-        except:
-            logging.error('newscale error')
+        while True:
+            while not self.qslow.empty() and not self.halt_requested:
+                cmd = self.qslow.get()
+                cmd.execute()
+                if not cmd.blocking:
+                    while not cmd.done() and not self.halt_requested:
+                        while not self.qfast.empty() and not self.halt_requested:
+                            fc = self.qfast.get()
+                            fc.execute()
+                        time.sleep(TIME_SLEEP)
+            while not self.qfast.empty() and not self.halt_requested:
+                fc = self.qfast.get()
+                fc.execute()
+            if self.halt_requested:
+                self.device.halt()
+                self.clear_queues()
+                self.halt_requested = False
+            time.sleep(TIME_SLEEP)
+        self.finished.emit()
 
     def queue_command(self, cmd):
         if cmd.fast:

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -28,23 +28,23 @@ class IOWorker(QObject):
                 cmd = self.qslow.get()
                 try:
                     cmd.execute()
-                except Exception as e:
-                    logging.error(e)
+                except:
+                    logging.error('newscale error')
                 if not cmd.blocking:
                     while not cmd.done() and not self.halt_requested:
                         while not self.qfast.empty() and not self.halt_requested:
                             fc = self.qfast.get()
                             try:
                                 fc.execute()
-                            except Exception as e:
-                                logging.error(e)
+                            except:
+                                logging.error('newscale error')
                         time.sleep(TIME_SLEEP)
             while not self.qfast.empty() and not self.halt_requested:
                 fc = self.qfast.get()
                 try:
                     fc.execute()
-                except Exception as e:
-                    logging.error(e)
+                except:
+                    logging.error('newscale error')
             if self.halt_requested:
                 self.device.halt()
                 self.clear_queues()

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -98,11 +98,14 @@ class Stage(QObject):
         self.worker.queue_command(cmd)
 
     def get_position(self):
-        cmd = io.GetPositionCommand(self.device)
-        self.worker.queue_command(cmd)
-        while not cmd.done():
-            time.sleep(TIME_SLEEP)
-        return cmd.result()
+        try:
+            cmd = io.GetPositionCommand(self.device)
+            self.worker.queue_command(cmd)
+            while not cmd.done():
+                time.sleep(TIME_SLEEP)
+            return cmd.result()
+        except:
+            print('error here')
 
     def get_speed(self):
         cmd = io.GetSpeedCommand(self.device)

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -1,5 +1,6 @@
 import queue
 import time
+import logging
 
 from PyQt5.QtCore import QObject, pyqtSignal, QThread
 

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -23,34 +23,28 @@ class IOWorker(QObject):
         self.halt_requested = False
 
     def run(self):
-        while True:
-            while not self.qslow.empty() and not self.halt_requested:
-                cmd = self.qslow.get()
-                try:
+        try:
+            while True:
+                while not self.qslow.empty() and not self.halt_requested:
+                    cmd = self.qslow.get()
                     cmd.execute()
-                except:
-                    logging.error('newscale error')
-                if not cmd.blocking:
-                    while not cmd.done() and not self.halt_requested:
-                        while not self.qfast.empty() and not self.halt_requested:
-                            fc = self.qfast.get()
-                            try:
+                    if not cmd.blocking:
+                        while not cmd.done() and not self.halt_requested:
+                            while not self.qfast.empty() and not self.halt_requested:
+                                fc = self.qfast.get()
                                 fc.execute()
-                            except:
-                                logging.error('newscale error')
-                        time.sleep(TIME_SLEEP)
-            while not self.qfast.empty() and not self.halt_requested:
-                fc = self.qfast.get()
-                try:
+                            time.sleep(TIME_SLEEP)
+                while not self.qfast.empty() and not self.halt_requested:
+                    fc = self.qfast.get()
                     fc.execute()
-                except:
-                    logging.error('newscale error')
-            if self.halt_requested:
-                self.device.halt()
-                self.clear_queues()
-                self.halt_requested = False
-            time.sleep(TIME_SLEEP)
-        self.finished.emit()
+                if self.halt_requested:
+                    self.device.halt()
+                    self.clear_queues()
+                    self.halt_requested = False
+                time.sleep(TIME_SLEEP)
+            self.finished.emit()
+        except:
+            logging.error('newscale error')
 
     def queue_command(self, cmd):
         if cmd.fast:

--- a/src/foraging_gui/stage.py
+++ b/src/foraging_gui/stage.py
@@ -25,16 +25,25 @@ class IOWorker(QObject):
         while True:
             while not self.qslow.empty() and not self.halt_requested:
                 cmd = self.qslow.get()
-                cmd.execute()
+                try:
+                    cmd.execute()
+                except Exception as e:
+                    logging.error(e)
                 if not cmd.blocking:
                     while not cmd.done() and not self.halt_requested:
                         while not self.qfast.empty() and not self.halt_requested:
                             fc = self.qfast.get()
-                            fc.execute()
+                            try:
+                                fc.execute()
+                            except Exception as e:
+                                logging.error(e)
                         time.sleep(TIME_SLEEP)
             while not self.qfast.empty() and not self.halt_requested:
                 fc = self.qfast.get()
-                fc.execute()
+                try:
+                    fc.execute()
+                except Exception as e:
+                    logging.error(e)
             if self.halt_requested:
                 self.device.halt()
                 self.clear_queues()
@@ -98,14 +107,11 @@ class Stage(QObject):
         self.worker.queue_command(cmd)
 
     def get_position(self):
-        try:
-            cmd = io.GetPositionCommand(self.device)
-            self.worker.queue_command(cmd)
-            while not cmd.done():
-                time.sleep(TIME_SLEEP)
-            return cmd.result()
-        except:
-            print('error here')
+        cmd = io.GetPositionCommand(self.device)
+        self.worker.queue_command(cmd)
+        while not cmd.done():
+            time.sleep(TIME_SLEEP)
+        return cmd.result()
 
     def get_speed(self):
         cmd = io.GetSpeedCommand(self.device)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- I reorganized the code that connects to the newscale stages. I was able to greatly simplify the code, and add error checks for various failure modes. 
- I removed the "Scan stages" function from the drop down menu (in both .ui files)
- I removed the "Stage" option box from the "Motor Stage" panel (in both .ui files). 
- I added "GetPosition()" to the startup sequence, so the newscale position is already loaded without a manual press of the Get positions button. 
- I stopped forcing a disconnect of the newscale instances, because it was alreadys throwing an SI_INVALID_HANDLE error
- I added more logging statements so we can understand when the newscale stage doesn't connect
- I removed the MotorStage and Manipulator dialogs, since all they did were open blank windows. 
- removed the icons for manipulator and motor stages

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/157
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/199
- partially addresses https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/237

### Describe the expected change in behavior from the perspective of the experimenter
- You will no longer see a box for "Stage: "
- The stage positions will automatically load at startup
<img width="300" alt="MicrosoftTeams-image5a1c0981fa016a3762a7f06ed8c8e206cdf53407cc7fc015e59f67bcca0679fe" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/5843e29b-f881-4b73-b736-c40d38d658e9">

### Describe the outcome of testing this update on a rig in 447
- tested in 447




