### PR TITLE
Cleaned up parameter change logs

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1201,8 +1201,6 @@ class Window(QMainWindow):
                             new = float(child.text())
                             if new != old:
                                 logging.info('Changing parameter: {}, {} -> {}'.format(child.objectName(), old,new))
-                        else:
-                            logging.error('Could not evaluate parameter change: "{}","{}" '.format(child.objectName(),child.text()))
                     
             # update the current training parameters
             self._GetTrainingParameters()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1141,11 +1141,12 @@ class Window(QMainWindow):
 
         # move newscale stage
         if hasattr(self,'current_stage'):
-            try:
-                self.StageStop.click
-                self.current_stage.move_absolute_3d(float(self.PositionX.text()),float(self.PositionY.text()),float(self.PositionZ.text()))
-            except Exception as e:
-                logging.error(str(e))
+            if (self.PositionX.text() != '')and (self.PositionY.text() != '')and (self.PositionZ.text() != ''):
+                try:
+                    self.StageStop.click
+                    self.current_stage.move_absolute_3d(float(self.PositionX.text()),float(self.PositionY.text()),float(self.PositionZ.text()))
+                except Exception as e:
+                    logging.error(str(e))
         # Get the parameters before change
         if hasattr(self, 'GeneratedTrials') and self.ToInitializeVisual==0: # use the current GUI paramters when no session starts running
             Parameters=self.GeneratedTrials

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2849,6 +2849,8 @@ class Window(QMainWindow):
                     elif self.default_ui=='ForagingGUI_Ephys.ui':
                         self.TotalWaterWarning.setText('Supplemental water is >3.5! Health issue and \n LAS should be alerted!')
                     self.TotalWaterWarning.setStyleSheet(self.default_warning_color)
+                    msg = 'Supplemental water is greater than 3.5, this suggests a health issue, alert LAS'
+                    reply = QMessageBox.question(self, 'Box {}, Potential health issue'.format(self.box_letter), msg, QMessageBox.Ok )
                 else:
                     self.TotalWaterWarning.setText('')
                 self.SuggestedWater.setText(str(np.round(suggested_water,3)))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2849,8 +2849,6 @@ class Window(QMainWindow):
                     elif self.default_ui=='ForagingGUI_Ephys.ui':
                         self.TotalWaterWarning.setText('Supplemental water is >3.5! Health issue and \n LAS should be alerted!')
                     self.TotalWaterWarning.setStyleSheet(self.default_warning_color)
-                    msg = 'Supplemental water is greater than 3.5, this suggests a health issue, alert LAS'
-                    reply = QMessageBox.question(self, 'Box {}, Potential health issue'.format(self.box_letter), msg, QMessageBox.Ok )
                 else:
                     self.TotalWaterWarning.setText('')
                 self.SuggestedWater.setText(str(np.round(suggested_water,3)))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1182,6 +1182,8 @@ class Window(QMainWindow):
                         if hasattr(Parameters, 'TP_'+child.objectName()) and child.objectName()!='':
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))                       
                         continue
+                    if (child.objectName() == 'LatestCalibrationDate') and (child.text() == 'NA'):
+                        continue
 
 
                     # check for empty string condition

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1169,10 +1169,7 @@ class Window(QMainWindow):
                     child.setStyleSheet('color: black;')
                     child.setStyleSheet('background-color: white;')
                     self._Task()
-                    if child.objectName()=='AnimalName' and child.text()=='':
-                        child.setText(getattr(Parameters, 'TP_'+child.objectName()))
-                        continue
-                    if child.objectName() in {'Experimenter','TotalWater','AnimalName','WeightBefore','WeightAfter','ExtraWater'}:
+                    if child.objectName() in {'Experimenter','TotalWater','WeightBefore','WeightAfter','ExtraWater'}:
                         continue
                     if child.objectName()=='UncoupledReward':
                         Correct=self._CheckFormat(child)
@@ -1233,7 +1230,7 @@ class Window(QMainWindow):
                 try:
                     if getattr(Parameters, 'TP_'+child.objectName())!=child.text() :
                         self.Continue=0
-                        if child.objectName() in {'Experimenter', 'AnimalName', 'UncoupledReward', 'WeightBefore', 'WeightAfter', 'ExtraWater'}:
+                        if child.objectName() in {'Experimenter', 'UncoupledReward', 'WeightBefore', 'WeightAfter', 'ExtraWater'}:
                             child.setStyleSheet(self.default_text_color)
                             self.Continue=1
                         if child.text()=='': # If empty, change background color and wait for confirmation

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1178,6 +1178,13 @@ class Window(QMainWindow):
                         if Correct ==0: # incorrect format; don't change
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
+                    if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight']) and
+                        (child.text() == '')):
+                        # These attributes can have the empty string, but we can't set the value as the empty string
+                        if hasattr(Parameters, 'TP_'+child.objectName()) and child.objectName()!='':
+                            child.setText(getattr(Parameters, 'TP_'+child.objectName()))                       
+                        continue
+
 
                     # check for empty string condition
                     try:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -991,7 +991,7 @@ class Window(QMainWindow):
         '''
         if key in parameters:
             # skip some keys
-            if key=='ExtraWater' or key=='WeightBefore' or key=='WeightAfter' or key=='SuggestedWater':
+            if key=='ExtraWater' or key=='WeightAfter' or key=='SuggestedWater':
                 self.WeightAfter.setText('')
                 return
             widget = widget_dict[key]
@@ -1169,7 +1169,7 @@ class Window(QMainWindow):
                     child.setStyleSheet('color: black;')
                     child.setStyleSheet('background-color: white;')
                     self._Task()
-                    if child.objectName() in {'Experimenter','TotalWater','WeightBefore','WeightAfter','ExtraWater'}:
+                    if child.objectName() in {'Experimenter','TotalWater','WeightAfter','ExtraWater'}:
                         continue
                     if child.objectName()=='UncoupledReward':
                         Correct=self._CheckFormat(child)
@@ -1232,7 +1232,7 @@ class Window(QMainWindow):
                 try:
                     if getattr(Parameters, 'TP_'+child.objectName())!=child.text() :
                         self.Continue=0
-                        if child.objectName() in {'Experimenter', 'UncoupledReward', 'WeightBefore', 'WeightAfter', 'ExtraWater'}:
+                        if child.objectName() in {'Experimenter', 'UncoupledReward', 'WeightAfter', 'ExtraWater'}:
                             child.setStyleSheet(self.default_text_color)
                             self.Continue=1
                         if child.text()=='': # If empty, change background color and wait for confirmation


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- The GUI log had multiple errors due to either the parameter name being the empty string, or the text of the parameter being the empty string. I added checks in the code that processes parameter changes to handle these case. 
- I removed the "AnimalName" and "WeightBefore" fields in the parameter processing code since they are outdated and not used. 
- The log was throwing errors when parameter changes were processed when the newscale positions were "" (either before GetPositions() was called, or no newscale present). I handle this case. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/191

### Describe the expected change in behavior from the perspective of the experimenter
- None

### Describe the outcome of testing this update on a rig in 447
- [x] Tested in 447




