### PR TITLE
[skip email] Adding delay for long updates

### DIFF
--- a/src/update_scripts/update_from_github_to_main.bat
+++ b/src/update_scripts/update_from_github_to_main.bat
@@ -13,4 +13,6 @@ git stash >>%logfile% 2>&1
 git checkout %branch% >>%logfile% 2>&1
 git reset --hard >>%logfile% 2>&1
 git pull origin %branch% >>%logfile% 2>&1
+echo waiting thirty second for long running processes >>%logfile%
+timeout 30>NUL
 git status >>%logfile% 2>&1

--- a/src/update_scripts/update_from_github_to_production_testing.bat
+++ b/src/update_scripts/update_from_github_to_production_testing.bat
@@ -13,4 +13,6 @@ git stash >>%logfile% 2>&1
 git checkout %branch% >>%logfile% 2>&1
 git reset --hard >>%logfile% 2>&1
 git pull origin %branch% >>%logfile% 2>&1
+echo waiting thirty seconds for logging to finish >>%logfile%
+timeout 30 >NUL
 git status >>%logfile% 2>&1


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Adds a thirty second delay after `git pull` before calling `git status` in the update scripts. 
- This is necessary because if there are a lot of updates, the file IO is slow enough that the subsequent "git status" commands get over-written. 





