### PR TITLE
Fixed interference between behavior and laser calibration

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -334,7 +334,7 @@ class WaterCalibrationDialog(QDialog):
         self.MainWindow=MainWindow
         self.FinishLeftValve=0
         if not hasattr(self.MainWindow,'WaterCalibrationResults'):
-            self.MainWindow.LaserCalibrationResults={}
+            self.MainWindow.WaterCalibrationResults={}
             self.WaterCalibrationResults={}
         else:
             self.WaterCalibrationResults=self.MainWindow.WaterCalibrationResults

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -285,8 +285,8 @@ class OptogeneticsDialog(QDialog):
                             ItemsRight=sorted(ItemsRight)
                             eval('self.LaserPowerLeft_'+str(Numb)+'.clear()')
                             eval('self.LaserPowerLeft_'+str(Numb)+'.addItems(ItemsLeft)')
-                            eval('self.LaserPowerLeft_'+str(Numb)+'.clear()')
-                            eval('self.LaserPowerLeft_'+str(Numb)+'.addItems(ItemsRight)')
+                            eval('self.LaserPowerRight_'+str(Numb)+'.clear()')
+                            eval('self.LaserPowerRight_'+str(Numb)+'.addItems(ItemsRight)')
                         self.MainWindow.WarningLabel.setText('')
                         self.MainWindow.WarningLabel.setStyleSheet("color: gray;")
                     else:

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1288,6 +1288,8 @@ class LaserCalibrationDialog(QDialog):
         self.CLP_InputVoltage=float(self.voltage.text())
         # generate the waveform based on self.CLP_CurrentDuration and Protocol, Frequency, RampingDown, PulseDur
         self._GetLaserAmplitude()
+        # send the trigger source. It's '/Dev1/PFI0' ( P2.0 of NIdaq USB6002) by default 
+        self.MainWindow.Channel.TriggerSource('/Dev1/PFI0')
         # dimension of self.CurrentLaserAmplitude indicates how many locations do we have
         for i in range(len(self.CurrentLaserAmplitude)):
             # in some cases the other paramters except the amplitude could also be different
@@ -1397,8 +1399,6 @@ class LaserCalibrationDialog(QDialog):
                 setattr(self, Prefix+'_'+child.objectName(), child.isChecked())
     def _InitiateATrial(self):
         '''Initiate calibration in bonsai'''
-        # send the trigger source. It's '/Dev1/PFI0' ( P2.0 of NIdaq USB6002) by default 
-        self.MainWindow.Channel.TriggerSource('/Dev1/PFI0')
         # start generating waveform in bonsai
         self.MainWindow.Channel.OptogeneticsCalibration(int(1))
         self.MainWindow.Channel.receive()
@@ -1697,7 +1697,6 @@ class LaserCalibrationDialog(QDialog):
             # change button color and disable the open button
             self.Open.setEnabled(False)
             self.Open.setStyleSheet("background-color : green;")
-            QApplication.processEvents()
             self._GetTrainingParameters(self.MainWindow)
             self._GetLaserWaveForm()
             self.worker2 = Worker(self._Sleep,float(self.LC_Duration_1)+1)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1401,6 +1401,7 @@ class LaserCalibrationDialog(QDialog):
         self.MainWindow.Channel.TriggerSource('/Dev1/PFI0')
         # start generating waveform in bonsai
         self.MainWindow.Channel.OptogeneticsCalibration(int(1))
+        self.MainWindow.Channel.receive()
     def _CopyFromOpto(self):
         '''Copy the optogenetics parameters'''
         N=[]


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Fixed interference between behavior and laser calibration

### What issues or discussions does this update address?
Before,
1. When we perform calibration first and then launch the behavior, the GUI crashes. This is because the `/ITIStartTimeHarp` is not being cleared after calibration. 
2. When we start the behavior and then start laser calibration, the GUI crashes. This is because the `Trigger source` could be different between behavior and calibration. And the `Trigger source ` should be sent before sending the waveform to overwrite it in bonsai. 

### Describe the expected change in behavior from the perspective of the experimenter
We can start Laser calibration after behavior without restarting the GUI. @ZhixiaoSu

### Describe the outcome of testing this update on a rig in 447
Tested in ephys rig




