### PR TITLE
Added session control for optogenetics

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -53,6 +53,7 @@ class OptogeneticsDialog(QDialog):
         self._Laser_3()
         self._Laser_4()
         self._Laser_calibration()
+        self._SessionWideControl()
     def _connectSignalsSlots(self):
         self.Laser_1.currentIndexChanged.connect(self._Laser_1)
         self.Laser_2.currentIndexChanged.connect(self._Laser_2)
@@ -104,6 +105,20 @@ class OptogeneticsDialog(QDialog):
         self.LaserEnd_4.currentIndexChanged.connect(self._activated_4)
         self.Laser_calibration.currentIndexChanged.connect(self._Laser_calibration)
         self.Laser_calibration.activated.connect(self._Laser_calibration)
+        self.SessionWideControl.currentIndexChanged.connect(self._SessionWideControl)
+    def _SessionWideControl(self):
+        '''enable/disable items based on session wide control'''
+        if self.SessionWideControl.currentText()=='on':
+            enable=True
+        else:
+            enable=False
+        self.label3_18.setEnabled(enable)
+        self.label3_21.setEnabled(enable)
+        self.FractionOfSession.setEnabled(enable)
+        self.label3_19.setEnabled(enable)
+        self.SessionStartWith.setEnabled(enable)
+        self.label3_17.setEnabled(enable)
+        self.SessionAlternating.setEnabled(enable)
     def _Laser_calibration(self):
         ''''change the laser calibration date'''
         # find the latest calibration date for the selected laser

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2013,7 +2013,13 @@ class Window(QMainWindow):
                             elif Tag==1:
                                 index = widget.findText(value)
                             if index != -1:
-                                widget.setCurrentIndex(index)
+                                # Alternating on/off for SessionStartWith if SessionAlternating is on
+                                if key=='SessionStartWith' and 'Opto_dialog' in Obj:
+                                    if Obj['Opto_dialog']['SessionAlternating']=='on':
+                                        index=1-index
+                                        widget.setCurrentIndex(index)
+                                else:
+                                    widget.setCurrentIndex(index)
                         elif isinstance(widget, QtWidgets.QDoubleSpinBox):
                             if Tag==0:
                                 widget.setValue(float(value[-1]))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2015,9 +2015,10 @@ class Window(QMainWindow):
                             if index != -1:
                                 # Alternating on/off for SessionStartWith if SessionAlternating is on
                                 if key=='SessionStartWith' and 'Opto_dialog' in Obj:
-                                    if Obj['Opto_dialog']['SessionAlternating']=='on':
-                                        index=1-index
-                                        widget.setCurrentIndex(index)
+                                    if 'SessionAlternating' in Obj['Opto_dialog'] and 'SessionWideControl' in Obj['Opto_dialog']:
+                                        if Obj['Opto_dialog']['SessionAlternating']=='on' and Obj['OptogeneticsB']=='on' and Obj['Opto_dialog']['SessionWideControl']=='on':
+                                            index=1-index
+                                            widget.setCurrentIndex(index)
                                 else:
                                     widget.setCurrentIndex(index)
                         elif isinstance(widget, QtWidgets.QDoubleSpinBox):

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -189,8 +189,12 @@ class GenerateTrials():
             self.session_control_state=self.calculated_state[self.B_RewardProHistory.shape[1]-1]
         else:
             self.session_control_state=0
-            
-
+        if self.session_control_state==0:
+            state='off'
+        else:
+            state='on'
+        self.win.Opto_dialog.SessionControlWarning.setText('Session control state: '+state)
+        self.win.Opto_dialog.SessionControlWarning.setStyleSheet(self.win.default_warning_color)    
 
     def _CheckWarmUp(self):
         '''Check if we should turn on warm up'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -69,6 +69,7 @@ class GenerateTrials():
         self.B_AutoWaterTrial=np.array([[],[]]).astype(bool) # to indicate if it is a trial with outo water.
         self.B_NewscalePositions=[]
         self.B_session_control_state=[]
+        self.B_opto_error=[]
         self.NextWaveForm=1 # waveform stored for later use
         self.CurrentWaveForm=1 # the current waveform to trigger the optogenetics
         self.Start_Delay_LeftLicks=[]
@@ -156,8 +157,10 @@ class GenerateTrials():
                 self.B_SelectedCondition.append(0)
                 self.CurrentLaserAmplitude=[0,0]
                 self.B_session_control_state.append(0)
+            self.B_opto_error.append(0)
         except Exception as e:
             # optogenetics is turned off
+            self.B_opto_error.append(1)
             self.LaserOn=0
             self.B_LaserOnTrial.append(self.LaserOn)
             self.B_LaserAmplitude.append([0,0]) # corresponding to two locations

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1294,14 +1294,14 @@ class GenerateTrials():
             return
         ConditionsOn=[]
         Probabilities=[]
+        empty=1
         for attr_name in dir(self):
-            empty=1
             if attr_name in ['TP_Laser_1','TP_Laser_2','TP_Laser_3','TP_Laser_4']:
                 if getattr(self, attr_name) !='NA':
                     parts = attr_name.split('_')
                     ConditionsOn.append(parts[-1])
                     Probabilities.append(float(eval('self.TP_Probability_'+parts[-1])))
-                empty=0
+                    empty=0
         if empty==1:
             self.SelctedCondition=0
             return

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1295,11 +1295,16 @@ class GenerateTrials():
         ConditionsOn=[]
         Probabilities=[]
         for attr_name in dir(self):
+            empty=1
             if attr_name in ['TP_Laser_1','TP_Laser_2','TP_Laser_3','TP_Laser_4']:
                 if getattr(self, attr_name) !='NA':
                     parts = attr_name.split('_')
                     ConditionsOn.append(parts[-1])
                     Probabilities.append(float(eval('self.TP_Probability_'+parts[-1])))
+                empty=0
+        if empty==1:
+            self.SelctedCondition=0
+            return
         self.ConditionsOn=ConditionsOn
         self.Probabilities=Probabilities
         ProAccu=list(accumulate(Probabilities))

--- a/src/foraging_gui/Optogenetics.ui
+++ b/src/foraging_gui/Optogenetics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1442</width>
-    <height>630</height>
+    <height>785</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -3066,8 +3066,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>10</x>
-     <y>480</y>
+     <x>20</x>
+     <y>740</y>
      <width>131</width>
      <height>20</height>
     </rect>
@@ -3082,8 +3082,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>140</x>
-     <y>480</y>
+     <x>150</x>
+     <y>740</y>
      <width>91</width>
      <height>20</height>
     </rect>
@@ -3585,8 +3585,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>260</x>
-     <y>530</y>
+     <x>270</x>
+     <y>690</y>
      <width>131</width>
      <height>20</height>
     </rect>
@@ -3601,8 +3601,8 @@
    </property>
    <property name="geometry">
     <rect>
-     <x>380</x>
-     <y>530</y>
+     <x>390</x>
+     <y>690</y>
      <width>91</width>
      <height>20</height>
     </rect>
@@ -3614,8 +3614,8 @@
   <widget class="QLabel" name="label1_17">
    <property name="geometry">
     <rect>
-     <x>100</x>
-     <y>530</y>
+     <x>110</x>
+     <y>690</y>
      <width>41</width>
      <height>20</height>
     </rect>
@@ -3627,8 +3627,8 @@
   <widget class="QComboBox" name="Laser_calibration">
    <property name="geometry">
     <rect>
-     <x>140</x>
-     <y>530</y>
+     <x>150</x>
+     <y>690</y>
      <width>80</width>
      <height>20</height>
     </rect>
@@ -3667,6 +3667,228 @@
      <string>NA</string>
     </property>
    </item>
+  </widget>
+  <widget class="Line" name="line">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>670</y>
+     <width>1411</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+  </widget>
+  <widget class="Line" name="line_2">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>440</y>
+     <width>1411</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="SessionAlternating">
+   <property name="geometry">
+    <rect>
+     <x>810</x>
+     <y>470</y>
+     <width>81</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="editable">
+    <bool>true</bool>
+   </property>
+   <item>
+    <property name="text">
+     <string>on</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>off</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string/>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string/>
+    </property>
+   </item>
+  </widget>
+  <widget class="QLabel" name="label3_17">
+   <property name="geometry">
+    <rect>
+     <x>660</x>
+     <y>470</y>
+     <width>141</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Alternating across sessions=</string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label3_18">
+   <property name="geometry">
+    <rect>
+     <x>220</x>
+     <y>470</y>
+     <width>141</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Fraction of session (trials) =</string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="FractionOfSession">
+   <property name="geometry">
+    <rect>
+     <x>370</x>
+     <y>470</y>
+     <width>81</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>0.5</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label3_19">
+   <property name="geometry">
+    <rect>
+     <x>480</x>
+     <y>470</y>
+     <width>61</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Start with=</string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="SessionStartWith">
+   <property name="geometry">
+    <rect>
+     <x>550</x>
+     <y>470</y>
+     <width>81</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="editable">
+    <bool>true</bool>
+   </property>
+   <item>
+    <property name="text">
+     <string>on</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>off</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string/>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string/>
+    </property>
+   </item>
+  </widget>
+  <widget class="QComboBox" name="SessionWideControl">
+   <property name="geometry">
+    <rect>
+     <x>110</x>
+     <y>470</y>
+     <width>81</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="editable">
+    <bool>true</bool>
+   </property>
+   <item>
+    <property name="text">
+     <string>on</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>off</string>
+    </property>
+   </item>
+  </widget>
+  <widget class="QLabel" name="label3_20">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>470</y>
+     <width>91</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Session control=</string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   </property>
   </widget>
   <zorder>OptoPar</zorder>
   <zorder>Laser_1</zorder>
@@ -3803,6 +4025,16 @@
   <zorder>LatestCalibrationDate</zorder>
   <zorder>label1_17</zorder>
   <zorder>Laser_calibration</zorder>
+  <zorder>line</zorder>
+  <zorder>line_2</zorder>
+  <zorder>SessionAlternating</zorder>
+  <zorder>label3_17</zorder>
+  <zorder>label3_18</zorder>
+  <zorder>FractionOfSession</zorder>
+  <zorder>label3_19</zorder>
+  <zorder>SessionStartWith</zorder>
+  <zorder>SessionWideControl</zorder>
+  <zorder>label3_20</zorder>
  </widget>
  <resources/>
  <connections/>

--- a/src/foraging_gui/Optogenetics.ui
+++ b/src/foraging_gui/Optogenetics.ui
@@ -3873,6 +3873,34 @@
     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
    </property>
   </widget>
+  <widget class="QLabel" name="SessionControlWarning">
+   <property name="geometry">
+    <rect>
+     <x>920</x>
+     <y>466</y>
+     <width>491</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
+   </property>
+   <property name="scaledContents">
+    <bool>false</bool>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+   </property>
+  </widget>
   <zorder>OptoPar</zorder>
   <zorder>Laser_1</zorder>
   <zorder>label1_2</zorder>
@@ -4018,6 +4046,7 @@
   <zorder>SessionStartWith</zorder>
   <zorder>SessionWideControl</zorder>
   <zorder>label3_20</zorder>
+  <zorder>SessionControlWarning</zorder>
  </widget>
  <resources/>
  <connections/>

--- a/src/foraging_gui/Optogenetics.ui
+++ b/src/foraging_gui/Optogenetics.ui
@@ -3745,8 +3745,8 @@
   <widget class="QLabel" name="label3_18">
    <property name="geometry">
     <rect>
-     <x>220</x>
-     <y>470</y>
+     <x>215</x>
+     <y>466</y>
      <width>141</width>
      <height>20</height>
     </rect>
@@ -3901,6 +3901,25 @@
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
    </property>
   </widget>
+  <widget class="QLabel" name="label3_21">
+   <property name="geometry">
+    <rect>
+     <x>215</x>
+     <y>480</y>
+     <width>141</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>(block size=max trial * frac) </string>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::AutoText</enum>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+   </property>
+  </widget>
   <zorder>OptoPar</zorder>
   <zorder>Laser_1</zorder>
   <zorder>label1_2</zorder>
@@ -4047,6 +4066,7 @@
   <zorder>SessionWideControl</zorder>
   <zorder>label3_20</zorder>
   <zorder>SessionControlWarning</zorder>
+  <zorder>label3_21</zorder>
  </widget>
  <resources/>
  <connections/>

--- a/src/foraging_gui/Optogenetics.ui
+++ b/src/foraging_gui/Optogenetics.ui
@@ -3710,7 +3710,7 @@
     </sizepolicy>
    </property>
    <property name="editable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <item>
     <property name="text">
@@ -3720,16 +3720,6 @@
    <item>
     <property name="text">
      <string>off</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string/>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string/>
     </property>
    </item>
   </widget>
@@ -3819,7 +3809,7 @@
     </sizepolicy>
    </property>
    <property name="editable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <item>
     <property name="text">
@@ -3829,16 +3819,6 @@
    <item>
     <property name="text">
      <string>off</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string/>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string/>
     </property>
    </item>
   </widget>
@@ -3858,7 +3838,7 @@
     </sizepolicy>
    </property>
    <property name="editable">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="currentIndex">
     <number>1</number>

--- a/src/foraging_gui/Optogenetics.ui
+++ b/src/foraging_gui/Optogenetics.ui
@@ -3860,6 +3860,9 @@
    <property name="editable">
     <bool>true</bool>
    </property>
+   <property name="currentIndex">
+    <number>1</number>
+   </property>
    <item>
     <property name="text">
      <string>on</string>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
1. To periodically turn on/off optogenetics if `session control` is `on` .  `Fraction of session (trials)` controls the period. `Start with` controls the on or off state of the first period. When `Alternating across sessions` is `on` in the json file, the `Start with` will be changed to the opposite when loading this json file. 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/22ca31a2-0a22-4c3b-a12b-c1e837e7eca5)


### What issues or discussions does this update address?
2. Periodically  and automatically turn on/off optogenetics in a session. In this way, we can do consecutive perturbation and perform within session control.  

### Describe the expected change in behavior from the perspective of the experimenter
Turn off `Session control` if you don't use this function. It is also turned off by default. 

### Describe the outcome of testing this update on a rig in 447
- [x] Tested on my own computer. 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/c3b793e7-aec3-4c08-b178-6ed66888f342)
- [x] test in ephys



