### PR TITLE
Fix uncoupled block

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1900,8 +1900,8 @@ class AutoTrainDialog(QDialog):
             
             # Reset override curriculum
             self.checkBox_override_curriculum.setChecked(False)
-            self.checkBox_override_curriculum.setEnabled(True)
-
+            if not self.auto_train_engaged:
+                self.checkBox_override_curriculum.setEnabled(True)
 
                     
         # Update UI

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2099,15 +2099,22 @@ class AutoTrainDialog(QDialog):
         )
 
         
-    def _update_available_training_stages(self):
-        if self.curriculum_in_use is not None:
-            available_training_stages = [v.name for v in 
-                                        self.curriculum_in_use.parameters.keys()]
+    def _update_available_training_stages(self):            
+        # If AutoTrain is engaged, and override stage is checked
+        if self.auto_train_engaged and self.checkBox_override_stage.isChecked():
+            # Restore stage_in_use. No need to reload available stages
+            self.comboBox_override_stage.setCurrentText(self.stage_in_use)
         else:
-            available_training_stages = []
-            
-        self.comboBox_override_stage.clear()
-        self.comboBox_override_stage.addItems(available_training_stages)
+            # Reload available stages
+            if self.curriculum_in_use is not None:
+                available_training_stages = [v.name for v in 
+                                            self.curriculum_in_use.parameters.keys()]
+            else:
+                available_training_stages = []
+                
+            self.comboBox_override_stage.clear()
+            self.comboBox_override_stage.addItems(available_training_stages)
+
                 
     def _override_stage_clicked(self, state):
         if state:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1406,37 +1406,16 @@ class Window(QMainWindow):
             self.RewardFamily.setEnabled(True)
             self.label_20.setEnabled(False)
             self.UncoupledReward.setEnabled(False)
-            # self.label_6.setStyleSheet("color: black;")
-            # self.label_7.setStyleSheet("color: black;")
-            # self.label_8.setStyleSheet("color: black;")
-            # self.BaseRewardSum.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.RewardPairsN.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.RewardFamily.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.label_20.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.UncoupledReward.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # # block
-            # if self.Randomness.currentText()=='Exponential':
-            #     self.BlockBeta.setEnabled(True)
-            #     self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-            #     self.label_14.setStyleSheet("color: black;background-color: rgba(0, 0, 0, 0)")
-            # else:
-            #     self.BlockBeta.setEnabled(False)
-            #     self.BlockBeta.setStyleSheet("color: gray;""border: 1px solid gray;")
-            #     self.label_14.setStyleSheet("color: gray;")
+
             self.label_12.setEnabled(True)
             self.label_11.setEnabled(True)
             self.BlockBeta.setEnabled(True)
             self.BlockMin.setEnabled(True)
             self.BlockMax.setEnabled(True)
-            # self.label_12.setStyleSheet("color: black;")
-            # self.label_11.setStyleSheet("color: black;")
-            # self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.BlockMin.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.BlockMax.setStyleSheet("color: black;""border: 1px solid gray;")
+
             self.label_27.setEnabled(False)
             self.InitiallyInactiveN.setEnabled(False)
-            # self.label_27.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.InitiallyInactiveN.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(1081, 23, 80, 20))
             # change name of min reward each block
             self.label_13.setText('min reward each block=')
@@ -1447,9 +1426,6 @@ class Window(QMainWindow):
             # move auto-reward
             self.IncludeAutoReward.setGeometry(QtCore.QRect(1080, 128, 80, 20))
             self.label_26.setGeometry(QtCore.QRect(929, 128, 146, 16))
-            # set block length to the default value
-            #self.BlockMin.setText('20')
-            #self.BlockMax.setText('60')
             
             # Reopen block beta, NextBlock, and AutoBlock panel
             self.BlockBeta.setEnabled(True)
@@ -1462,8 +1438,6 @@ class Window(QMainWindow):
             self.IncludeAutoReward.setEnabled(True)
             
         elif self.Task.currentText() in ['Uncoupled Baiting','Uncoupled Without Baiting']:
-            # border_color = "rgb(100, 100, 100,80)"
-            # border_style = "1px solid " + border_color
             self.label_6.setEnabled(False)
             self.label_7.setEnabled(False)
             self.label_8.setEnabled(False)
@@ -1472,36 +1446,14 @@ class Window(QMainWindow):
             self.RewardFamily.setEnabled(False)
             self.label_20.setEnabled(True)
             self.UncoupledReward.setEnabled(True)
-            # self.label_6.setStyleSheet("color: gray;")
-            # self.label_7.setStyleSheet("color: gray;")
-            # self.label_8.setStyleSheet("color: gray;")
-            # self.BaseRewardSum.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
-            # self.RewardPairsN.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
-            # self.RewardFamily.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
-            # self.label_20.setStyleSheet("color: black;")
-            # self.UncoupledReward.setStyleSheet("color: black;""border: 1px solid gray;")
-            # # block
-            # if self.Randomness.currentText()=='Exponential':
-            #     self.BlockBeta.setEnabled(True)
-            #     # self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-            #     # self.label_14.setStyleSheet("color: black;")
-            # else:
-            #     self.BlockBeta.setEnabled(False)
-            #     self.BlockBeta.setStyleSheet("color: gray;""border: 1px solid gray;")
-            #     self.label_14.setStyleSheet("color: gray;")
+
             self.label_12.setEnabled(True)
             self.label_11.setEnabled(True)
             self.BlockMin.setEnabled(True)
             self.BlockMax.setEnabled(True)
-            # self.label_12.setStyleSheet("color: black;")
-            # self.label_11.setStyleSheet("color: black;")
-            # self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.BlockMin.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.BlockMax.setStyleSheet("color: black;""border: 1px solid gray;")
+
             self.label_27.setEnabled(False)
             self.InitiallyInactiveN.setEnabled(False)
-            # self.label_27.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.InitiallyInactiveN.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(1081, 23, 80, 20))
             # change name of min reward each block
             self.label_13.setText('min reward each block=')
@@ -1532,14 +1484,7 @@ class Window(QMainWindow):
             self.RewardFamily.setEnabled(True)
             self.label_20.setEnabled(False)
             self.UncoupledReward.setEnabled(False)
-            # self.label_6.setStyleSheet("color: black;")
-            # self.label_7.setStyleSheet("color: black;")
-            # self.label_8.setStyleSheet("color: black;")
-            # self.BaseRewardSum.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.RewardPairsN.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.RewardFamily.setStyleSheet("color: black;""border: 1px solid gray;")
-            # self.label_20.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.UncoupledReward.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+
             # block
             self.label_14.setEnabled(False)
             self.label_12.setEnabled(False)
@@ -1547,17 +1492,11 @@ class Window(QMainWindow):
             self.BlockBeta.setEnabled(False)
             self.BlockMin.setEnabled(False)
             self.BlockMax.setEnabled(False)
-            # self.label_14.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.label_12.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.label_11.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.BlockBeta.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.BlockMin.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # self.BlockMax.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+
             # block; no reward when initially active
             self.label_27.setEnabled(True)
             self.InitiallyInactiveN.setEnabled(True)
-            # self.label_27.setStyleSheet("color: black;")
-            # self.InitiallyInactiveN.setStyleSheet("color: black;""border: 1px solid gray;")
+
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(403, 128, 80, 20))
             # change name of min reward each block
             self.label_13.setText('RewardN=')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1217,9 +1217,15 @@ class Window(QMainWindow):
                 for child in container.findChildren((QtWidgets.QLineEdit,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox)):
                     if child.objectName()=='qt_spinbox_lineedit':
                         continue
-                    child.setStyleSheet('color: black;')
-                    child.setStyleSheet('background-color: white;')
-                    self._Task()
+                    
+                    if not (hasattr(self, 'AutoTrain_dialog') and self.AutoTrain_dialog.auto_train_engaged):
+                        # Only run _Task again if AutoTrain is NOT engaged
+                        # To avoid the _Task() function overwriting the AutoTrain UI locks
+                        # resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/239
+                        child.setStyleSheet('color: black;')
+                        child.setStyleSheet('background-color: white;')
+                        self._Task()
+                    
                     if child.objectName() in {'Experimenter','TotalWater','WeightAfter','ExtraWater'}:
                         continue
                     if child.objectName()=='UncoupledReward':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1153,9 +1153,8 @@ class Window(QMainWindow):
             self.BlockBeta.setEnabled(True)
             self.DelayBeta.setEnabled(True)
             self.ITIBeta.setEnabled(True)
-            if self.Task.currentText()!='RewardN':
-                self.BlockBeta.setStyleSheet("color: black;border: 1px solid gray;background-color: white;")
-                self.label_14.setStyleSheet("color: black;background-color: white;")
+            # if self.Task.currentText()!='RewardN':
+            #     self.BlockBeta.setStyleSheet("color: black;border: 1px solid gray;background-color: white;")
         elif self.Randomness.currentText()=='Even':
             self.label_14.setEnabled(False)
             self.label_18.setEnabled(False)
@@ -1163,11 +1162,10 @@ class Window(QMainWindow):
             self.BlockBeta.setEnabled(False)
             self.DelayBeta.setEnabled(False)
             self.ITIBeta.setEnabled(False)
-            if self.Task.currentText()!='RewardN':
-                border_color = "rgb(100, 100, 100,80)"
-                border_style = "1px solid " + border_color
-                self.BlockBeta.setStyleSheet(f"color: gray;border:{border_style};background-color: rgba(0, 0, 0, 0);")
-                self.label_14.setStyleSheet("color: gray;background-color: rgba(0, 0, 0, 0);")
+            # if self.Task.currentText()!='RewardN':
+            #     border_color = "rgb(100, 100, 100,80)"
+            #     border_style = "1px solid " + border_color
+            #     self.BlockBeta.setStyleSheet(f"color: gray;border:{border_style};background-color: rgba(0, 0, 0, 0);")
 
     def _AdvancedBlockAuto(self):
         '''enable/disable some fields in the AdvancedBlockAuto'''
@@ -1397,6 +1395,8 @@ class Window(QMainWindow):
         '''hide and show some fields based on the task type'''
         self.label_43.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
         self.ITIIncrease.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+        self._Randomness()
+
         if self.Task.currentText() in ['Coupled Baiting','Coupled Without Baiting']:
             self.label_6.setEnabled(True)
             self.label_7.setEnabled(True)
@@ -1406,37 +1406,37 @@ class Window(QMainWindow):
             self.RewardFamily.setEnabled(True)
             self.label_20.setEnabled(False)
             self.UncoupledReward.setEnabled(False)
-            self.label_6.setStyleSheet("color: black;")
-            self.label_7.setStyleSheet("color: black;")
-            self.label_8.setStyleSheet("color: black;")
-            self.BaseRewardSum.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.RewardPairsN.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.RewardFamily.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.label_20.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.UncoupledReward.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            # block
-            if self.Randomness.currentText()=='Exponential':
-                self.BlockBeta.setEnabled(True)
-                self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-                self.label_14.setStyleSheet("color: black;background-color: rgba(0, 0, 0, 0)")
-            else:
-                self.BlockBeta.setEnabled(False)
-                self.BlockBeta.setStyleSheet("color: gray;""border: 1px solid gray;")
-                self.label_14.setStyleSheet("color: gray;")
+            # self.label_6.setStyleSheet("color: black;")
+            # self.label_7.setStyleSheet("color: black;")
+            # self.label_8.setStyleSheet("color: black;")
+            # self.BaseRewardSum.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.RewardPairsN.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.RewardFamily.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.label_20.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.UncoupledReward.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # # block
+            # if self.Randomness.currentText()=='Exponential':
+            #     self.BlockBeta.setEnabled(True)
+            #     self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
+            #     self.label_14.setStyleSheet("color: black;background-color: rgba(0, 0, 0, 0)")
+            # else:
+            #     self.BlockBeta.setEnabled(False)
+            #     self.BlockBeta.setStyleSheet("color: gray;""border: 1px solid gray;")
+            #     self.label_14.setStyleSheet("color: gray;")
             self.label_12.setEnabled(True)
             self.label_11.setEnabled(True)
             self.BlockBeta.setEnabled(True)
             self.BlockMin.setEnabled(True)
             self.BlockMax.setEnabled(True)
-            self.label_12.setStyleSheet("color: black;")
-            self.label_11.setStyleSheet("color: black;")
-            self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.BlockMin.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.BlockMax.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.label_12.setStyleSheet("color: black;")
+            # self.label_11.setStyleSheet("color: black;")
+            # self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.BlockMin.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.BlockMax.setStyleSheet("color: black;""border: 1px solid gray;")
             self.label_27.setEnabled(False)
             self.InitiallyInactiveN.setEnabled(False)
-            self.label_27.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.InitiallyInactiveN.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.label_27.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.InitiallyInactiveN.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(1081, 23, 80, 20))
             # change name of min reward each block
             self.label_13.setText('min reward each block=')
@@ -1462,8 +1462,8 @@ class Window(QMainWindow):
             self.IncludeAutoReward.setEnabled(True)
             
         elif self.Task.currentText() in ['Uncoupled Baiting','Uncoupled Without Baiting']:
-            border_color = "rgb(100, 100, 100,80)"
-            border_style = "1px solid " + border_color
+            # border_color = "rgb(100, 100, 100,80)"
+            # border_style = "1px solid " + border_color
             self.label_6.setEnabled(False)
             self.label_7.setEnabled(False)
             self.label_8.setEnabled(False)
@@ -1472,36 +1472,36 @@ class Window(QMainWindow):
             self.RewardFamily.setEnabled(False)
             self.label_20.setEnabled(True)
             self.UncoupledReward.setEnabled(True)
-            self.label_6.setStyleSheet("color: gray;")
-            self.label_7.setStyleSheet("color: gray;")
-            self.label_8.setStyleSheet("color: gray;")
-            self.BaseRewardSum.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
-            self.RewardPairsN.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
-            self.RewardFamily.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
-            self.label_20.setStyleSheet("color: black;")
-            self.UncoupledReward.setStyleSheet("color: black;""border: 1px solid gray;")
-            # block
-            if self.Randomness.currentText()=='Exponential':
-                self.BlockBeta.setEnabled(True)
-                self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-                self.label_14.setStyleSheet("color: black;")
-            else:
-                self.BlockBeta.setEnabled(False)
-                self.BlockBeta.setStyleSheet("color: gray;""border: 1px solid gray;")
-                self.label_14.setStyleSheet("color: gray;")
+            # self.label_6.setStyleSheet("color: gray;")
+            # self.label_7.setStyleSheet("color: gray;")
+            # self.label_8.setStyleSheet("color: gray;")
+            # self.BaseRewardSum.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
+            # self.RewardPairsN.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
+            # self.RewardFamily.setStyleSheet(f"color: gray;background-color: rgba(0, 0, 0, 0);border: 1px solid gray;border:{border_style};")
+            # self.label_20.setStyleSheet("color: black;")
+            # self.UncoupledReward.setStyleSheet("color: black;""border: 1px solid gray;")
+            # # block
+            # if self.Randomness.currentText()=='Exponential':
+            #     self.BlockBeta.setEnabled(True)
+            #     # self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
+            #     # self.label_14.setStyleSheet("color: black;")
+            # else:
+            #     self.BlockBeta.setEnabled(False)
+            #     self.BlockBeta.setStyleSheet("color: gray;""border: 1px solid gray;")
+            #     self.label_14.setStyleSheet("color: gray;")
             self.label_12.setEnabled(True)
             self.label_11.setEnabled(True)
             self.BlockMin.setEnabled(True)
             self.BlockMax.setEnabled(True)
-            self.label_12.setStyleSheet("color: black;")
-            self.label_11.setStyleSheet("color: black;")
-            self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.BlockMin.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.BlockMax.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.label_12.setStyleSheet("color: black;")
+            # self.label_11.setStyleSheet("color: black;")
+            # self.BlockBeta.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.BlockMin.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.BlockMax.setStyleSheet("color: black;""border: 1px solid gray;")
             self.label_27.setEnabled(False)
             self.InitiallyInactiveN.setEnabled(False)
-            self.label_27.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.InitiallyInactiveN.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.label_27.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.InitiallyInactiveN.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(1081, 23, 80, 20))
             # change name of min reward each block
             self.label_13.setText('min reward each block=')
@@ -1532,14 +1532,14 @@ class Window(QMainWindow):
             self.RewardFamily.setEnabled(True)
             self.label_20.setEnabled(False)
             self.UncoupledReward.setEnabled(False)
-            self.label_6.setStyleSheet("color: black;")
-            self.label_7.setStyleSheet("color: black;")
-            self.label_8.setStyleSheet("color: black;")
-            self.BaseRewardSum.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.RewardPairsN.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.RewardFamily.setStyleSheet("color: black;""border: 1px solid gray;")
-            self.label_20.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.UncoupledReward.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.label_6.setStyleSheet("color: black;")
+            # self.label_7.setStyleSheet("color: black;")
+            # self.label_8.setStyleSheet("color: black;")
+            # self.BaseRewardSum.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.RewardPairsN.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.RewardFamily.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.label_20.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.UncoupledReward.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
             # block
             self.label_14.setEnabled(False)
             self.label_12.setEnabled(False)
@@ -1547,17 +1547,17 @@ class Window(QMainWindow):
             self.BlockBeta.setEnabled(False)
             self.BlockMin.setEnabled(False)
             self.BlockMax.setEnabled(False)
-            self.label_14.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.label_12.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.label_11.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.BlockBeta.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.BlockMin.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-            self.BlockMax.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.label_14.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.label_12.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.label_11.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.BlockBeta.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.BlockMin.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
+            # self.BlockMax.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
             # block; no reward when initially active
             self.label_27.setEnabled(True)
             self.InitiallyInactiveN.setEnabled(True)
-            self.label_27.setStyleSheet("color: black;")
-            self.InitiallyInactiveN.setStyleSheet("color: black;""border: 1px solid gray;")
+            # self.label_27.setStyleSheet("color: black;")
+            # self.InitiallyInactiveN.setStyleSheet("color: black;""border: 1px solid gray;")
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(403, 128, 80, 20))
             # change name of min reward each block
             self.label_13.setText('RewardN=')
@@ -1571,7 +1571,6 @@ class Window(QMainWindow):
             # set block length to be 1
             self.BlockMin.setText('1')
             self.BlockMax.setText('1')
-        self._Randomness()
 
     def _ShowRewardPairs(self):
         '''Show reward pairs'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1444,6 +1444,17 @@ class Window(QMainWindow):
             # set block length to the default value
             #self.BlockMin.setText('20')
             #self.BlockMax.setText('60')
+            
+            # Reopen block beta, NextBlock, and AutoBlock panel
+            self.BlockBeta.setEnabled(True)
+            self.NextBlock.setEnabled(True)
+            
+            self.AdvancedBlockAuto.setEnabled(True)
+            self._AdvancedBlockAuto() # Update states of SwitchThr and PointsInARow
+            
+            self.BlockMinReward.setEnabled(True)
+            self.IncludeAutoReward.setEnabled(True)
+            
         elif self.Task.currentText() in ['Uncoupled Baiting','Uncoupled Without Baiting']:
             border_color = "rgb(100, 100, 100,80)"
             border_style = "1px solid " + border_color
@@ -1474,7 +1485,6 @@ class Window(QMainWindow):
                 self.label_14.setStyleSheet("color: gray;")
             self.label_12.setEnabled(True)
             self.label_11.setEnabled(True)
-            self.BlockBeta.setEnabled(True)
             self.BlockMin.setEnabled(True)
             self.BlockMax.setEnabled(True)
             self.label_12.setStyleSheet("color: black;")
@@ -1496,9 +1506,17 @@ class Window(QMainWindow):
             # move auto-reward
             self.IncludeAutoReward.setGeometry(QtCore.QRect(1080, 128, 80, 20))
             self.label_26.setGeometry(QtCore.QRect(929, 128, 146, 16))
-            # set block length to the default value
-            #self.BlockMin.setText('20')
-            #self.BlockMax.setText('60')
+            
+            # Disable block beta, NextBlock, and AutoBlock panel
+            self.BlockBeta.setEnabled(False)
+            self.NextBlock.setEnabled(False)
+            self.AdvancedBlockAuto.setEnabled(False)
+            self.SwitchThr.setEnabled(False)
+            self.PointsInARow.setEnabled(False)
+            self.BlockMinReward.setEnabled(False)
+            self.IncludeAutoReward.setEnabled(False)
+            
+            
         elif self.Task.currentText() in ['RewardN']:
             self.label_6.setEnabled(True)
             self.label_7.setEnabled(True)
@@ -2688,12 +2706,15 @@ class Window(QMainWindow):
                 GeneratedTrials.B_CurrentTrialN+=1
                 print('Current trial: '+str(GeneratedTrials.B_CurrentTrialN+1))
                 logging.info('Current trial: '+str(GeneratedTrials.B_CurrentTrialN+1))
-                if not (self.GeneratedTrials.TP_AutoReward  or int(self.GeneratedTrials.TP_BlockMinReward)>0):
-                    # generate a new trial and get reward
-                    self.NewTrialRewardOrder=1
+                if (self.GeneratedTrials.TP_AutoReward  or int(self.GeneratedTrials.TP_BlockMinReward)>0
+                    or self.GeneratedTrials.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']):
+                    # The next trial parameters must be dependent on the current trial's choice
+                    # get animal response and then generate a new trial
+                    self.NewTrialRewardOrder=0
                 else:
-                    # get reward and generate a new trial
-                    self.NewTrialRewardOrder=0    
+                    # By default, to save time, generate a new trial as early as possible
+                    # generate a new trial and then get animal response
+                    self.NewTrialRewardOrder=1   
  
                 #initiate the generated trial
                 try:

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -534,7 +534,7 @@
                       <x>0</x>
                       <y>0</y>
                       <width>178</width>
-                      <height>182</height>
+                      <height>199</height>
                      </rect>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout">
@@ -616,6 +616,18 @@
                        </property>
                        <property name="alignment">
                         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="WarningLabel_uncoupled_task">
+                       <property name="font">
+                        <font>
+                         <pointsize>7</pointsize>
+                        </font>
+                       </property>
+                       <property name="text">
+                        <string/>
                        </property>
                       </widget>
                      </item>
@@ -834,7 +846,7 @@
             <string notr="true"/>
            </property>
            <property name="currentIndex">
-            <number>1</number>
+            <number>0</number>
            </property>
            <widget class="QWidget" name="tab_2">
             <attribute name="title">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -13,7 +13,7 @@
     <x>0</x>
     <y>0</y>
     <width>1875</width>
-    <height>1032</height>
+    <height>1015</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -3054,6 +3054,24 @@
       </property>
       <property name="wordWrap">
        <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="WarningLabel_uncoupled_task">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>130</y>
+        <width>261</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>7</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string/>
       </property>
      </widget>
     </widget>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3056,24 +3056,6 @@
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QLabel" name="WarningLabel_uncoupled_task">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>130</y>
-        <width>261</width>
-        <height>16</height>
-       </rect>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>7</pointsize>
-       </font>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
     </widget>
    </widget>
    <widget class="QLineEdit" name="ID">
@@ -4362,6 +4344,24 @@
      <string>Streamlit!</string>
     </property>
    </widget>
+   <widget class="QLabel" name="WarningLabel_uncoupled_task">
+    <property name="geometry">
+     <rect>
+      <x>1240</x>
+      <y>870</y>
+      <width>261</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>7</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string/>
+    </property>
+   </widget>
    <zorder>PhotometryB</zorder>
    <zorder>infor</zorder>
    <zorder>line</zorder>
@@ -4393,6 +4393,7 @@
    <zorder>AutoTrain</zorder>
    <zorder>label_auto_train_stage</zorder>
    <zorder>pushButton_streamlit</zorder>
+   <zorder>WarningLabel_uncoupled_task</zorder>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -118,7 +118,8 @@ class GenerateTrials():
                 self._generate_next_coupled_block()
         elif self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']:
             # -- Use Han's standalone class --
-            if self.B_CurrentTrialN == -1:
+            if self.B_CurrentTrialN == -1 or \
+                not hasattr(self, 'uncoupled_blocks'): # Or the user start uncoupled in the midde of the session
                 # Get uncoupled task settings
                 self.RewardProbPoolUncoupled = self._get_uncoupled_reward_prob_pool()
                 
@@ -147,9 +148,9 @@ class GenerateTrials():
                 # Update self.BlockLenHistory from diff(block_ends)
                 # Note we don't need override_block_len here since all
                 # overrides are handled by the UncoupledBlocks object
-                self.BlockLenHistory[i] = np.diff(
+                self.BlockLenHistory[i] = list(np.diff(
                     [0] + self.uncoupled_blocks.block_ends[side]
-                )
+                ))
                 
             # Show msg
             self.win.WarningLabel_uncoupled_task.setText(msg_uncoupled_block)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -93,6 +93,7 @@ class GenerateTrials():
         self.Obj={}
         # get all of the training parameters of the current trial
         self._GetTrainingParameters(self.win)
+        
     def _GenerateATrial(self,Channel4):
         self.finish_select_par=0
         if self.win.UpdateParameters==1:
@@ -105,10 +106,15 @@ class GenerateTrials():
             self._LickSta([self.B_CurrentTrialN-1])
         # to decide if it's an auto water trial. will give water in _GetAnimalResponse
         self._CheckAutoWater()
+        
         # check block transition
         self._check_block_transition()
-        # Get reward probability and other trial related parameters
-        self._generate_next_trial_paras()
+        # Get reward probability
+        self._generate_next_trial_reward_prob()
+        
+        # Generate other parameters such as ITI, delay, and response time
+        self._generate_next_trial_other_paras()
+        
         # check if bait is permitted at the current trial
         self._CheckBaitPermitted()
         self.finish_select_par=1
@@ -284,7 +290,7 @@ class GenerateTrials():
         else:
             return np.max(length)
 
-    def _generate_next_trial_paras(self):
+    def _generate_next_trial_reward_prob(self):
         '''Select the training parameter of the next trial'''
         # determine the reward probability of the next trial based on tasks
         if (self.TP_Task in ['Coupled Baiting','Coupled Without Baiting','RewardN']) and any(self.B_ANewBlock==1):
@@ -350,8 +356,9 @@ class GenerateTrials():
                     self.BlockLenHistory[i].append(self.BlockLen)
                     self.B_ANewBlock[i]=0
 
-                    
         self.B_RewardProHistory=np.append(self.B_RewardProHistory,self.B_CurrentRewardProb.reshape(self.B_LickPortN,1),axis=1)
+
+    def _generate_next_trial_other_paras(self):
         # get the ITI time and delay time
         if self.TP_Randomness=='Exponential':
             self.CurrentITI = float(np.random.exponential(float(self.TP_ITIBeta),1)+float(self.TP_ITIMin))
@@ -391,6 +398,8 @@ class GenerateTrials():
             return  # Early return here
             
         # --- Decide block transition based on this block length ---
+        # self.BlockLenHistory is initialized as [[],[]] in __init__
+        # So the first block is also generated here
         for i in range(len(self.B_ANewBlock)):
             if self.B_CurrentTrialN+1>=sum(self.BlockLenHistory[i]):
                 self.B_ANewBlock[i]=1

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -124,8 +124,8 @@ class GenerateTrials():
                 # Initialize the UncoupledBlocks object and generate the first trial
                 self.uncoupled_blocks = UncoupledBlocks(                 
                     rwd_prob_array=self.RewardProbPoolUncoupled,
-                    block_min=self.TP_BlockMin, 
-                    block_max=self.TP_BlockMax,
+                    block_min=int(self.TP_BlockMin), 
+                    block_max=int(self.TP_BlockMax),
                     persev_add=True,  # Hard-coded to True for now
                     perseverative_limit=4, # Hard-coded to 4 for now
                     max_block_tally=3, # Hard-coded to 3 for now
@@ -139,6 +139,16 @@ class GenerateTrials():
                 self.uncoupled_blocks.next_trial()
             
             # Extract parameters from the UncoupledBlocks object
+            for i, side in enumerate(['L', 'R']):
+                # Update self.B_CurrentRewardProb from trial_rwd_prob
+                self.B_CurrentRewardProb[i] = self.uncoupled_blocks.trial_rwd_prob[side][-1]
+                
+                # Update self.BlockLenHistory from diff(block_ends)
+                # Note we don't need override_block_len here since all
+                # overrides are handled by the UncoupledBlocks object
+                self.BlockLenHistory[i] = np.diff(
+                    [0] + self.uncoupled_blocks.block_ends[side]
+                )
             
         # Append the (updated) current reward probability to the history 
         self.B_RewardProHistory=np.append(

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -108,7 +108,7 @@ class GenerateTrials():
         # check block transition
         self._check_block_transition()
         # Get reward probability and other trial related parameters
-        self._generate_next_reward_prob()
+        self._generate_next_trial_paras()
         # check if bait is permitted at the current trial
         self._CheckBaitPermitted()
         self.finish_select_par=1
@@ -284,7 +284,7 @@ class GenerateTrials():
         else:
             return np.max(length)
 
-    def _generate_next_reward_prob(self):
+    def _generate_next_trial_paras(self):
         '''Select the training parameter of the next trial'''
         # determine the reward probability of the next trial based on tasks
         if (self.TP_Task in ['Coupled Baiting','Coupled Without Baiting','RewardN']) and any(self.B_ANewBlock==1):

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1474,7 +1474,9 @@ class GenerateTrials():
                 if np.random.random(1)<0.1: # no response
                     self.B_AnimalCurrentResponse=2
                 else:
-                    if any(self.B_RewardedHistory[:,-1]==1):# win
+                    if np.random.random(1) < 0:  # Introduce a left bias if needed
+                        self.B_AnimalCurrentResponse = 0
+                    elif any(self.B_RewardedHistory[:,-1]==1):# win
                         self.B_AnimalCurrentResponse=self.B_AnimalResponseHistory[-1]
                     elif any(self.B_RewardedHistory[:,-1]==0) and self.B_AnimalResponseHistory[-1]!=2:# lose
                         self.B_AnimalCurrentResponse=1-self.B_AnimalResponseHistory[-1]

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -117,6 +117,7 @@ class GenerateTrials():
                 # assign the next block's reward prob to self.B_CurrentRewardProb 
                 self._generate_next_coupled_block()
         elif self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']:
+            # -- Use Han's standalone class --
             if self.B_CurrentTrialN == -1:
                 # Get uncoupled task settings
                 self.RewardProbPoolUncoupled = self._get_uncoupled_reward_prob_pool()
@@ -374,42 +375,6 @@ class GenerateTrials():
             self.BlockLenHistory[i].append(self.BlockLen)
         self.B_ANewBlock=np.array([0,0])
             
-        # elif (self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting'])  and any(self.B_ANewBlock==1):
-        #     # get the reward probabilities pool
-        #     for i in range(len(self.B_ANewBlock)):
-        #         if self.B_ANewBlock[i]==1:
-        #             input_string=self.win.UncoupledReward.text()
-        #             # remove any square brackets and spaces from the string
-        #             input_string = input_string.replace('[','').replace(']','').replace(',', ' ')
-        #             # split the remaining string into a list of individual numbers
-        #             num_list = input_string.split()
-        #             # convert each number in the list to a float
-        #             num_list = [float(num) for num in num_list]
-        #             # create a numpy array from the list of numbers
-        #             RewardProbPool=np.array(num_list)
-        #             self.RewardProbPoolUncoupled=RewardProbPool.copy()
-        #             # exclude the previous reward probabilities
-        #             if self.B_RewardProHistory.size!=0:
-        #                 RewardProbPool=RewardProbPool[RewardProbPool!=self.B_RewardProHistory[i,-1]]
-        #             # exclude pairs with small reward size (temporarily)
-        #             if (i==0 and self.B_CurrentRewardProb[1]==0.1) or (i==1 and self.B_CurrentRewardProb[0]==0.1):
-        #                     RewardProbPool=RewardProbPool[RewardProbPool!=0.1]
-        #             # get the reward probabilities of the current block
-        #             self.B_CurrentRewardProb[i]=RewardProbPool[random.choice(range(np.shape(RewardProbPool)[0]))]
-        #             # "if one spout was assigned a reward probability greater than or equal to the reward probability of the other spout for 3 consecutive blocks, the probability of that spout was set to 0.1 to encourage switching behavior and limit the creation of a direction bias"
-        #             if np.shape(self.BlockLenHistory[i])[0]>=3:
-        #                 total_trial=np.sum(self.BlockLenHistory[i][-3:])
-        #                 if np.all(self.B_RewardProHistory[i][-total_trial:]>=self.B_RewardProHistory[1-i][-total_trial:]):
-        #                     self.B_CurrentRewardProb[i]=0.1
-        #             # randomly draw a block length between Min and Max
-        #             if self.TP_Randomness=='Exponential':
-        #                 self.BlockLen = np.array(int(np.random.exponential(float(self.TP_BlockBeta),1)+float(self.TP_BlockMin)))
-        #             elif self.TP_Randomness=='Even':
-        #                 self.BlockLen=  np.array(np.random.randint(float(self.TP_BlockMin), float(self.TP_BlockMax)+1))
-        #             if self.BlockLen>float(self.TP_BlockMax):
-        #                 self.BlockLen=int(self.TP_BlockMax)
-        #             self.BlockLenHistory[i].append(self.BlockLen)
-        #             self.B_ANewBlock[i]=0
 
     def _generate_next_trial_other_paras(self):
         # get the ITI time and delay time
@@ -476,16 +441,6 @@ class GenerateTrials():
                 or self.AdvancedBlockSwitchPermitted==0:
                 self.B_ANewBlock=np.zeros_like(self.B_ANewBlock)
                 self._override_block_len(range(len(self.B_ANewBlock)))
-        # elif self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']:
-        #     # For uncoupled task, hold block switch on each side separately 
-        #     # (this is actually problematic!!)
-        #     for i in range(len(self.B_ANewBlock)):
-        #         if self.B_ANewBlock[i]==1 and (
-        #             self.BS_RewardedTrialN_CurrentBlock[i] < float(self.TP_BlockMinReward) 
-        #             or self.AdvancedBlockSwitchPermitted==0
-        #             ) and self.AllRewardThisBlock!=-1:
-        #             self.B_ANewBlock[i]=0
-        #             self._override_block_len([i])
                         
     def _override_block_len(self,ind):
         '''Get the block length and update the block length history'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -118,14 +118,17 @@ class GenerateTrials():
                 self._generate_next_coupled_block()
         elif self.TP_Task in ['Uncoupled Baiting','Uncoupled Without Baiting']:
             if self.B_CurrentTrialN == -1:
+                # Get uncoupled task settings
+                self.RewardProbPoolUncoupled = self._get_uncoupled_reward_prob_pool()
+                
                 # Initialize the UncoupledBlocks object and generate the first trial
                 self.uncoupled_blocks = UncoupledBlocks(                 
-                    rwd_prob_array=[0.1, 0.5, 0.9],
-                    block_min=20, 
-                    block_max=35,
-                    persev_add=True, 
-                    perseverative_limit=4,
-                    max_block_tally=3,
+                    rwd_prob_array=self.RewardProbPoolUncoupled,
+                    block_min=self.TP_BlockMin, 
+                    block_max=self.TP_BlockMax,
+                    persev_add=True,  # Hard-coded to True for now
+                    perseverative_limit=4, # Hard-coded to 4 for now
+                    max_block_tally=3, # Hard-coded to 3 for now
                 )
                 self.uncoupled_blocks.next_trial()
             else:
@@ -135,7 +138,7 @@ class GenerateTrials():
                 )
                 self.uncoupled_blocks.next_trial()
             
-            # 
+            # Extract parameters from the UncoupledBlocks object
             
         # Append the (updated) current reward probability to the history 
         self.B_RewardProHistory=np.append(
@@ -235,6 +238,18 @@ class GenerateTrials():
             state='on'
         self.win.Opto_dialog.SessionControlWarning.setText('Session control state: '+state)
         self.win.Opto_dialog.SessionControlWarning.setStyleSheet(self.win.default_warning_color)    
+
+    def _get_uncoupled_reward_prob_pool(self):
+        # Get reward prob pool from the input string (e.g., ["0.1", "0.5", "0.9"])
+        input_string = self.win.UncoupledReward.text()
+        # remove any square brackets and spaces from the string
+        input_string = input_string.replace('[','').replace(']','').replace(',', ' ')
+        # split the remaining string into a list of individual numbers
+        num_list = input_string.split()
+        # convert each number in the list to a float
+        num_list = [float(num) for num in num_list]
+        # return a numpy array from the list of numbers
+        return np.array(num_list)
 
     def _CheckWarmUp(self):
         '''Check if we should turn on warm up'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -131,13 +131,13 @@ class GenerateTrials():
                     perseverative_limit=4, # Hard-coded to 4 for now
                     max_block_tally=3, # Hard-coded to 3 for now
                 )
-                self.uncoupled_blocks.next_trial()
+                _, msg_uncoupled_block = self.uncoupled_blocks.next_trial()
             else:
                 # Add animal's last choice and generate the next trial
                 self.uncoupled_blocks.add_choice(
                     ['L', 'R', 'ignored'][int(self.B_AnimalResponseHistory[-1])]
                 )
-                self.uncoupled_blocks.next_trial()
+                _, msg_uncoupled_block = self.uncoupled_blocks.next_trial()
             
             # Extract parameters from the UncoupledBlocks object
             for i, side in enumerate(['L', 'R']):
@@ -150,6 +150,9 @@ class GenerateTrials():
                 self.BlockLenHistory[i] = np.diff(
                     [0] + self.uncoupled_blocks.block_ends[side]
                 )
+                
+            # Show msg
+            self.win.WarningLabel_uncoupled_task.setText(msg_uncoupled_block)
             
         # Append the (updated) current reward probability to the history 
         self.B_RewardProHistory=np.append(

--- a/src/foraging_gui/reward_schedules/random_walk.py
+++ b/src/foraging_gui/reward_schedules/random_walk.py
@@ -1,0 +1,100 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib
+# matplotlib.use('Qt5Agg')
+
+#  np.random.seed(56)
+
+class RandomWalkReward:
+    '''
+    Generate reward schedule with random walk
+
+    (see Miller et al. 2021, https://www.biorxiv.org/content/10.1101/461129v3.full.pdf)
+    '''
+
+    def __init__(self,
+                 p_min=[0, 0],  # L and R
+                 p_max=[1, 1], # L and R 
+                 sigma=[0.15, 0.15],  # L and R
+                 mean=[0, 0],         # L and R
+                 ) -> None:
+        
+        self.__dict__.update(locals())
+        
+        if not type(sigma) == list:
+            sigma = [sigma, sigma]  # Backward compatibility
+            
+        if not type(p_min) == list:
+            p_min = [p_min, p_min]  # Backward compatibility
+
+        if not type(p_max) == list:
+            p_max = [p_max, p_max]  # Backward compatibility
+       
+        self.p_min, self.p_max, self.sigma, self.mean = p_min, p_max, sigma, mean
+                   
+        self.trial_rwd_prob = {'L':[], 'R': []}  # Rwd prob per trial
+        self.choice_history = []
+
+        self.hold_this_block = False
+        self.first_trial()
+    
+    def first_trial(self): 
+        self.trial_now = 0
+        for i, side in enumerate(['L', 'R']):
+            self.trial_rwd_prob[side].append(np.random.uniform(self.p_min[i], self.p_max[i]))
+            
+    def next_trial(self):
+        self.trial_now += 1
+        for i, side in enumerate(['L', 'R']):
+            if not self.hold_this_block:
+                p = np.random.normal(self.trial_rwd_prob[side][-1] + self.mean[i], self.sigma[i])
+                p = min(self.p_max[i], max(self.p_min[i], p))
+            else:
+                p = self.trial_rwd_prob[side][-1]
+            self.trial_rwd_prob[side].append(p)
+
+    def add_choice(self, this_choice):
+        self.choice_history.append(this_choice)
+
+    def auto_corr(self, data):
+        mean = np.mean(data)
+        # Variance
+        var = np.var(data)
+        # Normalized data
+        ndata = data - mean
+        acorr = np.correlate(ndata, ndata, 'full')[len(ndata)-1:] 
+        acorr = acorr / var / len(ndata)
+        return acorr
+
+    def plot_reward_schedule(self):
+        fig, ax = plt.subplots(2, 2, figsize=[15, 7], sharex='col', gridspec_kw=dict(width_ratios=[4, 1], wspace=0.1))
+
+        for s, col in zip(['L', 'R'], ['r', 'b']):
+            ax[0, 0].plot(self.trial_rwd_prob[s], col, marker='.', alpha=0.5, lw=2)
+            ax[0, 1].plot(self.auto_corr(self.trial_rwd_prob[s]), col)
+
+        ax[1, 0].plot(np.array(self.trial_rwd_prob['L']) + np.array(self.trial_rwd_prob['R']), label='sum')
+        ax[1, 0].plot(np.array(self.trial_rwd_prob['R']) / (np.array(self.trial_rwd_prob['L']) + np.array(self.trial_rwd_prob['R'])), label='R/(L+R)')
+        ax[1, 0].legend()
+
+        ax[0, 1].set(title='auto correlation', xlim=[0, 100])
+        ax[0, 1].axhline(y=0, c='k', ls='--')
+
+        plt.show()
+        
+
+if __name__ == '__main__':
+    total_trial = 1000
+
+    reward_schedule = RandomWalkReward(p_min=[0.1, 0.1], p_max=0.9, sigma=[0.1, 0.1], mean=[-0.0, 0.0]) 
+
+    while reward_schedule.trial_now <= total_trial:    
+        reward_schedule.next_trial()
+        '''
+        run protocol here
+        '''
+
+    reward_schedule.plot_reward_schedule()
+    
+    pass
+    # %%

--- a/src/foraging_gui/reward_schedules/uncoupled_block.py
+++ b/src/foraging_gui/reward_schedules/uncoupled_block.py
@@ -1,0 +1,212 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.use('Qt5Agg')
+
+#  np.random.seed(56)
+
+class UncoupledBlocks:
+    '''
+    Generate uncoupled block reward schedule
+    (by on-line updating)
+
+    adapted from Cohen lab's Arduino code (with some bug fixes?)
+    '''
+
+    def __init__(self,
+                 rwd_prob_array=[0.1, 0.5, 0.9],
+                 block_min=20, block_max=35,
+                 persev_add=True, perseverative_limit=4,
+                 max_block_tally=4,  # Max number of consecutive blocks in which one side has higher rwd prob than the other
+                 ) -> None:
+        
+        self.__dict__.update(locals())
+        self.block_stagger = int((round(block_max - block_min - 0.5) / 2 + block_min) / 2)
+        
+        self.rwd_tally = {'L': 0, 'R': 0}
+        self.trial_now = -1  # Index of trial number, starting from 0
+
+        self.block_ends = {'L': [], 'R': []} # Trial number on which each block ends
+        self.block_rwd_prob = {'L':[], 'R':[]}  # Reward probability
+        self.block_ind = {'L': 0, 'R': 0}  # Index of current block (= len(block_end_at_trial))
+
+        self.trial_rwd_prob = {'L':[], 'R': []}  # Rwd prob per trial
+
+        self.force_by_tally = {'L':[], 'R': []}
+        self.force_by_both_lowest = {'L':[], 'R': []}
+
+        # Anti-persev
+        self.persev_add, self.perseverative_limit = persev_add, perseverative_limit
+        self.persev_consec_on_min_prob = {'L': 0, 'R': 0}
+        self.persev_add_at_trials = []
+        self.choice_history = []
+
+        # Manually block hold
+        self.hold_this_block = False
+        
+        self.generate_first_block()
+    
+    def generate_first_block(self):    
+        for side in ['L', 'R']:
+            self.generate_next_block(side)
+            
+        # Avoid both blocks have the lowest reward prob
+        while np.all([x[0] == np.min(self.rwd_prob_array) for x in self.block_rwd_prob.values()]):
+            self.block_rwd_prob[np.random.choice(['L', 'R'])][0] = np.random.choice(self.rwd_prob_array)  # Random change one side to another prob
+        
+        # Start with block stagger: the lower side makes the first block switch earlier
+        smaller_side = min(self.block_rwd_prob, key=lambda x: self.block_rwd_prob[x][0])
+        self.block_ends[smaller_side][0] -= self.block_stagger
+        
+        self.block_effective_ind = 1  # Effective block ind
+
+    def generate_next_block(self, side, check_higher_in_a_row=True, check_both_lowest=True):
+        other_side = list({'L', 'R'} - {side})[0]
+        random_block_len = np.random.randint(low=self.block_min, high=self.block_max + 1)
+        
+        if self.block_ind[side] == 0:  # The first block
+            self.block_ends[side].append(random_block_len)
+            self.block_rwd_prob[side].append(np.random.choice(self.rwd_prob_array))
+            
+        else:  # Not the first block
+            self.block_ends[side].append(random_block_len + self.block_ends[side][self.block_ind[side] - 1])       
+            
+            # If this side has higher prob for too long, force it to be the lowest
+            if check_higher_in_a_row:
+                # For each effective block, update number of times each side >= the other side
+                this_prev = self.block_rwd_prob[side][self.block_ind[side] - 1]
+                other_now = self.block_rwd_prob[other_side][self.block_ind[other_side]]
+                if this_prev > other_now:
+                    self.rwd_tally[side] += 1
+                    self.rwd_tally[other_side] = 0
+                elif this_prev == other_now:
+                    self.rwd_tally[side] += 1
+                    self.rwd_tally[other_side] += 1
+                else:
+                    self.rwd_tally[other_side] += 1
+                    self.rwd_tally[side] = 0
+                
+                if self.rwd_tally[side] >= self.max_block_tally:  # Only check higher-in-a-row for this side
+                    print(f'--- {self.trial_now}: {side} is higher for {self.rwd_tally[side]} eff_blocks, force {side} to lowest ---')
+                    self.block_rwd_prob[side].append(min(self.rwd_prob_array))
+                    self.rwd_tally[side] = self.rwd_tally[other_side] = 0            
+                    self.force_by_tally[side].append(self.trial_now)
+                else:  # Otherwise, randomly choose one
+                    self.block_rwd_prob[side].append(np.random.choice(self.rwd_prob_array))
+            else:               
+                self.block_rwd_prob[side].append(np.random.choice(self.rwd_prob_array))
+            
+            # Don't repeat the previous rwd prob 
+            # (this will not mess up with the "forced" case since the previous block cannot be the lowest prob in the first place)
+            while self.block_rwd_prob[side][-2] == self.block_rwd_prob[side][-1]:
+                self.block_rwd_prob[side][-1] = np.random.choice(self.rwd_prob_array)
+                
+            # If the other side is already at the lowest prob AND this side just generates the same
+            # (either through "forced" case or not), push the previous lowest side to a higher prob
+            if check_both_lowest and self.block_rwd_prob[side][-1] == self.block_rwd_prob[other_side][-1] == min(self.rwd_prob_array):
+                # Stagger this side
+                self.block_ends[side][-1] -= self.block_stagger
+                
+                # Force block switch of the other side
+                print(f'--- {self.trial_now}: both side is the lowest, push {side} to higher ---')
+                self.force_by_both_lowest[side].append(self.trial_now)
+                self.block_ends[other_side][-1] = self.trial_now
+                self.block_ind[other_side] += 1  # Two sides change at the same time, no need to add block_effective_ind twice
+                self.generate_next_block(other_side, check_higher_in_a_row=False, check_both_lowest=False)  # Just generate new block, no need to do checks
+
+    def auto_shape_perseverance(self):
+        for s in ['L', 'R']:
+            if self.choice_history[-1] == s:
+                self.persev_consec_on_min_prob[list({'L', 'R'} - {s})[0]] = 0  # Reset other side as soon as there is an opposite choice
+                if self.trial_rwd_prob[s][-2] == min(self.rwd_prob_array):   # If last choice is on side with min_prob (0.1), add counter
+                    self.persev_consec_on_min_prob[s] += 1  
+
+        for s in ['L', 'R']:
+            if self.persev_consec_on_min_prob[s] >= self.perseverative_limit:
+                for ss in ['L', 'R']:
+                    self.block_ends[ss][-1] += self.perseverative_limit   # Add 'perseverative_limit' trials to both blocks
+                    self.persev_consec_on_min_prob[ss] = 0
+                print(f'persev at side = {s}, added {self.perseverative_limit} trials to both sides')
+                self.persev_add_at_trials.append(self.trial_now)
+
+    def add_choice(self, this_choice):
+        self.choice_history.append(this_choice)
+
+    def next_trial(self):
+        self.trial_now += 1  # Starts from 0; initialized from -1
+        
+        # Block switch?
+        if not self.hold_this_block:
+            for s in ['L', 'R']:
+                if self.trial_now >= self.block_ends[s][self.block_ind[s]]:
+                    # In case a block is mannually 'held', update the actual block transition 
+                    self.block_ends[s][self.block_ind[s]] = self.trial_now  
+
+                    self.block_ind[s] += 1
+                    self.block_effective_ind += 1
+                    self.generate_next_block(s, check_higher_in_a_row=True, check_both_lowest=True)
+
+        # Fill new value
+        for s in ['L', 'R']:
+            self.trial_rwd_prob[s].append(self.block_rwd_prob[s][self.block_ind[s]])
+
+        # Anti-persev
+        if not self.hold_this_block and self.persev_add and len(self.choice_history):
+            self.auto_shape_perseverance()
+        else:
+            for s in ['L', 'R']:
+                self.persev_consec_on_min_prob[s] = 0
+        
+        assert (self.trial_now + 1) == len(self.trial_rwd_prob['L']) == len(self.trial_rwd_prob['R'])
+        assert all([self.block_ind['L'] + 1 == len(self.block_rwd_prob['L']) == len(self.block_ends['L']) for s in ['L', 'R']])
+
+        return ([self.trial_rwd_prob[s][-2] != self.trial_rwd_prob[s][-1] for s in ['L', 'R']]  # Whether block just switched
+                if self.trial_now > 0 else [0, 0])
+    
+    def plot_reward_schedule(self):
+        fig, ax = plt.subplots(2, 1, figsize=[15, 7], sharex='col')
+
+        def annotate_block(ax):
+            for s, col in zip(['L', 'R'], ['r', 'b']):
+                [ax.axvline(x + (0.1 if s=='R' else 0), 0, 1, color=col, ls='--', lw=0.5) for x in self.block_ends[s]]
+                [ax.plot(x, 1.2, marker='>', color=col) for x in self.force_by_tally[s]]
+                [ax.plot(x, 1.1, marker='v', color=col) for x in self.force_by_both_lowest[s]]
+     
+            for s, col, pos, m in zip(['L', 'R', 'ignored'], ['r', 'b', 'k'], [0, 1, 0.95], ['|', '|', 'x']):
+                this_choice = np.where(np.array(self.choice_history) == s)
+                ax.plot(this_choice, [pos] * len(this_choice), m, color=col)
+            
+            ax.plot(self.persev_add_at_trials, [1.05] * len(self.persev_add_at_trials), marker='+', ls='', color='c')
+
+        for s, col in zip(['L', 'R'], ['r', 'b']):
+            ax[0].plot(self.trial_rwd_prob[s], col, marker='.', alpha=0.5, lw=2)
+        annotate_block(ax[0])
+
+        ax[1].plot(np.array(self.trial_rwd_prob['L']) + np.array(self.trial_rwd_prob['R']), label='sum')
+        ax[1].plot(np.array(self.trial_rwd_prob['R']) / (np.array(self.trial_rwd_prob['L']) + np.array(self.trial_rwd_prob['R'])), label='R/(L+R)')
+        ax[1].legend()
+        annotate_block(ax[1])
+
+        plt.show()
+        
+
+if __name__ == '__main__':
+    total_trial = 1000
+
+    reward_schedule = UncoupledBlocks(perseverative_limit=4) 
+
+    while reward_schedule.trial_now <= total_trial:    
+        reward_schedule.next_trial()
+        '''
+        run protocol here
+        '''
+        reward_schedule.add_choice(['L', 'R', 'ignored'][np.random.choice([0]*100 + [1]*20 + [2]*1)])
+
+        reward_schedule.hold_this_block = 500 < reward_schedule.trial_now < 700
+
+
+    reward_schedule.plot_reward_schedule()
+    print(f'effective blocks = {reward_schedule.block_effective_ind}')
+    
+    pass
+    # %%


### PR DESCRIPTION
### Describe changes:
- Use the same uncoupled task logic as in Grossman 2022 and Su 2022 (Python implementation of the Arduino code)
- Use `anti_perseverative` to fight against bias in uncoupled tasks
    - However, I hardcode perserverative_limit = 4 and max_block_tally = 3 for now
- Accordingly, the following block controls are disabled because they don't make much sense when blocks are uncoupled:
  - The manual "NextBlock" button (maybe we'll add "NextLeftBlock" and "NextRightBlock" in the future)
  - Block hold based on `BlockMinReward`
  - Block hold based on `AdvancedBlock` (recent choice proportion)

### What issues or discussions does this update address?
- Replaces #204 
- Finally resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/36
- Resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/169#issuecomment-1911041687
- Resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/239
- Resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/261

### Describe the expected change in behavior from the perspective of the experimenter
- The uncoupled blocks should be more balanced.
- The anti-perseverative is harded coded and turned on by default, like in Grossman and Su's papers.

### Describe the outcome of testing this update on a rig in 447
- [x] tested on my PC
    - [x] Uncoupled task matches the one described in Grossman et al 
    - [x] Uncoupled task responds correctly to a biased agent
    - [x] Has no interference with Coupled / Reward N task, and the user can switch among them smoothly
    - [x] Works well with warmup and autotrain




