### PR TITLE
Adds an updating timer for the photometry baseline

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2463,11 +2463,10 @@ class Window(QMainWindow):
         '''
             Updates photometry baseline timer
         '''
-        logging.info('updating photometry baseline timer')
         minutes = int(np.floor(time/60))
         seconds = np.remainder(time,60)
-        if seconds == 0:
-            seconds = '00'
+        if len(str(seconds) == 1:
+            seconds = '0{}'.format(seconds)
         self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))
         self.WarningLabelStop.setStyleSheet(self.default_warning_color)       
      
@@ -2630,7 +2629,7 @@ class Window(QMainWindow):
             self.workertimer.moveToThread(self.workertimer_thread)
             self.workertimer_thread.start()
 
-            self.Time.emit(int(float(self.baselinetime.text())*60)) 
+            self.Time.emit(int(np.floor(float(self.baselinetime.text())*60))) 
             self.WarningLabelStop.setText('Running photometry baseline')
             self.WarningLabelStop.setStyleSheet(self.default_warning_color)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2198,6 +2198,9 @@ class Window(QMainWindow):
         if self.StartExcitation.isChecked():
             logging.info('StartExcitation is checked')
             self.StartExcitation.setStyleSheet("background-color : green;")
+            ## DEBUGGING CODE
+            self.TeensyWarning.setText('')
+            self.TeensyWarning.setStyleSheet(self.default_warning_color)   
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
                 # Trigger Teensy with the above specified exp mode

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2627,9 +2627,9 @@ class Window(QMainWindow):
             self.finish_Timer=0
             self.PhotometryRun=1
             workertimer = TimerWorker()#self._Timer,float(self.baselinetime.text())*60)
-            workertimer.signals.finished.connect(self._thread_complete_timer)
-            workertimer.signals.progress.connect(self._update_photometery_timer)
-            workertimer.signals.Time.connect(workertimer._Timer)
+            workertimer.finished.connect(self._thread_complete_timer)
+            workertimer.progress.connect(self._update_photometery_timer)
+            workertimer.Time.connect(workertimer._Timer)
             self.threadpool_workertimer.start(workertimer)
             self.Time.emit(int(float(self.baselinetime.text())*60)) 
             self.WarningLabelStop.setText('Running photometry baseline')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2200,10 +2200,6 @@ class Window(QMainWindow):
         if self.StartExcitation.isChecked():
             logging.info('StartExcitation is checked')
             self.StartExcitation.setStyleSheet("background-color : green;")
-            ## DEBUGGING CODE
-            self.TeensyWarning.setText('')
-            self.TeensyWarning.setStyleSheet(self.default_warning_color)   
-            return
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
                 # Trigger Teensy with the above specified exp mode

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2621,6 +2621,8 @@ class Window(QMainWindow):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
+            
+            # If we already created a workertimer and thread we can reuse them
             if not hasattr(self, 'workertimer'):
                 self.workertimer = TimerWorker()
                 self.workertimer_thread = QThread()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -41,6 +41,8 @@ class NumpyEncoder(json.JSONEncoder):
         return super(NumpyEncoder, self).default(obj)
     
 class Window(QMainWindow):
+    Time = QtCore.pyqtSignal(int)
+
     def __init__(self, parent=None,box_number=1,start_bonsai_ide=True):
         logging.info('Creating Window')
         super().__init__(parent)
@@ -109,7 +111,7 @@ class Window(QMainWindow):
         self.TimeDistribution_ToInitializeVisual=1
         self.finish_Timer=1     # for photometry baseline recordings
         self.PhotometryRun=0    # 1. Photometry has been run; 0. Photometry has not been carried out.
-        self.Time = QtCore.pyqtSignal(int)
+
         self._Optogenetics()    # open the optogenetics panel 
         self._LaserCalibration()# to open the laser calibration panel
         self._WaterCalibration()# to open the water calibration panel

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -41,7 +41,7 @@ class NumpyEncoder(json.JSONEncoder):
         return super(NumpyEncoder, self).default(obj)
     
 class Window(QMainWindow):
-    Time = QtCore.pyqtSignal(int)
+    Time = QtCore.pyqtSignal(int) # Photometry timer signal
 
     def __init__(self, parent=None,box_number=1,start_bonsai_ide=True):
         logging.info('Creating Window')
@@ -111,7 +111,6 @@ class Window(QMainWindow):
         self.TimeDistribution_ToInitializeVisual=1
         self.finish_Timer=1     # for photometry baseline recordings
         self.PhotometryRun=0    # 1. Photometry has been run; 0. Photometry has not been carried out.
-
         self._Optogenetics()    # open the optogenetics panel 
         self._LaserCalibration()# to open the laser calibration panel
         self._WaterCalibration()# to open the water calibration panel
@@ -2461,23 +2460,17 @@ class Window(QMainWindow):
         self.WarningLabelStop.setStyleSheet(self.default_warning_color)
    
     def _update_photometery_timer(self,time):
+        '''
+            Updates photometry baseline timer
+        '''
+        logging.info('updating photometry baseline timer')
         minutes = int(np.floor(time/60))
         seconds = np.remainder(time,60)
-        logging.info('updating photometry baseline timer')
+        if seconds == 0:
+            seconds = '00'
         self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))
         self.WarningLabelStop.setStyleSheet(self.default_warning_color)       
- 
-    def _Timer(self,Time):
-        '''sleep some time'''
-        num_updates = np.mod(Time,15)
-        while num_updates >0:
-            time.sleep(15)
-            Time -=15
-            self.progress.emit(int(Time))
-            logging.info('emitting photometry baseline timer progress')
-            num_updates += 1
-        time.sleep(Time)
-    
+     
     def _set_metadata_enabled(self, enable: bool):
         '''Enable or disable metadata fields'''
         self.ID.setEnabled(enable)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2465,7 +2465,7 @@ class Window(QMainWindow):
         '''
         minutes = int(np.floor(time/60))
         seconds = np.remainder(time,60)
-        if len(str(seconds) == 1:
+        if len(str(seconds)) == 1:
             seconds = '0{}'.format(seconds)
         self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))
         self.WarningLabelStop.setStyleSheet(self.default_warning_color)       

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -109,6 +109,7 @@ class Window(QMainWindow):
         self.TimeDistribution_ToInitializeVisual=1
         self.finish_Timer=1     # for photometry baseline recordings
         self.PhotometryRun=0    # 1. Photometry has been run; 0. Photometry has not been carried out.
+        self.Time = QtCore.pyqtSignal(int)
         self._Optogenetics()    # open the optogenetics panel 
         self._LaserCalibration()# to open the laser calibration panel
         self._WaterCalibration()# to open the water calibration panel
@@ -2626,14 +2627,14 @@ class Window(QMainWindow):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
-            self.Time = QtCore.pyqtSignal(int)
-            self.workertimer = TimerWorker()#self._Timer,float(self.baselinetime.text())*60)
-            self.workertimer.finished.connect(self._thread_complete_timer)
-            self.workertimer.progress.connect(self._update_photometery_timer)
-            self.Time.connect(self.workertimer._Timer)
+            self.workertimer = TimerWorker()
             self.workertimer_thread = QThread()
+            self.workertimer.progress.connect(self._update_photometery_timer)
+            self.workertimer.finished.connect(self._thread_complete_timer)
+            self.Time.connect(self.workertimer._Timer)
             self.workertimer.moveToThread(self.workertimer_thread)
             self.worker_thread.start()
+
             self.Time.emit(int(float(self.baselinetime.text())*60)) 
             self.WarningLabelStop.setText('Running photometry baseline')
             self.WarningLabelStop.setStyleSheet(self.default_warning_color)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2461,7 +2461,7 @@ class Window(QMainWindow):
         self.WarningLabelStop.setStyleSheet(self.default_warning_color)
    
     def _update_photometery_timer(self,time):
-        minutes = np.mod(time, 60)
+        minutes = int(np.floor(time/60))
         seconds = np.remainder(time,60)
         logging.info('updating photometry baseline timer')
         self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -16,7 +16,7 @@ from scipy.io import savemat, loadmat
 from PyQt5.QtWidgets import QApplication, QMainWindow, QMessageBox
 from PyQt5.QtWidgets import QFileDialog,QVBoxLayout,QLineEdit
 from PyQt5 import QtWidgets,QtGui,QtCore, uic
-from PyQt5.QtCore import QThreadPool,Qt
+from PyQt5.QtCore import QThreadPool,Qt,QThread
 from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 
@@ -2626,11 +2626,14 @@ class Window(QMainWindow):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
-            workertimer = TimerWorker()#self._Timer,float(self.baselinetime.text())*60)
-            workertimer.finished.connect(self._thread_complete_timer)
-            workertimer.progress.connect(self._update_photometery_timer)
-            workertimer.Time.connect(workertimer._Timer)
-            self.threadpool_workertimer.start(workertimer)
+            self.Time = QtCore.pyqtSignal(int)
+            self.workertimer = TimerWorker()#self._Timer,float(self.baselinetime.text())*60)
+            self.workertimer.finished.connect(self._thread_complete_timer)
+            self.workertimer.progress.connect(self._update_photometery_timer)
+            self.Time.connect(self.workertimer._Timer)
+            self.workertimer_thread = QThread()
+            self.workertimer.moveToThread(self.workertimer_thread)
+            self.worker_thread.start()
             self.Time.emit(int(float(self.baselinetime.text())*60)) 
             self.WarningLabelStop.setText('Running photometry baseline')
             self.WarningLabelStop.setStyleSheet(self.default_warning_color)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2635,7 +2635,7 @@ class Window(QMainWindow):
             self.workertimer.finished.connect(self._thread_complete_timer)
             self.Time.connect(self.workertimer._Timer)
             self.workertimer.moveToThread(self.workertimer_thread)
-            self.worker_thread.start()
+            self.workertimer_thread.start()
 
             self.Time.emit(int(float(self.baselinetime.text())*60)) 
             self.WarningLabelStop.setText('Running photometry baseline')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2621,13 +2621,14 @@ class Window(QMainWindow):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
-            self.workertimer = TimerWorker()
-            self.workertimer_thread = QThread()
-            self.workertimer.progress.connect(self._update_photometery_timer)
-            self.workertimer.finished.connect(self._thread_complete_timer)
-            self.Time.connect(self.workertimer._Timer)
-            self.workertimer.moveToThread(self.workertimer_thread)
-            self.workertimer_thread.start()
+            if not hasattr(self, 'workertimer'):
+                self.workertimer = TimerWorker()
+                self.workertimer_thread = QThread()
+                self.workertimer.progress.connect(self._update_photometery_timer)
+                self.workertimer.finished.connect(self._thread_complete_timer)
+                self.Time.connect(self.workertimer._Timer)
+                self.workertimer.moveToThread(self.workertimer_thread)
+                self.workertimer_thread.start()
 
             self.Time.emit(int(np.floor(float(self.baselinetime.text())*60))) 
             self.WarningLabelStop.setText('Running photometry baseline')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -26,7 +26,7 @@ from foraging_gui.Dialogs import OptogeneticsDialog,WaterCalibrationDialog,Camer
 from foraging_gui.Dialogs import LaserCalibrationDialog
 from foraging_gui.Dialogs import LickStaDialog,TimeDistributionDialog
 from foraging_gui.Dialogs import AutoTrainDialog
-from foraging_gui.MyFunctions import GenerateTrials, Worker,NewScaleSerialY
+from foraging_gui.MyFunctions import GenerateTrials, Worker,TimerWorker, NewScaleSerialY
 from foraging_gui.stage import Stage
 from foraging_gui.TransferToNWB import bonsai_to_nwb
 
@@ -2626,10 +2626,12 @@ class Window(QMainWindow):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
-            workertimer = Worker(self._Timer,float(self.baselinetime.text())*60)
+            workertimer = TimerWorker()#self._Timer,float(self.baselinetime.text())*60)
             workertimer.signals.finished.connect(self._thread_complete_timer)
             workertimer.signals.progress.connect(self._update_photometery_timer)
+            workertimer.signals.Time.connect(workertimer._Timer)
             self.threadpool_workertimer.start(workertimer)
+            self.Time.emit(int(float(self.baselinetime.text())*60)) 
             self.WarningLabelStop.setText('Running photometry baseline')
             self.WarningLabelStop.setStyleSheet(self.default_warning_color)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2460,6 +2460,7 @@ class Window(QMainWindow):
     def _update_photometery_timer(self,time):
         minutes = np.mod(time, 60)
         seconds = np.remainder(time,60)
+        logging.info('updating photometry baseline timer')
         self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))
         self.WarningLabelStop.setStyleSheet(self.default_warning_color)       
  
@@ -2470,6 +2471,7 @@ class Window(QMainWindow):
             time.sleep(15)
             Time -=15
             self.progress.emit(int(Time))
+            logging.info('emitting photometry baseline timer progress')
             num_updates += 1
         time.sleep(Time)
     

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1849,6 +1849,6 @@ class TimerWorker(QtCore.QRunnable):
             logging.info('emitting photometry baseline timer progress')
             num_updates += 1
         time.sleep(Time)
-        self.signals.finished.emit()
+        self.finished.emit()
 
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1841,6 +1841,8 @@ class TimerWorker(QtCore.QObject):
     def _Timer(self,Time):
         '''sleep some time'''
         num_updates = np.mod(Time,15)
+        logging.info('here {}, {}'.format(num_updates, Time))
+        self.progress.emit(int(Time))
         while num_updates >0:
             time.sleep(15)
             Time -=15

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1823,16 +1823,7 @@ class Worker(QtCore.QRunnable):
 
 class TimerWorker(QtCore.QObject):
     '''
-    Worker thread
-
-    Inherits from QRunnable to handler worker thread setup, signals and wrap-up.
-
-    :param callback: The function callback to run on this worker thread. Supplied args and
-                     kwargs will be passed through to the runner.
-    :type callback: function
-    :param args: Arguments to pass to the callback function
-    :param kwargs: Keywords to pass to the callback function
-
+        Worker for photometry timer
     '''
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
@@ -1840,15 +1831,20 @@ class TimerWorker(QtCore.QObject):
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
         '''sleep some time'''
-        logging.info('here {}'.format(Time))
-        num_updates = int(np.floor(Time/15))
+        # Emit initial status
+        interval = 5
+        num_updates = int(np.floor(Time/interval))
         self.progress.emit(int(Time))
+
+        # Iterate through intervals 
         while num_updates >0:
-            time.sleep(15)
-            Time -=15
+            time.sleep(interval)
+            Time -=interval
             self.progress.emit(int(Time))
             logging.info('emitting photometry baseline timer progress')
-            num_updates += 1
+            num_updates -= 1
+        
+        # Sleep the remainder of the time and finish
         time.sleep(Time)
         self.finished.emit()
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1835,12 +1835,9 @@ class TimerWorker(QtCore.QRunnable):
 
     '''
     Time = QtCore.pyqtSignal(int)
-    def __init__(self):
-        super(Worker, self).__init__()
+    finished = QtCore.pyqtSignal()
+    progress = QtCore.pyqtSignal(int)
 
-        # Store constructor arguments (re-used for processing)
-        self.signals = WorkerSignals()
-        self.setAutoDelete(False) 
 
     def _Timer(self,Time):
         '''sleep some time'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1840,8 +1840,8 @@ class TimerWorker(QtCore.QObject):
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
         '''sleep some time'''
-        num_updates = int(np.floor(Time,15))
-        logging.info('here {}, {}'.format(num_updates, Time))
+        logging.info('here {}'.format(Time))
+        num_updates = int(np.floor(Time/15))
         self.progress.emit(int(Time))
         while num_updates >0:
             time.sleep(15)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1832,7 +1832,7 @@ class TimerWorker(QtCore.QObject):
     def _Timer(self,Time):
         '''sleep some time'''
         # Emit initial status
-        interval = 5
+        interval = 1
         num_updates = int(np.floor(Time/interval))
         self.progress.emit(int(Time))
 
@@ -1841,7 +1841,6 @@ class TimerWorker(QtCore.QObject):
             time.sleep(interval)
             Time -=interval
             self.progress.emit(int(Time))
-            logging.info('emitting photometry baseline timer progress')
             num_updates -= 1
         
         # Sleep the remainder of the time and finish

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1835,16 +1835,12 @@ class TimerWorker(QtCore.QRunnable):
 
     '''
     Time = QtCore.pyqtSignal(int)
-    def __init__(self, fn, *args, **kwargs):
+    def __init__(self):
         super(Worker, self).__init__()
 
         # Store constructor arguments (re-used for processing)
-        self.fn = fn
-        self.args = args
-        self.kwargs = kwargs
         self.signals = WorkerSignals()
         self.setAutoDelete(False) 
-        # Add the callback to our kwargs
 
     def _Timer(self,Time):
         '''sleep some time'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1846,24 +1846,6 @@ class TimerWorker(QtCore.QRunnable):
         self.setAutoDelete(False) 
         # Add the callback to our kwargs
 
-    @QtCore.pyqtSlot()
-    def run(self):
-        '''
-        Initialise the runner function with passed args, kwargs.
-        '''
-
-        # Retrieve args/kwargs here; and fire processing using them
-        try:
-            result = self.fn(*self.args, **self.kwargs)
-        except ValueError as e:
-            exctype, value = sys.exc_info()[:2]
-            self.signals.error.emit((exctype, value, traceback.format_exc()))
-            logging.error(str(e))
-        else:
-            self.signals.result.emit(result)  # Return the result of the processing
-        finally:
-            self.signals.finished.emit()  # Done
-
     def _Timer(self,Time):
         '''sleep some time'''
         num_updates = np.mod(Time,15)
@@ -1874,6 +1856,6 @@ class TimerWorker(QtCore.QRunnable):
             logging.info('emitting photometry baseline timer progress')
             num_updates += 1
         time.sleep(Time)
- 
+        self.signals.finished.emit()
 
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1834,7 +1834,6 @@ class TimerWorker(QtCore.QRunnable):
     :param kwargs: Keywords to pass to the callback function
 
     '''
-    Time = QtCore.pyqtSignal(int)
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1837,7 +1837,7 @@ class TimerWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
 
-    @pyqtSlot(int)
+    @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
         '''sleep some time'''
         num_updates = np.mod(Time,15)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1840,7 +1840,7 @@ class TimerWorker(QtCore.QObject):
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
         '''sleep some time'''
-        num_updates = np.mod(Time,15)
+        num_updates = int(np.floor(Time,15))
         logging.info('here {}, {}'.format(num_updates, Time))
         self.progress.emit(int(Time))
         while num_updates >0:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1837,7 +1837,7 @@ class TimerWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
 
-
+    @pyqtSlot(int)
     def _Timer(self,Time):
         '''sleep some time'''
         num_updates = np.mod(Time,15)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1821,7 +1821,7 @@ class Worker(QtCore.QRunnable):
 
 
 
-class TimerWorker(QtCore.QRunnable):
+class TimerWorker(QtCore.QObject):
     '''
     Worker thread
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
Right now during the photometry baseline period, users do not have any updates of how much time is remaining. Now the status will be updated in 1 second intervals in the warning box

### What issues or discussions does this update address?
- None

### Describe the expected change in behavior from the perspective of the experimenter
You can see the remaining time in the photometry baseline period

<img width="300" alt="MicrosoftTeams-imagec6c9085852da99066281fc9af952953e3f2f843c6bca13a062c0e6d2bea232ea" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/edda0c96-d343-45e9-b3bd-769a30569ef3">


### Describe the outcome of testing this update on a rig in 447





