### PR TITLE
Improve Dash Board tab

### DIFF
--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -532,7 +532,7 @@
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>-22</y>
+                      <y>0</y>
                       <width>178</width>
                       <height>182</height>
                      </rect>
@@ -834,7 +834,7 @@
             <string notr="true"/>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="tab_2">
             <attribute name="title">
@@ -2157,6 +2157,76 @@
                          </property>
                          <property name="checkable">
                           <bool>false</bool>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item alignment="Qt::AlignTop">
+                     <widget class="QGroupBox" name="groupBox_7">
+                      <property name="maximumSize">
+                       <size>
+                        <width>260</width>
+                        <height>110</height>
+                       </size>
+                      </property>
+                      <property name="font">
+                       <font>
+                        <pointsize>8</pointsize>
+                       </font>
+                      </property>
+                      <property name="title">
+                       <string>Manual motor stage</string>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_11">
+                       <item row="0" column="0">
+                        <widget class="QPushButton" name="MoveXP_2">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>20</width>
+                           <height>25</height>
+                          </size>
+                         </property>
+                         <property name="maximumSize">
+                          <size>
+                           <width>100</width>
+                           <height>16777215</height>
+                          </size>
+                         </property>
+                         <property name="text">
+                          <string>Move Left</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QPushButton" name="MoveXN_2">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>20</width>
+                           <height>25</height>
+                          </size>
+                         </property>
+                         <property name="maximumSize">
+                          <size>
+                           <width>100</width>
+                           <height>16777215</height>
+                          </size>
+                         </property>
+                         <property name="text">
+                          <string>Move Right</string>
                          </property>
                         </widget>
                        </item>
@@ -5203,5 +5273,38 @@ Current pair:
   <tabstop>Task</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>MoveXP_2</sender>
+   <signal>clicked()</signal>
+   <receiver>MoveXP</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>412</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>337</x>
+     <y>414</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>MoveXN_2</sender>
+   <signal>clicked()</signal>
+   <receiver>MoveXN</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>487</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>404</x>
+     <y>424</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -920,8 +920,8 @@ class GenerateTrials():
                 self.win.info_performance_essential_1 += (
                                     f'Responded trial: {self.BS_FinisheTrialN}/{self.BS_AllTrialN} ({self.BS_RespondedRate:.2f})\n'
                                     f'Reward Trial: {self.BS_RewardTrialN}/{self.BS_AllTrialN} ({self.BS_OverallRewardRate:.2f})\n'
-                                    f'Earned Reward: {self.BS_TotalReward:.0f} uL\n'
-                                    f'Water in session: {self.win.water_in_session*1000 if self.B_CurrentTrialN>=0 else 0:.0f} uL'   
+                                    f'Earned Reward: {self.BS_TotalReward / 1000:.3f} mL\n'
+                                    f'Water in session: {self.win.water_in_session if self.B_CurrentTrialN>=0 else 0:.3f} mL'   
                 )
             self.win.label_info_performance_essential_1.setText(self.win.info_performance_essential_1)
             


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Add copies of lickspout "Move Left" and "Move Right" buttons to the Dash Board tab.
- Change Earned Reward and Water in Session to `ml`

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/252
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/245

### Describe the expected change in behavior from the perspective of the experimenter
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/81b735a3-4351-4fff-a10f-ed626fba19d8)

### Describe the outcome of testing this update on a rig in 447
- [ ] Needs feedback from the RAs whether the two buttons work.




