### PR TITLE
[skip email] only stopping photometry in the d box (back merging into production testing)

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2308,6 +2308,8 @@ class Window(QMainWindow):
         '''
             Stop either bleaching or photometry
         '''
+        if self.box_letter != "D":
+            return
         logging.info('Checking that photometry is not running')
         try:
             ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/255
### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter

### Describe the outcome of testing this update on a rig in 447
- tested




