### PR TITLE
Force StartExcitation to unchecked 

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2138,8 +2138,7 @@ class Window(QMainWindow):
                     self.Basic.setTitle(Obj['Other_BasicTitle'])
                 if 'Other_BasicText' in Obj:
                     self.ShowBasic.setText(Obj['Other_BasicText'])
-                
-            # Set newscale position to last position
+                Set newscale position to last position
             if 'B_NewscalePositions' in Obj:
                 try:
                     last_positions=Obj['B_NewscalePositions'][-1]
@@ -2157,6 +2156,7 @@ class Window(QMainWindow):
                     
         else:
             self.NewSession.setDisabled(False)
+        self.StartExcitation.setChecked(False)
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2138,7 +2138,8 @@ class Window(QMainWindow):
                     self.Basic.setTitle(Obj['Other_BasicTitle'])
                 if 'Other_BasicText' in Obj:
                     self.ShowBasic.setText(Obj['Other_BasicText'])
-                Set newscale position to last position
+            
+            #Set newscale position to last position
             if 'B_NewscalePositions' in Obj:
                 try:
                     last_positions=Obj['B_NewscalePositions'][-1]


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- When loading data, the "StartExcitation" button is sometimes saved as "checked". This forces the button to always be set as "unchecked" on loading. This resolves the issue with the photometry start excitation being unresponsive. 
- This is a quick fix, this issue covers a long term fix: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/262

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/262

### Describe the expected change in behavior from the perspective of the experimenter
The photometry excitation should always start after one click

### Describe the outcome of testing this update on a rig in 447
- https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/262#issuecomment-1952871053
- tested in 447




