### PR TITLE
Update for ATrain v1.0

### DIFF
--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -391,6 +391,9 @@
             <property name="text">
              <string>Preview changes</string>
             </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
          </layout>

--- a/src/foraging_gui/AutoTrain.ui
+++ b/src/foraging_gui/AutoTrain.ui
@@ -61,26 +61,6 @@
         </item>
         <item>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="1">
-           <widget class="QLabel" name="label_subject_id">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Unknown</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_4">
             <property name="sizePolicy">
@@ -154,6 +134,99 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_subject_id">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Unknown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="label_last_actual_stage">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Unknown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Selected ID:  </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" colspan="4">
+           <widget class="QLabel" name="label_curriculum_name">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Unknown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" alignment="Qt::AlignRight">
+           <widget class="QCheckBox" name="checkBox_override_stage">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>5</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Override stage</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="0">
            <widget class="QLabel" name="label_6">
             <property name="font">
@@ -168,16 +241,60 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="0" alignment="Qt::AlignRight">
-           <widget class="QCheckBox" name="checkBox_override_stage">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Sessions finished:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1" alignment="Qt::AlignLeft">
+           <widget class="QComboBox" name="comboBox_override_stage">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>7</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>120</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>1000000</width>
+              <height>16777215</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>5</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
             <property name="text">
-             <string>Override stage</string>
+             <string>Stage suggested:</string>
             </property>
            </widget>
           </item>
@@ -221,128 +338,11 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Sessions finished:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLabel" name="label_last_actual_stage">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Unknown</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="1" alignment="Qt::AlignLeft">
-           <widget class="QComboBox" name="comboBox_override_stage">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>7</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>1000000</width>
-              <height>16777215</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Selected ID:  </string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>5</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>10</pointsize>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Stage suggested:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="4">
-           <widget class="QLabel" name="label_curriculum_name">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>13</pointsize>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Unknown</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="4" rowspan="6">
+          <item row="2" column="4" rowspan="6" colspan="2">
            <widget class="QPushButton" name="pushButton_apply_auto_train_paras">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>12</horstretch>
+              <horstretch>8</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
@@ -367,6 +367,29 @@
             </property>
             <property name="checkable">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5" rowspan="2">
+           <widget class="QPushButton" name="pushButton_preview_auto_train_paras">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>130</width>
+              <height>10000</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(225, 225, 0);
+</string>
+            </property>
+            <property name="text">
+             <string>Preview changes</string>
             </property>
            </widget>
           </item>
@@ -660,8 +683,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>263</x>
-     <y>791</y>
+     <x>272</x>
+     <y>743</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -676,8 +699,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>331</x>
-     <y>791</y>
+     <x>340</x>
+     <y>743</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -692,12 +715,12 @@
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>860</x>
-     <y>232</y>
+     <x>669</x>
+     <y>228</y>
     </hint>
     <hint type="destinationlabel">
-     <x>248</x>
-     <y>230</y>
+     <x>168</x>
+     <y>226</y>
     </hint>
    </hints>
   </connection>
@@ -708,11 +731,11 @@
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>789</x>
-     <y>114</y>
+     <x>669</x>
+     <y>222</y>
     </hint>
     <hint type="destinationlabel">
-     <x>248</x>
+     <x>168</x>
      <y>127</y>
     </hint>
    </hints>
@@ -724,12 +747,12 @@
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
+     <x>168</x>
      <y>127</y>
     </hint>
     <hint type="destinationlabel">
-     <x>828</x>
-     <y>128</y>
+     <x>669</x>
+     <y>228</y>
     </hint>
    </hints>
   </connection>
@@ -740,7 +763,7 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
+     <x>168</x>
      <y>127</y>
     </hint>
     <hint type="destinationlabel">

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1882,6 +1882,9 @@ class AutoTrainDialog(QDialog):
                             f"Please choose another valid curriculum and a training stage for this mouse."
                         )
                     
+                    # Clear curriculum in use
+                    self.curriculum_in_use = None
+
                     # Turn on override curriculum
                     self.checkBox_override_curriculum.setChecked(True)
                     self.checkBox_override_curriculum.setEnabled(False)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2169,7 +2169,9 @@ class AutoTrainDialog(QDialog):
                         current_stage_suggested=None,
                         current_stage_actual=None,
                         decision=None,
-                        next_stage_suggested='STAGE_1',
+                        next_stage_suggested='STAGE_1_WARMUP' 
+                            if 'STAGE_1_WARMUP' in [k.name for k in self.curriculum_in_use.parameters.keys()]
+                            else 'STAGE_1',
                         if_closed_loop=None,
                         if_overriden_by_trainer=None,
                         finished_trials=None,

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1888,6 +1888,7 @@ class AutoTrainDialog(QDialog):
                     
                     # Clear curriculum in use
                     self.curriculum_in_use = None
+                    self.pushButton_preview_auto_train_paras.setEnabled(False)
 
                     # Turn on override curriculum
                     self.checkBox_override_curriculum.setChecked(True)
@@ -1913,7 +1914,8 @@ class AutoTrainDialog(QDialog):
                         curriculum_schema_version=last_curriculum_schema_version,
                         curriculum_version=self.last_session['curriculum_version'],
                     )['curriculum']
-                    
+
+                    self.pushButton_preview_auto_train_paras.setEnabled(True)
             
                 # update stage info
                 self.label_last_actual_stage.setText(str(self.last_session['current_stage_actual']))
@@ -2270,7 +2272,11 @@ class AutoTrainDialog(QDialog):
     def _preview_auto_train_paras(self, preview_checked):
         """Apply parameters to the GUI without applying and locking the widgets.
         """
+        
         if preview_checked:
+            if self.curriculum_in_use is None:
+                return
+            
             # Get parameter settings
             paras = self.curriculum_in_use.parameters[
                 TrainingStage[self.stage_in_use]

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2027,6 +2027,7 @@ class AutoTrainDialog(QDialog):
                  'session_date',
                  'curriculum_name', 
                  'curriculum_version',
+                 'curriculum_schema_version',
                  'task',
                  'current_stage_suggested',
                  'current_stage_actual',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -306,14 +306,7 @@ class Window(QMainWindow):
         # get parameters before the warm up is on
         parameters={}
         for attr_name in dir(self):
-            # Only recovery warm up-related parameters to fix the bug
-            # where if the user makes some other changes (like reward size) when "warm up" is on, 
-            # the changes will not be saved when "warm up" is off, because they are incorrectly "recovered". 
-            # Specifically, I found this bug when switching AutoTrain from STAGE_1_Warmup to STAGE_1 without running the task.
-            if attr_name.startswith('WarmupBackup_') and attr_name!='WarmupBackup_' and attr_name!='WarmupBackup_warmup'\
-                and any(f in attr_name for f in ['BaseRewardSum', 'RewardFamily', 'RewardPairsN', 
-                                                 'BlockBeta', 'BlockMin', 'BlockMax', 'BlockMinReward', 'AutoReward',
-                                                 'AutoWaterType', 'Multiplier', 'Unrewarded', 'Ignored', 'AdvancedBlockAuto']):
+            if attr_name.startswith('WarmupBackup_') and attr_name!='WarmupBackup_' and attr_name!='WarmupBackup_warmup':
                 parameters[attr_name.replace('WarmupBackup_','')]=getattr(self,attr_name)
         widget_dict = {w.objectName(): w for w in self.TrainingParameters.findChildren((QtWidgets.QPushButton,QtWidgets.QLineEdit,QtWidgets.QTextEdit, QtWidgets.QComboBox,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox))}
         widget_dict['Task']=self.Task

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -306,7 +306,14 @@ class Window(QMainWindow):
         # get parameters before the warm up is on
         parameters={}
         for attr_name in dir(self):
-            if attr_name.startswith('WarmupBackup_') and attr_name!='WarmupBackup_' and attr_name!='WarmupBackup_warmup':
+            # Only recovery warm up-related parameters to fix the bug
+            # where if the user makes some other changes (like reward size) when "warm up" is on, 
+            # the changes will not be saved when "warm up" is off, because they are incorrectly "recovered". 
+            # Specifically, I found this bug when switching AutoTrain from STAGE_1_Warmup to STAGE_1 without running the task.
+            if attr_name.startswith('WarmupBackup_') and attr_name!='WarmupBackup_' and attr_name!='WarmupBackup_warmup'\
+                and any(f in attr_name for f in ['BaseRewardSum', 'RewardFamily', 'RewardPairsN', 
+                                                 'BlockBeta', 'BlockMin', 'BlockMax', 'BlockMinReward', 'AutoReward',
+                                                 'AutoWaterType', 'Multiplier', 'Unrewarded', 'Ignored', 'AdvancedBlockAuto']):
                 parameters[attr_name.replace('WarmupBackup_','')]=getattr(self,attr_name)
         widget_dict = {w.objectName(): w for w in self.TrainingParameters.findChildren((QtWidgets.QPushButton,QtWidgets.QLineEdit,QtWidgets.QTextEdit, QtWidgets.QComboBox,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox))}
         widget_dict['Task']=self.Task


### PR DESCRIPTION
### Describe changes:
- Starting from ATrain v1.0, use `STAGE_1_WARMUP` as the default first stage of a new mouse, if it exists in a curriculum
- Check whether the `curriculum_schema_version` of the last session of a mouse matches that of the local AutoTrain repo. If not, meaning the AutoTrain system has been upgraded since the last session, prompt the user to select a new curriculum. Note that this curriculum overriding will requires manually selecting a training stage.
    <img src = "https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/b75ff843-b2e1-4fe4-9316-651e3d2cbef1" width=450>
- Add a `Preview Changes` button to preview parameters changed by a chosen AutoTrain stage. Pressing it again reverts to previous parameters.
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/6bb0b55b-7bd2-42cd-8718-aa61ed221057)
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/57bc1278-7bd2-40ca-bd92-12872af1325c)
- Fix some GUI bugs caused by interactions between AutoTrain and Warmup

### What issues or discussions does this update address?
- Related to the recent ATrain update https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training/pull/66

### Describe the expected change in behavior from the perspective of the experimenter
- See above

### Describe the outcome of testing this update on a rig in 447
- [x] test locally
- [ ] test in 447




