### PR TITLE
adding prompt to end session; stopping photometry in NewSession

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2711,8 +2711,17 @@ class Window(QMainWindow):
             # disable metadata fields
             self._set_metadata_enabled(False)
         else:
-            logging.info('Start button pressed: ending trial loop')
-            self.Start.setStyleSheet("background-color : none")
+            reply = QMessageBox.question(self, 
+                'Box {}, Start'.format(self.box_letter), 
+                'Stop current session?',
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
+            if reply == QMessageBox.Yes:
+                logging.info('Start button pressed: ending trial loop')
+                self.Start.setStyleSheet("background-color : none")
+            else:
+                logging.info('Start button pressed: user continued session')               
+                self.Start.setChecked(True)
+                return
  
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2711,18 +2711,20 @@ class Window(QMainWindow):
             # disable metadata fields
             self._set_metadata_enabled(False)
         else:
+            # Prompt user to confirm stopping trials
             reply = QMessageBox.question(self, 
                 'Box {}, Start'.format(self.box_letter), 
                 'Stop current session?',
                 QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
             if reply == QMessageBox.Yes:
+                # End trials
                 logging.info('Start button pressed: ending trial loop')
                 self.Start.setStyleSheet("background-color : none")
             else:
+                # Continue trials
                 logging.info('Start button pressed: user continued session')               
                 self.Start.setChecked(True)
-                return
- 
+                return 
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2095,29 +2095,6 @@ class Window(QMainWindow):
                 W.combo.currentText(),
             )        
 
-            # Version 1, keeping it for the moment 
-            ### Prompt user to enter mouse ID, with auto-completion
-            ##dialog = QtWidgets.QInputDialog(self)
-            ##dialog.setWindowTitle('Box {}, Load mouse'.format(self.box_letter))
-            ##dialog.setLabelText('Enter the mouse ID')
-            ##dialog.setTextValue('')
-            ##lineEdit = dialog.findChild(QtWidgets.QLineEdit)
-        
-            ### Set auto complete
-            ##mice = self._Open_getListOfMice()
-            ##completer = QtWidgets.QCompleter(mice, lineEdit)
-            ##lineEdit.setCompleter(completer)
-            ##
-            ### Only accept integers
-            ##onlyInt = QtGui.QIntValidator()
-            ##onlyInt.setRange(0, 100000000)
-            ##lineEdit.setValidator(onlyInt)
-        
-            ### Get response
-            ##ok, mouse_id = (
-            ##    dialog.exec_() == QtWidgets.QDialog.Accepted, 
-            ##    dialog.textValue(),
-            ##)
             if not ok: 
                 logging.info('Quick load failed, user hit cancel or X')
                 return                                
@@ -2572,6 +2549,7 @@ class Window(QMainWindow):
         self._set_metadata_enabled(True)
 
         # Reset state variables
+        self._StopPhotometry() # Make sure photoexcitation is stopped 
         self.StartANewSession=1
         self.CreateNewFolder=1
         self.PhotometryRun=0


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- When the "start" button is pressed to end trials, the user is prompted to confirm the session should end. This is a request from the RAs. 
- NewSession() stops photometry (which means Open() does too)
- Removes some old comment blocks

### What issues or discussions does this update address?
- resolves #274 
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/262

### Describe the expected change in behavior from the perspective of the experimenter
- When the "start" button is pressed to end trials, the user is prompted to confirm the session should end. 
- Photometry excitation will stop when loading a new mouse, or starting a new session. This is just a sanity check to make sure we have separate photometry data files. 

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




