### PR TITLE
Configure photometry to run on any box

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2847,7 +2847,7 @@ class Window(QMainWindow):
             if self.Teensy_COM == '':
                 logging.warning('No Teensy COM configured for this box, cannot start excitation')
                 msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'
-                reply = QMessageBox.info(self,'Box {}, Start'.format(self.box_letter), 
+                reply = QMessageBox.information(self,'Box {}, Start'.format(self.box_letter), 
                     msg, QMessageBox.Ok)
                 self.Start.setStyleSheet("background-color : none")
                 self.Start.setChecked(False)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2398,6 +2398,8 @@ class Window(QMainWindow):
             msg = 'No Teensy COM configured for this box, cannot start excitation'
             reply = QMessageBox.information(self, 
                 'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
+            self.StartExcitation.setChecked(False)
+            self.StartExcitation.setStyleSheet("background-color : none")
             return
 
         if self.StartExcitation.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2843,6 +2843,16 @@ class Window(QMainWindow):
         # Check if photometry excitation is running or not
         if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
+            
+            if self.Teensy_COM == '':
+                logging.warning('No Teensy COM configured for this box, cannot start excitation')
+                msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'
+                reply = QMessageBox.info(self,'Box {}, Start'.format(self.box_letter), 
+                    msg, QMessageBox.Ok)
+                self.Start.setStyleSheet("background-color : none")
+                self.Start.setChecked(False)
+                return
+
             reply = QMessageBox.question(self, 
                 'Box {}, Start'.format(self.box_letter), 
                 'Photometry is set to "on", but excitation is not running. Start excitation now?',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -691,7 +691,7 @@ class Window(QMainWindow):
         self.default_saveFolder=Settings['default_saveFolder']
         self.current_box=Settings['current_box']
         self.temporary_video_folder=Settings['temporary_video_folder']
-        self.Teensy_COM = Settings['Teensy_COM_box'+self.box_number]
+        self.Teensy_COM = Settings['Teensy_COM_box'+str(self.box_number)]
         self.bonsai_path=Settings['bonsai_path']
         self.bonsaiworkflow_path=Settings['bonsaiworkflow_path']
         self.newscale_serial_num_box1=Settings['newscale_serial_num_box1']

--- a/src/setting_templates/ForagingSettings.json
+++ b/src/setting_templates/ForagingSettings.json
@@ -1,7 +1,10 @@
 {
     "default_saveFolder": "C:\\behavior_data\\",
     "current_box":"",
-    "Teensy_COM":"",
+    "Teensy_COM_box1":"",
+    "Teensy_COM_box2":"",
+    "Teensy_COM_box3":"",
+    "Teensy_COM_box4":"",
     "bonsai_path":"C:\\Users\\svc_aind_behavior\\Documents\\Github\\dynamic-foraging-task\\bonsai\\Bonsai.exe",
     "bonsaiworkflow_path":"C:\\Users\\svc_aind_behavior\\Documents\\Github\\dynamic-foraging-task\\src\\workflows\\foraging.bonsai",
     "temporary_video_folder":"C:\\Users\\svc_aind_behavior\\Documents\\temporaryvideo\\",


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Changes the Teensy_COM setting to be box specific. Previously the FIP box was hard coded to only be box D. Now any box can be a FIP box. 
- Adds a check in `StartExcitation()` and `StartBleaching()` to gracefully handle a missing Teensy_COM setting, rather than crashing. Also checks at the start of the photometry baseline run. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/255

### Describe the expected change in behavior from the perspective of the experimenter
- When configuring the computer, you need to enter a Teensy_COM for each box (if applicable)
- If you try to start FIP excitation or bleaching without the Teensy_COM you will get an alert. 

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447
- [ ] manually updated settings `.json` files for each computer
- [x] updated the template `.json` file




