### PR TITLE
removing SaveTraining from GUI

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2374,8 +2374,7 @@ class AutoTrainDialog(QDialog):
                 return
                 
             self.widgets_locked_by_auto_train.extend(
-                [self.MainWindow.TrainingStage,
-                self.MainWindow.SaveTraining]
+                [self.MainWindow.TrainingStage]
                 )
 
             # lock the widgets that have been set by auto training 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -214,7 +214,6 @@ class Window(QMainWindow):
         self.Randomness.currentIndexChanged.connect(self._Randomness)
         self.TrainingStage.currentIndexChanged.connect(self._TrainingStage)
         self.TrainingStage.activated.connect(self._TrainingStage)
-        self.SaveTraining.clicked.connect(self._SaveTraining)
         self.actionTemporary_Logging.triggered.connect(self._startTemporaryLogging)
         self.actionFormal_logging.triggered.connect(self._startFormalLogging)
         self.actionOpen_logging_folder.triggered.connect(self._OpenLoggingFolder)
@@ -1021,8 +1020,8 @@ class Window(QMainWindow):
 
     def _TrainingStage(self):
         '''Change the parameters automatically based on training stage and task'''
-        self.WarningLabel_SaveTrainingStage.setText('')
-        self.WarningLabel_SaveTrainingStage.setStyleSheet("color: none;")
+        #self.WarningLabel_SaveTrainingStage.setText('')
+        #self.WarningLabel_SaveTrainingStage.setStyleSheet("color: none;")
         # load the prestored training stage parameters
         self._LoadTrainingPar()
         # set the training parameters in the GUI
@@ -1109,38 +1108,6 @@ class Window(QMainWindow):
             if not (isinstance(widget, QtWidgets.QComboBox) or isinstance(widget, QtWidgets.QPushButton)):
                 pass
                 #widget.clear()
-
-    def _SaveTraining(self):
-        '''Save the training stage parameters'''
-        logging.info('Saving training stage parameters')
-        # load the pre-stored training stage parameters
-        self._LoadTrainingPar()
-        # get the current training stage parameters
-        widget_dict = {w.objectName(): w for w in self.TrainingParameters.findChildren((QtWidgets.QPushButton,QtWidgets.QLineEdit,QtWidgets.QTextEdit, QtWidgets.QComboBox,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox))}
-        Task=self.Task.currentText()
-        CurrentTrainingStage=self.TrainingStage.currentText()
-        for key in widget_dict.keys():
-            widget = widget_dict[key]
-            if Task not in self.TrainingStagePar:
-                self.TrainingStagePar[Task]={}
-            if CurrentTrainingStage not in self.TrainingStagePar[Task]:
-                self.TrainingStagePar[Task][CurrentTrainingStage]={}
-            if isinstance(widget, QtWidgets.QPushButton):
-                self.TrainingStagePar[Task][CurrentTrainingStage][widget.objectName()]=widget.isChecked()
-            elif isinstance(widget, QtWidgets.QTextEdit):
-                self.TrainingStagePar[Task][CurrentTrainingStage][widget.objectName()]=widget.toPlainText()
-            elif isinstance(widget, QtWidgets.QDoubleSpinBox) or isinstance(widget, QtWidgets.QLineEdit)  or isinstance(widget, QtWidgets.QSpinBox):
-                self.TrainingStagePar[Task][CurrentTrainingStage][widget.objectName()]=widget.text()
-            elif isinstance(widget, QtWidgets.QComboBox):
-                self.TrainingStagePar[Task][CurrentTrainingStage][widget.objectName()]=widget.currentText()
-        # save
-        if not os.path.exists(os.path.dirname(self.TrainingStageFiles)):
-            os.makedirs(os.path.dirname(self.TrainingStageFiles))
-        with open(self.TrainingStageFiles, "w") as file:
-            json.dump(self.TrainingStagePar, file,indent=4) 
-        self.WarningLabel_SaveTrainingStage.setText('Training stage parameters were saved!')
-        self.WarningLabel_SaveTrainingStage.setStyleSheet(self.default_warning_color)
-        self.SaveTraining.setChecked(False)
 
     def _LoadTrainingPar(self):
         '''load the training stage parameters'''
@@ -2683,8 +2650,8 @@ class Window(QMainWindow):
  
         # Clear warnings
         self.WarningLabelInitializeBonsai.setText('')
-        self.WarningLabel_SaveTrainingStage.setText('')
-        self.WarningLabel_SaveTrainingStage.setStyleSheet("color: none;")
+        #self.WarningLabel_SaveTrainingStage.setText('')
+        #self.WarningLabel_SaveTrainingStage.setStyleSheet("color: none;")
         self.NewSession.setDisabled(False)
             
         # Toggle button colors

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -778,33 +778,6 @@
                        </property>
                       </widget>
                      </item>
-                     <item>
-                      <widget class="QLabel" name="WarningLabel_SaveTrainingStage">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="font">
-                        <font>
-                         <pointsize>7</pointsize>
-                        </font>
-                       </property>
-                       <property name="text">
-                        <string/>
-                       </property>
-                       <property name="textFormat">
-                        <enum>Qt::AutoText</enum>
-                       </property>
-                       <property name="scaledContents">
-                        <bool>false</bool>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                       </property>
-                      </widget>
-                     </item>
                     </layout>
                    </widget>
                   </widget>
@@ -4419,22 +4392,6 @@ Double dipping:
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="6">
-                       <widget class="QPushButton" name="SaveTraining">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Save training</string>
-                        </property>
-                        <property name="checkable">
-                         <bool>true</bool>
                         </property>
                        </widget>
                       </item>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2014,28 +2014,6 @@
       <enum>Qt::AutoText</enum>
      </property>
     </widget>
-    <widget class="QPushButton" name="SaveTraining">
-     <property name="geometry">
-      <rect>
-       <x>403</x>
-       <y>23</y>
-       <width>80</width>
-       <height>22</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Save training</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
     <widget class="QLabel" name="label_27">
      <property name="geometry">
       <rect>
@@ -3205,34 +3183,6 @@
      </property>
     </widget>
     <widget class="QLabel" name="WarningLabel_2">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>70</y>
-       <width>331</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="scaledContents">
-      <bool>false</bool>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="WarningLabel_SaveTrainingStage">
      <property name="geometry">
       <rect>
        <x>10</x>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- SaveTraining() saves the definition of the training stages. We do not want this to happen, since the training stages are now centrally defined. I removed this function and the button in the GUI

### What issues or discussions does this update address?
- resolves #229

### Describe the expected change in behavior from the perspective of the experimenter
- The button that said "Save Training Stage" no longer exists. 

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




