### PR TITLE
Visualization fixes

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2577,6 +2577,9 @@ class Window(QMainWindow):
         self.PhotometryRun=0
         self.unsaved_data=False
         self.ManualWaterVolume=[0,0]       
+    
+        # Clear Plots
+        self.PlotLick._Update(GeneratedTrials=None)
 
         # Add note to log
         logging.info('New Session complete')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2759,7 +2759,7 @@ class Window(QMainWindow):
             self.GeneratedTrials=GeneratedTrials
             self.StartANewSession=0
             PlotM=PlotV(win=self,GeneratedTrials=GeneratedTrials,width=5, height=4)
-            PlotM.finish=1
+            #PlotM.finish=1
             self.PlotM=PlotM
             #generate the first trial outside the loop, only for new session
             self.ToReceiveLicks=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2579,7 +2579,7 @@ class Window(QMainWindow):
         self.ManualWaterVolume=[0,0]       
     
         # Clear Plots
-        self.PlotLick._Update(GeneratedTrials=None)
+        self.PlotM._Update(GeneratedTrials=None,Channel=None):
 
         # Add note to log
         logging.info('New Session complete')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2189,13 +2189,14 @@ class Window(QMainWindow):
                             self.WeightAfter.setText('')
                             continue
                         widget = widget_dict[key]
-                        try: # load the paramter used by last trial
+
+                        if 'TP_{}'.format(key) in CurrentObj:
                             value=np.array([CurrentObj['TP_'+key][-2]])
                             Tag=0
-                        except Exception as e: # sometimes we only have training parameters, no behavior parameters
-                            logging.error(str(e))
+                        else:
                             value=CurrentObj[key]
                             Tag=1
+
                         if key in {'BaseWeight','TotalWater','TargetWeight','WeightAfter','SuggestedWater','TargetRatio'}:
                             self.BaseWeight.disconnect()
                             self.TargetRatio.disconnect()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2579,7 +2579,7 @@ class Window(QMainWindow):
         self.ManualWaterVolume=[0,0]       
     
         # Clear Plots
-        self.PlotM._Update(GeneratedTrials=None,Channel=None):
+        self.PlotM._Update(GeneratedTrials=None,Channel=None)
 
         # Add note to log
         logging.info('New Session complete')

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -255,19 +255,20 @@ class PlotV(FigureCanvas):
             SeInd=~np.logical_or(np.logical_or(np.isinf(x),np.isinf(y)), np.logical_or(np.isnan(x),np.isnan(y)))
             x=x[SeInd]
             y=y[SeInd]
-            slope, intercept, r_value, p_value, _ = stats.linregress(x, y)
-            fit_x = x
-            fit_y = x * slope + intercept
+            if len(np.unique(x)) > 1:
+                slope, intercept, r_value, p_value, _ = stats.linregress(x, y)
+                fit_x = x
+                fit_y = x * slope + intercept
             
-            # Save intercept to show bias in performane info
-            self.main_win.B_Bias_R=intercept
+                # Save intercept to show bias in performane info
+                self.main_win.B_Bias_R=intercept
             
-            ax.plot(fit_x, fit_y, 'r', label=f'r = {r_value:.3f}\np = {p_value:.2e}')
-            ax.set_title(f'slope = {slope:.2f}, bias_R = {intercept:.2f}', fontsize=9)
-            ax.legend(loc='upper left', fontsize=8)
-            ax.axis('equal')
-            ax.set_xlim([fit_x.min()-2, fit_x.max()+2])
-            ax.set_ylim([fit_y.min()-2, fit_y.max()+2])
+                ax.plot(fit_x, fit_y, 'r', label=f'r = {r_value:.3f}\np = {p_value:.2e}')
+                ax.set_title(f'slope = {slope:.2f}, bias_R = {intercept:.2f}', fontsize=9)
+                ax.legend(loc='upper left', fontsize=8)
+                ax.axis('equal')
+                ax.set_xlim([fit_x.min()-2, fit_x.max()+2])
+                ax.set_ylim([fit_y.min()-2, fit_y.max()+2])
         except Exception as e:
             logging.error(str(e))
         self.draw()

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -9,11 +9,11 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 ## TODO
 # What is finish=1?
 
-
 class PlotV(FigureCanvas):
     def __init__(self,win,GeneratedTrials=None,parent=None,dpi=100,width=5, height=4):
         self.fig = Figure(figsize=(width, height), dpi=dpi)
-        gs = GridSpec(10, 30, wspace = 3, hspace = 0.1, bottom = 0.1, top = 0.95, left = 0.04, right = 0.98)
+        gs = GridSpec(10, 30, wspace = 3, hspace = 0.1, bottom = 0.1, 
+            top = 0.95, left = 0.04, right = 0.98)
         self.ax1 = self.fig.add_subplot(gs[0:4, 0:20])
         self.ax2 = self.fig.add_subplot(gs[4:10, 0:20])
         self.ax3 = self.fig.add_subplot(gs[1:9, 22:])
@@ -29,14 +29,19 @@ class PlotV(FigureCanvas):
         self.main_win = win
 
     def _Update(self,GeneratedTrials=None,Channel=None):
+
         if GeneratedTrials is None:
+            # If we have no trials, clear the plots
             self.ax1.cla()
             self.ax2.cla()
             self.ax3.cla() 
             self.draw()        
             return
+
         if Channel is not None:
             GeneratedTrials._GetLicks(Channel)
+
+        # Unpack data 
         self.B_AnimalResponseHistory=GeneratedTrials.B_AnimalResponseHistory
         self.B_LickPortN=GeneratedTrials.B_LickPortN
         self.B_RewardProHistory=GeneratedTrials.B_RewardProHistory
@@ -61,6 +66,7 @@ class PlotV(FigureCanvas):
             self.B_Time=self.B_RewardOutcomeTime-GeneratedTrials.B_TrialStartTime[0]
         else:
             self.B_Time=self.B_RewardOutcomeTime
+
         self.B_BTime=self.B_Time.copy()
         if self.B_TrialEndTime.size!=0:
             Delta=self.B_TrialEndTime[-1]-self.B_TrialStartTime[0]
@@ -70,15 +76,26 @@ class PlotV(FigureCanvas):
 
         try:
             self._PlotBlockStructure()
+        except Exception as e:
+            logging.error(str(e))
+
+        try:
             self._PlotChoice()
+        except Exception as e:
+            logging.error(str(e))
+
+        try:
             self._PlotLicks()
         except Exception as e:
             logging.error(str(e))
+
         try:
             self._PlotMatching()
         except Exception as e:
             logging.error(str(e))
-        self.finish=1
+
+        #self.finish=1
+
     def _PlotBlockStructure(self):
         ax2=self.ax2
         ax2.cla()

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -6,6 +6,9 @@ from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 
+## TODO
+# What is finish=1?
+
 
 class PlotV(FigureCanvas):
     def __init__(self,win,GeneratedTrials=None,parent=None,dpi=100,width=5, height=4):
@@ -29,7 +32,9 @@ class PlotV(FigureCanvas):
         if GeneratedTrials is None:
             self.ax1.cla()
             self.ax2.cla()
-            self.ax3.cla()          
+            self.ax3.cla() 
+            self.draw()        
+            return
         if Channel is not None:
             GeneratedTrials._GetLicks(Channel)
         self.B_AnimalResponseHistory=GeneratedTrials.B_AnimalResponseHistory

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -255,12 +255,14 @@ class PlotV(FigureCanvas):
             SeInd=~np.logical_or(np.logical_or(np.isinf(x),np.isinf(y)), np.logical_or(np.isnan(x),np.isnan(y)))
             x=x[SeInd]
             y=y[SeInd]
+
+            # check we have enough data to do regression
             if len(np.unique(x)) > 1:
                 slope, intercept, r_value, p_value, _ = stats.linregress(x, y)
                 fit_x = x
                 fit_y = x * slope + intercept
             
-                # Save intercept to show bias in performane info
+                # Save intercept to show bias in performance info
                 self.main_win.B_Bias_R=intercept
             
                 ax.plot(fit_x, fit_y, 'r', label=f'r = {r_value:.3f}\np = {p_value:.2e}')

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -6,9 +6,6 @@ from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 
-## TODO
-# What is finish=1?
-
 class PlotV(FigureCanvas):
     def __init__(self,win,GeneratedTrials=None,parent=None,dpi=100,width=5, height=4):
         self.fig = Figure(figsize=(width, height), dpi=dpi)
@@ -94,27 +91,25 @@ class PlotV(FigureCanvas):
         except Exception as e:
             logging.error(str(e))
 
-        #self.finish=1
-
     def _PlotBlockStructure(self):
-        ax2=self.ax2
-        ax2.cla()
+        self.ax2.cla()
         Len=len(self.B_Time)
-        ax2.plot(self.B_Time, self.B_RewardProHistory[0][0:Len],color='r', label='p_L',alpha=1)
-        ax2.plot(self.B_Time, self.B_RewardProHistory[1][0:Len],color='b', label='p_R',alpha=1)
+        self.ax2.plot(self.B_Time, self.B_RewardProHistory[0][0:Len],color='r', label='p_L',alpha=1)
+        self.ax2.plot(self.B_Time, self.B_RewardProHistory[1][0:Len],color='b', label='p_R',alpha=1)
         Fraction=self.B_RewardProHistory[1]/self.B_RewardProHistory.sum(axis=0)
-        ax2.plot(self.B_Time,Fraction[0:Len],linestyle=':',color='y',label='p_R_frac',alpha=0.8)
+        self.ax2.plot(self.B_Time,Fraction[0:Len],linestyle=':',color='y',label='p_R_frac',alpha=0.8)
         self.draw()
+
     def _PlotChoice(self):
-        MarkerSize=self.MarkerSize
-        ax1=self.ax1
-        ax2=self.ax2
-        ax1.cla()
+        self.ax1.cla()
+
+        # Define trial types
         LeftChoice_Rewarded=np.where(np.logical_and(self.B_AnimalResponseHistory==0,self.B_RewardedHistory[0]==True))
         LeftChoice_UnRewarded=np.where(np.logical_and(self.B_AnimalResponseHistory==0,self.B_RewardedHistory[0]==False))
         RightChoice_Rewarded=np.where(np.logical_and(self.B_AnimalResponseHistory==1,self.B_RewardedHistory[1]==True))
         RightChoice_UnRewarded=np.where(np.logical_and(self.B_AnimalResponseHistory==1, self.B_RewardedHistory[1]==False))
         Optogenetics_On=np.where(self.B_LaserOnTrial[:-1]==1)
+
         # running average of choice
         if self.RunLength()!='':
             kernel_size = int(self.RunLength())
@@ -128,6 +123,7 @@ class PlotV(FigureCanvas):
         ResponseHistoryT=self.B_AnimalResponseHistory.copy()
         ResponseHistoryT[ResponseHistoryT==2]=np.nan
         ResponseHistoryF=ResponseHistoryT.copy()
+
         # running average of reward and succuss rate
         RewardedHistoryT=self.B_AnimalResponseHistory.copy()
         LeftRewarded=np.logical_and(self.B_RewardedHistory[0]==1,self.B_RewardedHistory[1]==0)  
@@ -137,11 +133,11 @@ class PlotV(FigureCanvas):
         RewardedHistoryT[RightRewarded]=1
         RewardedHistoryT[NoReward]=np.nan
         RewardedHistoryF=RewardedHistoryT.copy()
-
         SuccessHistoryT=self.B_AnimalResponseHistory.copy()
         SuccessHistoryT[np.logical_or(SuccessHistoryT==1, SuccessHistoryT==0)]=1
         SuccessHistoryT[SuccessHistoryT==2]=0
         SuccessHistoryF=SuccessHistoryT.copy()
+
         # running average of response fraction
         for i in range(len(self.B_AnimalResponseHistory)):
             if i>=kernel_size-1:
@@ -170,18 +166,20 @@ class PlotV(FigureCanvas):
             else:
                 NewTrialStart=np.array(self.B_BTime[-1]+0.1)
                 NewTrialStart2=np.array(self.B_BTime[-1])
-            ax1.eventplot(NewTrialStart.reshape((1,)), lineoffsets=.5, linelengths=2, linewidth=2, color='k', label='UpcomingTrial', alpha=0.3)
-            ax2.eventplot(NewTrialStart.reshape((1,)), lineoffsets=.5, linelengths=2, linewidth=2, color='k', alpha=0.3)
+            self.ax1.eventplot(NewTrialStart.reshape((1,)), lineoffsets=.5, 
+                linelengths=2, linewidth=2, color='k', label='UpcomingTrial', alpha=0.3)
+            self.ax2.eventplot(NewTrialStart.reshape((1,)), lineoffsets=.5, 
+                linelengths=2, linewidth=2, color='k', alpha=0.3)
             if self.B_BaitHistory[0][-1]==True:
-                ax1.plot(NewTrialStart2,-0.2, 'kD',label='Bait',markersize=MarkerSize, alpha=0.4)
+                self.ax1.plot(NewTrialStart2,-0.2, 'kD',label='Bait',markersize=self.MarkerSize, alpha=0.4)
             if self.B_BaitHistory[1][-1]==True:
-                ax1.plot(NewTrialStart2,1.2, 'kD',markersize=MarkerSize, alpha=0.4)
+                self.ax1.plot(NewTrialStart2,1.2, 'kD',markersize=self.MarkerSize, alpha=0.4)
             if self.B_LaserOnTrial[-1]==1:
-                ax1.plot(NewTrialStart2,1.5, 'bo',markersize=MarkerSize,markerfacecolor = (0, 0, 1, 1), alpha=1)
+                self.ax1.plot(NewTrialStart2,1.5, 'bo',markersize=self.MarkerSize,markerfacecolor = (0, 0, 1, 1), alpha=1)
             if self.B_AutoWaterTrial[0][-1]==1:
-                ax1.plot(NewTrialStart2,0.4, 'bo',markerfacecolor = (0, 1, 0, 1),markersize=MarkerSize)
+                self.ax1.plot(NewTrialStart2,0.4, 'bo',markerfacecolor = (0, 1, 0, 1),markersize=self.MarkerSize)
             if self.B_AutoWaterTrial[1][-1]==1:
-                ax1.plot(NewTrialStart2,0.6, 'bo',markerfacecolor = (0, 1, 0, 1),markersize=MarkerSize)
+                self.ax1.plot(NewTrialStart2,0.6, 'bo',markerfacecolor = (0, 1, 0, 1),markersize=self.MarkerSize)
         else:
             LeftBait=np.where(self.B_BaitHistory[0]==True)
             RightBait=np.where(self.B_BaitHistory[1]==True)
@@ -189,37 +187,50 @@ class PlotV(FigureCanvas):
             RightAutoWater=np.where(self.B_AutoWaterTrial[1]==1)
         
         if np.size(LeftAutoWater) !=0:
-            ax1.plot(self.B_BTime[LeftAutoWater], np.zeros(len(self.B_BTime[LeftAutoWater]))+0.4, 'bo',markerfacecolor = (0, 1, 0, 1),markersize=MarkerSize)
+            self.ax1.plot(self.B_BTime[LeftAutoWater], np.zeros(len(self.B_BTime[LeftAutoWater]))+0.4, 
+                'bo',markerfacecolor = (0, 1, 0, 1),markersize=self.MarkerSize)
         if np.size(RightAutoWater) !=0:
-            ax1.plot(self.B_BTime[RightAutoWater], np.zeros(len(self.B_BTime[RightAutoWater]))+0.6, 'bo',markerfacecolor =(0, 1, 0, 1),markersize=MarkerSize,label='AutoWater')
+            self.ax1.plot(self.B_BTime[RightAutoWater], np.zeros(len(self.B_BTime[RightAutoWater]))+0.6, 
+                'bo',markerfacecolor =(0, 1, 0, 1),markersize=self.MarkerSize,label='AutoWater')
 
         if np.size(Optogenetics_On) !=0:
-            ax1.plot(self.B_BTime[Optogenetics_On], np.zeros(len(self.B_BTime[Optogenetics_On]))+1.5, 'bo',markerfacecolor = (0, 0, 1, 1),label='Optogenetics',markersize=MarkerSize, alpha=1)
+            self.ax1.plot(self.B_BTime[Optogenetics_On], np.zeros(len(self.B_BTime[Optogenetics_On]))+1.5, 
+                'bo',markerfacecolor = (0, 0, 1, 1),label='Optogenetics',markersize=self.MarkerSize, alpha=1)
         if np.size(LeftBait) !=0:
-            ax1.plot(self.B_BTime[LeftBait], np.zeros(len(self.B_BTime[LeftBait]))-0.2, 'kD',markersize=MarkerSize, alpha=0.2)
+            self.ax1.plot(self.B_BTime[LeftBait], np.zeros(len(self.B_BTime[LeftBait]))-0.2, 
+                'kD',markersize=self.MarkerSize, alpha=0.2)
         if np.size(RightBait) !=0:
-            ax1.plot(self.B_BTime[RightBait], np.zeros(len(self.B_BTime[RightBait]))+1.2, 'kD',markersize=MarkerSize, alpha=0.2)
+            self.ax1.plot(self.B_BTime[RightBait], np.zeros(len(self.B_BTime[RightBait]))+1.2, 
+                'kD',markersize=self.MarkerSize, alpha=0.2)
         if np.size(LeftChoice) !=0:
-            ax1.plot(self.B_Time[LeftChoice], np.zeros(len(self.B_Time[LeftChoice]))+0, 'go',markerfacecolor = (1, 1, 1, 1),label='Choice',markersize=MarkerSize)
+            self.ax1.plot(self.B_Time[LeftChoice], np.zeros(len(self.B_Time[LeftChoice]))+0, 
+                'go',markerfacecolor = (1, 1, 1, 1),label='Choice',markersize=self.MarkerSize)
         if np.size(LeftChoice_Rewarded) !=0:
-            ax1.plot(self.B_Time[LeftChoice_Rewarded], np.zeros(len(self.B_Time[LeftChoice_Rewarded]))+.2, 'go',markerfacecolor = (0, 1, 0, 1),label='Rewarded',markersize=MarkerSize)
+            self.ax1.plot(self.B_Time[LeftChoice_Rewarded], np.zeros(len(self.B_Time[LeftChoice_Rewarded]))+.2, 
+                'go',markerfacecolor = (0, 1, 0, 1),label='Rewarded',markersize=self.MarkerSize)
         if np.size(RightChoice) !=0:
-            ax1.plot(self.B_Time[RightChoice], np.zeros(len(self.B_Time[RightChoice]))+1, 'go',markerfacecolor = (1, 1, 1, 1),markersize=MarkerSize)
+            self.ax1.plot(self.B_Time[RightChoice], np.zeros(len(self.B_Time[RightChoice]))+1, 
+                'go',markerfacecolor = (1, 1, 1, 1),markersize=self.MarkerSize)
         if np.size(RightChoice_Rewarded) !=0:
-            ax1.plot(self.B_Time[RightChoice_Rewarded], np.zeros(len(self.B_Time[RightChoice_Rewarded]))+.8, 'go',markerfacecolor = (0, 1, 0, 1),markersize=MarkerSize)
+            self.ax1.plot(self.B_Time[RightChoice_Rewarded], np.zeros(len(self.B_Time[RightChoice_Rewarded]))+.8, 
+                'go',markerfacecolor = (0, 1, 0, 1),markersize=self.MarkerSize)
         if np.size(NoResponse) !=0:
-            ax1.plot(self.B_Time[NoResponse], np.zeros(len(self.B_Time[NoResponse]))+.5, 'Xk',label='NoResponse',markersize=MarkerSize,alpha=0.2)
+            self.ax1.plot(self.B_Time[NoResponse], np.zeros(len(self.B_Time[NoResponse]))+.5, 
+                'Xk',label='NoResponse',markersize=self.MarkerSize,alpha=0.2)
         if self.B_CurrentTrialN>kernel_size:
-            ax2.plot(self.B_Time[kernel_size-1:],ResponseHistoryF[:-kernel_size+1],'k',label='Choice_frac',linewidth=2,alpha=0.8)
-            ax2.plot(self.B_Time[kernel_size-1:],RewardedHistoryF[:-kernel_size+1],'g',label='reward_frac',linewidth=1,alpha=0.8)
-            ax2.plot(self.B_Time[kernel_size-1:],SuccessHistoryF[:-kernel_size+1],'c',label='finish_frac', alpha=0.2)
+            self.ax2.plot(self.B_Time[kernel_size-1:],ResponseHistoryF[:-kernel_size+1],
+                'k',label='Choice_frac',linewidth=2,alpha=0.8)
+            self.ax2.plot(self.B_Time[kernel_size-1:],RewardedHistoryF[:-kernel_size+1],
+                'g',label='reward_frac',linewidth=1,alpha=0.8)
+            self.ax2.plot(self.B_Time[kernel_size-1:],SuccessHistoryF[:-kernel_size+1],
+                'c',label='finish_frac', alpha=0.2)
         self._UpdateAxis()
         self.draw()
 
     def _PlotMatching(self):
         ax=self.ax3
-        ax.cla()
-        ax.set_box_aspect(1)
+        self.ax3.cla()
+        self.ax3.set_box_aspect(1)
 
         if self.WindowSize()!='':
             WindowSize=int(self.WindowSize())
@@ -265,16 +276,16 @@ class PlotV(FigureCanvas):
         if self.MarchingType=='log ratio':
             x=reward_log_ratio
             y=choice_log_ratio
-            ax.set(xlabel='Log Reward_R/L',ylabel='Log Choice_R/L')
-            ax.plot(x, y, 'ko')
-            max_range = max(np.abs(ax.get_xlim()).max(), np.abs(ax.get_ylim()).max())
-            ax.plot([-max_range, max_range], [-max_range, max_range], 'k--', lw=1)
+            self.ax3.set(xlabel='Log Reward_R/L',ylabel='Log Choice_R/L')
+            self.ax3.plot(x, y, 'ko')
+            max_range = max(np.abs(self.ax3.get_xlim()).max(), np.abs(self.ax3.get_ylim()).max())
+            self.ax3.plot([-max_range, max_range], [-max_range, max_range], 'k--', lw=1)
         else:
             x=reward_R_frac
             y=choice_R_frac
-            ax.set(xlabel='frac Reward_R',ylabel='frac Choice_R')
-            ax.plot(x, y, 'ko')
-            ax.plot([0, 1], [0, 1], 'k--', lw=1)
+            self.ax3.set(xlabel='frac Reward_R',ylabel='frac Choice_R')
+            self.ax3.plot(x, y, 'ko')
+            self.ax3.plot([0, 1], [0, 1], 'k--', lw=1)
 
         # linear fitting
         try: 
@@ -291,12 +302,12 @@ class PlotV(FigureCanvas):
                 # Save intercept to show bias in performance info
                 self.main_win.B_Bias_R=intercept
             
-                ax.plot(fit_x, fit_y, 'r', label=f'r = {r_value:.3f}\np = {p_value:.2e}')
-                ax.set_title(f'slope = {slope:.2f}, bias_R = {intercept:.2f}', fontsize=9)
-                ax.legend(loc='upper left', fontsize=8)
-                ax.axis('equal')
-                ax.set_xlim([fit_x.min()-2, fit_x.max()+2])
-                ax.set_ylim([fit_y.min()-2, fit_y.max()+2])
+                self.ax3.plot(fit_x, fit_y, 'r', label=f'r = {r_value:.3f}\np = {p_value:.2e}')
+                self.ax3.set_title(f'slope = {slope:.2f}, bias_R = {intercept:.2f}', fontsize=9)
+                self.ax3.legend(loc='upper left', fontsize=8)
+                self.ax3.axis('equal')
+                self.ax3.set_xlim([fit_x.min()-2, fit_x.max()+2])
+                self.ax3.set_ylim([fit_y.min()-2, fit_y.max()+2])
         except Exception as e:
             logging.error(str(e))
         self.draw()
@@ -304,9 +315,8 @@ class PlotV(FigureCanvas):
     def _PlotLicks(self):
         if self.B_CurrentTrialN<1:
             return
-        ax=self.ax1
-        ax.plot(self.B_LeftLickTime-self.B_TrialStartTime[0], np.zeros(len(self.B_LeftLickTime))-0.4, 'k|')
-        ax.plot(self.B_RightLickTime-self.B_TrialStartTime[0], np.zeros(len(self.B_RightLickTime))+1.4, 'k|')
+        self.ax1.plot(self.B_LeftLickTime-self.B_TrialStartTime[0], np.zeros(len(self.B_LeftLickTime))-0.4, 'k|')
+        self.ax1.plot(self.B_RightLickTime-self.B_TrialStartTime[0], np.zeros(len(self.B_RightLickTime))+1.4, 'k|')
         self.draw()
 
     def _UpdateAxis(self):

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -26,6 +26,10 @@ class PlotV(FigureCanvas):
         self.main_win = win
 
     def _Update(self,GeneratedTrials=None,Channel=None):
+        if GeneratedTrials is None:
+            self.ax1.cla()
+            self.ax2.cla()
+            self.ax3.cla()          
         if Channel is not None:
             GeneratedTrials._GetLicks(Channel)
         self.B_AnimalResponseHistory=GeneratedTrials.B_AnimalResponseHistory


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Only runs the regression on the matching plot if we have enough data, thus avoiding several errors. 
- Removes an unused `PlotV.finish` flag
- General code clean up
- Clear the plots when NewSession is pressed
- Adds some logic to check for training parameter versus behavior parameter when loading session

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/85
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/86
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/87
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/186

### Describe the expected change in behavior from the perspective of the experimenter
If you press `NewSession` the plots will be cleared. This will also happen briefly when loading a mouse

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




