### PR TITLE
Use schedule to make suggestion when loading mice

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -29,7 +29,7 @@ codebase_curriculum_schema_version = DynamicForagingCurriculum.model_fields['cur
 logger = logging.getLogger(__name__)
 
 class MouseScheduleDialog(QDialog):
-    def __init__(self, MainWindow, schedule_mouse, parent=None):
+    def __init__(self, MainWindow, scheduled_mouse, parent=None):
         super().__init__(parent)
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -46,17 +46,17 @@ class MouseScheduleDialog(QDialog):
         font.setPointSize(12)
         msg0.setFont(font)
 
-        msg = QLabel('mouse: <span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
+        msg = QLabel('mouse:'.ljust(8)+'<span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)
 
-        msg1 = QLabel('box:   {}'.format(scheduled_mouse['Box']))
+        msg1 = QLabel('box:'.ljust(8)+'{}'.format(scheduled_mouse['Box']))
         font = msg1.font()
         font.setPointSize(12)
         msg1.setFont(font)
 
-        msg2 = QLabel('time:  {}'.format(scheduled_mouse['Time Slot']))
+        msg2 = QLabel('time:'.ljust(8)+'{}'.format(scheduled_mouse['Time Slot']))
         font = msg2.font()
         font.setPointSize(12)
         msg2.setFont(font)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -35,7 +35,7 @@ class MouseSelectorDialog(QDialog):
         if scheduled_mouse is None:
             self.mice = ['']+mice
         else:
-            self.mice = [schedule_mouse['Mouse ID'] + mice
+            self.mice = [schedule_mouse['Mouse ID']] + mice
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -33,7 +33,7 @@ class MouseScheduleDialog(QDialog):
         super().__init__(parent)
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
-        self.setFixedSize(250,125)
+        self.setFixedSize(250,150)
 
         self.buttonBox = QDialogButtonBox()
         self.buttonBox.addButton('Yes',QDialogButtonBox.AcceptRole)
@@ -41,22 +41,28 @@ class MouseScheduleDialog(QDialog):
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
 
-        msg = QLabel('Scheduled mouse: <span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
+        msg0 = QLabel('Load scheduled mouse ?')
+        font = msg0.font()
+        font.setPointSize(12)
+        msg0.setFont(font)
+
+        msg = QLabel('mouse: <span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)
 
-        msg1 = QLabel('Scheduled box: {}'.format(scheduled_mouse['Box']))
+        msg1 = QLabel('box:   {}'.format(scheduled_mouse['Box']))
         font = msg1.font()
         font.setPointSize(12)
         msg1.setFont(font)
 
-        msg2 = QLabel('Scheduled Time: {}'.format(scheduled_mouse['Time Slot']))
+        msg2 = QLabel('time:  {}'.format(scheduled_mouse['Time Slot']))
         font = msg2.font()
         font.setPointSize(12)
         msg2.setFont(font)
 
         self.layout = QVBoxLayout(self)
+        self.layout.addWidget(msg0)
         self.layout.addWidget(msg)
         self.layout.addWidget(msg1)
         self.layout.addWidget(msg2)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -30,9 +30,12 @@ logger = logging.getLogger(__name__)
 
 class MouseSelectorDialog(QDialog):
     
-    def __init__(self, MainWindow, schedule, mice, parent=None):
+    def __init__(self, MainWindow, scheduled_mouse, mice, parent=None):
         super().__init__(parent)
-        self.mice = ['']+mice
+        if scheduled_mouse is None:
+            self.mice = ['']+mice
+        else:
+            self.mice = [schedule_mouse['Mouse ID'] + mice
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)
@@ -58,6 +61,12 @@ class MouseSelectorDialog(QDialog):
         msg.setFont(font)
 
         self.layout = QVBoxLayout(self)
+        if scheduled_mouse is not None:
+            mouse = scheduled_mouse['Mouse ID']
+            box = scheduled_mouse['Box']
+            timeslot = scheduled_mouse['Time Slot']
+            schedule_info = QLabel('Scheduled mouse: {}\nSchedule Box: {}\nScheduled Time: {}'.format(mouse, box, timeslot))
+            self.layout.addWidget(schedule_info)
         self.layout.addWidget(msg)
         self.layout.addWidget(self.combo)
         self.layout.addWidget(self.buttonBox)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -35,7 +35,7 @@ class MouseSelectorDialog(QDialog):
         if scheduled_mouse is None:
             self.mice = ['']+mice
         else:
-            self.mice = [schedule_mouse['Mouse ID']] + mice
+            self.mice = [scheduled_mouse['Mouse ID']] + mice
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -28,14 +28,32 @@ codebase_curriculum_schema_version = DynamicForagingCurriculum.model_fields['cur
 
 logger = logging.getLogger(__name__)
 
+class MouseScheduleDialog(QDialog):
+    def __init__(self, MainWindow, schedule_mouse, parent=None):
+        super().__init__(parent)
+        self.MainWindow = MainWindow
+        self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
+        self.setFixedSize(250,125)
+
+        QBtns = QDialogButtonBox.Yes | QDialogButtonBox.No
+        self.buttonBox = QDialogButtonBox(QBtns)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+
+        msg = QLabel('Scheduled mouse: {}'.format(scheduled_mouse['Mouse ID']))
+        font = msg.font()
+        font.setPointSize(12)
+        msg.setFont(font)
+
+        self.layout = QVBoxLayout(self)
+        self.layout.addWidget(self.buttonBox)
+        self.layout.addWidget(msg)
+        self.setLayout(self.layout)
+
 class MouseSelectorDialog(QDialog):
     
-    def __init__(self, MainWindow, scheduled_mouse, mice, parent=None):
+    def __init__(self, MainWindow, mice, parent=None):
         super().__init__(parent)
-        if scheduled_mouse is None:
-            self.mice = ['']+mice
-        else:
-            self.mice = [scheduled_mouse['Mouse ID']] + mice
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)
@@ -61,12 +79,12 @@ class MouseSelectorDialog(QDialog):
         msg.setFont(font)
 
         self.layout = QVBoxLayout(self)
-        if scheduled_mouse is not None:
-            mouse = scheduled_mouse['Mouse ID']
-            box = scheduled_mouse['Box']
-            timeslot = scheduled_mouse['Time Slot']
-            schedule_info = QLabel('Scheduled mouse: {}\nSchedule Box: {}\nScheduled Time: {}'.format(mouse, box, timeslot))
-            self.layout.addWidget(schedule_info)
+        #if scheduled_mouse is not None:
+        #    mouse = scheduled_mouse['Mouse ID']
+        #    box = scheduled_mouse['Box']
+        #    timeslot = scheduled_mouse['Time Slot']
+        #    schedule_info = QLabel('Scheduled mouse: {}\nSchedule Box: {}\nScheduled Time: {}'.format(mouse, box, timeslot))
+        #    self.layout.addWidget(schedule_info)
         self.layout.addWidget(msg)
         self.layout.addWidget(self.combo)
         self.layout.addWidget(self.buttonBox)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -73,7 +73,7 @@ class MouseSelectorDialog(QDialog):
     
     def __init__(self, MainWindow, mice, parent=None):
         super().__init__(parent)
-        self.mice = ['']+ mice
+        self.mice = ['']+mice
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)
@@ -99,12 +99,6 @@ class MouseSelectorDialog(QDialog):
         msg.setFont(font)
 
         self.layout = QVBoxLayout(self)
-        #if scheduled_mouse is not None:
-        #    mouse = scheduled_mouse['Mouse ID']
-        #    box = scheduled_mouse['Box']
-        #    timeslot = scheduled_mouse['Time Slot']
-        #    schedule_info = QLabel('Scheduled mouse: {}\nSchedule Box: {}\nScheduled Time: {}'.format(mouse, box, timeslot))
-        #    self.layout.addWidget(schedule_info)
         self.layout.addWidget(msg)
         self.layout.addWidget(self.combo)
         self.layout.addWidget(self.buttonBox)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -35,7 +35,7 @@ class MouseScheduleDialog(QDialog):
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)
 
-        self.buttonBox = QDialogButtonBox(QBtns)
+        self.buttonBox = QDialogButtonBox()
         self.buttonBox.addButton('Yes',QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton('No',QDialogButtonBox.RejectRole)
         self.buttonBox.accepted.connect(self.accept)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -46,17 +46,17 @@ class MouseScheduleDialog(QDialog):
         font.setPointSize(12)
         msg0.setFont(font)
 
-        msg = QLabel('mouse:'.ljust(12)+'<span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
+        msg = QLabel('mouse:'.ljust(9)+'<span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)
 
-        msg1 = QLabel('box:'.ljust(12)+'{}'.format(scheduled_mouse['Box']))
+        msg1 = QLabel('box:'.ljust(9)+'{}'.format(scheduled_mouse['Box']))
         font = msg1.font()
         font.setPointSize(12)
         msg1.setFont(font)
 
-        msg2 = QLabel('time:'.ljust(12)+'{}'.format(scheduled_mouse['Time Slot']))
+        msg2 = QLabel('time:'.ljust(9)+'{}'.format(scheduled_mouse['Time Slot']))
         font = msg2.font()
         font.setPointSize(12)
         msg2.setFont(font)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -41,13 +41,25 @@ class MouseScheduleDialog(QDialog):
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
 
-        msg = QLabel('Scheduled mouse: {}'.format(scheduled_mouse['Mouse ID']))
+        msg = QLabel('Scheduled mouse: <span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)
 
+        msg1 = QLabel('Scheduled box: {}'.format(scheduled_mouse['Box']))
+        font = msg1.font()
+        font.setPointSize(12)
+        msg1.setFont(font)
+
+        msg2 = QLabel('Scheduled Time: {}'.format(scheduled_mouse['Time Slot']))
+        font = msg2.font()
+        font.setPointSize(12)
+        msg2.setFont(font)
+
         self.layout = QVBoxLayout(self)
         self.layout.addWidget(msg)
+        self.layout.addWidget(msg1)
+        self.layout.addWidget(msg2)
         self.layout.addWidget(self.buttonBox)
         self.setLayout(self.layout)
 

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -54,6 +54,7 @@ class MouseSelectorDialog(QDialog):
     
     def __init__(self, MainWindow, mice, parent=None):
         super().__init__(parent)
+        self.mice = ['']+ mice
         self.MainWindow = MainWindow
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -35,8 +35,9 @@ class MouseScheduleDialog(QDialog):
         self.setWindowTitle('Box {}, Load Mouse'.format(self.MainWindow.box_letter))
         self.setFixedSize(250,125)
 
-        QBtns = QDialogButtonBox.Yes | QDialogButtonBox.No
         self.buttonBox = QDialogButtonBox(QBtns)
+        self.buttonBox.addButton('Yes',QDialogButtonBox.AcceptRole)
+        self.buttonBox.addButton('No',QDialogButtonBox.RejectRole)
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
 
@@ -46,8 +47,8 @@ class MouseScheduleDialog(QDialog):
         msg.setFont(font)
 
         self.layout = QVBoxLayout(self)
-        self.layout.addWidget(self.buttonBox)
         self.layout.addWidget(msg)
+        self.layout.addWidget(self.buttonBox)
         self.setLayout(self.layout)
 
 class MouseSelectorDialog(QDialog):

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 class MouseSelectorDialog(QDialog):
     
-    def __init__(self, MainWindow, mice, parent=None):
+    def __init__(self, MainWindow, schedule, mice, parent=None):
         super().__init__(parent)
         self.mice = ['']+mice
         self.MainWindow = MainWindow

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -46,17 +46,17 @@ class MouseScheduleDialog(QDialog):
         font.setPointSize(12)
         msg0.setFont(font)
 
-        msg = QLabel('mouse:'.ljust(8)+'<span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
+        msg = QLabel('mouse:'.ljust(12)+'<span style="color:purple;font-weight:bold">{}</span>'.format(scheduled_mouse['Mouse ID']))
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)
 
-        msg1 = QLabel('box:'.ljust(8)+'{}'.format(scheduled_mouse['Box']))
+        msg1 = QLabel('box:'.ljust(12)+'{}'.format(scheduled_mouse['Box']))
         font = msg1.font()
         font.setPointSize(12)
         msg1.setFont(font)
 
-        msg2 = QLabel('time:'.ljust(8)+'{}'.format(scheduled_mouse['Time Slot']))
+        msg2 = QLabel('time:'.ljust(12)+'{}'.format(scheduled_mouse['Time Slot']))
         font = msg2.font()
         font.setPointSize(12)
         msg2.setFont(font)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2050,7 +2050,7 @@ class Window(QMainWindow):
                     break
         return mice  
 
-    def _Open_getSchedule():
+    def _Open_getSchedule(self):
         '''
             Loads the local copy of the schedule
             if the schedule is not found, then returns None
@@ -2079,7 +2079,7 @@ class Window(QMainWindow):
         
         print(datetime.datetime.now())                     
 
-
+        return schedule
 
     def _Open(self,open_last = False):
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2094,7 +2094,7 @@ class Window(QMainWindow):
         if open_last:
             schedule = self._Open_getSchedule()
             mice = self._Open_getListOfMice()
-            W = MouseSelectorDialog(self, schedule mice)
+            W = MouseSelectorDialog(self, schedule, mice)
 
             ok, mouse_id = (
                 W.exec_() == QtWidgets.QDialog.Accepted, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -60,6 +60,7 @@ class Window(QMainWindow):
         # Load Settings that are specific to this computer  
         self.SettingFolder=os.path.join(os.path.expanduser("~"), "Documents","ForagingSettings")
         self.SettingFile=os.path.join(self.SettingFolder,'ForagingSettings.json')
+        self.ScheduleFile=os.path.join(self.SettingFolder,'ForagingSchedule.xlsx')
         self._GetSettings()
 
         # Load Settings that are specific to this box 
@@ -2049,6 +2050,37 @@ class Window(QMainWindow):
                     break
         return mice  
 
+    def _Open_getSchedule():
+        '''
+            Loads the local copy of the schedule
+            if the schedule is not found, then returns None
+        '''        
+    
+        # Schedule not found
+        if not os.path.exists(self.ScheduleFile):
+            return None
+
+        # Load schedule
+        try:
+            schedule = pd.read_excel(self.ScheduleFile)
+        except Exception as e:
+            # Error, return None
+            logging.error(str(e))
+            return None
+        
+        # Clean up, check its current
+        schedule_date =  schedule.iloc[0]['Mouse ID']  
+        schedule = schedule[['Mouse ID','Box','Time Slot']].dropna()
+
+        # Is this schedule current?
+        print(schedule)
+
+        print(self.current_box)
+        
+        print(datetime.datetime.now())                     
+
+
+
     def _Open(self,open_last = False):
 
         # stop current session first
@@ -2060,8 +2092,9 @@ class Window(QMainWindow):
             return
 
         if open_last:
+            schedule = self._Open_getSchedule()
             mice = self._Open_getListOfMice()
-            W = MouseSelectorDialog(self, mice)
+            W = MouseSelectorDialog(self, schedule mice)
 
             ok, mouse_id = (
                 W.exec_() == QtWidgets.QDialog.Accepted, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2114,7 +2114,7 @@ class Window(QMainWindow):
         ''' 
             Returns the string of the start window for the most recent start window
         '''
-        if datetime.now().time() > datetime.strptime('05:00 PM').time():
+        if datetime.now().time() > datetime.strptime('05:00 PM','%I:%M %p').time():
             logging.info('After 5pm, no scheduled time')
             slot = ''
             return slot

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2116,7 +2116,7 @@ class Window(QMainWindow):
         '''
         afternoon_cutoff = '01:30 PM'
         if datetime.now().time() > datetime.strptime(afternoon_cutoff,'%I:%M %p').time():
-            logging.info('After {}, no scheduled time'.format(afternoon cutoff))
+            logging.info('After {}, no scheduled time'.format(afternoon_cutoff))
             slot = ''
             return slot
         starts = [datetime.strptime(x,'%I:%M %p').time() for x in starts]

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2114,7 +2114,7 @@ class Window(QMainWindow):
         ''' 
             Returns the string of the start window for the most recent start window
         '''
-        afternoon_cutoff = '01:30 PM'
+        afternoon_cutoff = '04:00 PM'
         if datetime.now().time() > datetime.strptime(afternoon_cutoff,'%I:%M %p').time():
             logging.info('After {}, no scheduled time'.format(afternoon_cutoff))
             slot = ''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2056,8 +2056,9 @@ class Window(QMainWindow):
 
     def _Open_getSchedule(self):
         '''
-            Loads the local copy of the schedule
+            Loads the local copy of the schedule, and parses for the box/time
             if the schedule is not found, then returns None
+            if a scheduled mouse is found, returns a dictionary with the schedule info
         '''        
     
         # Schedule not found
@@ -2084,6 +2085,7 @@ class Window(QMainWindow):
                 logging.info('Schedule is out of date: {}'.format(schedule_date_str)) 
                 return None
 
+            # Parse schedule, figure out 30 minute time start before each window
             schedule = schedule[['Mouse ID','Box','Time Slot']].dropna()
             schedule['Box'] = ['447-'+x[0]+'-'+x[1] for x in schedule['Box']]
             schedule['start'] = [x.split('-')[0] for x in schedule['Time Slot']]
@@ -2092,6 +2094,7 @@ class Window(QMainWindow):
             starts = schedule['start'].unique()
             slot = self._Open_findScheduleSlot(starts)
 
+            # See if there is a mouse for this time slot on this box
             output = schedule.query('(Box==@self.current_box)&(start == @slot)')
             if len(output) ==1:
                 mouse_slot = output.iloc[0].to_dict()
@@ -2125,10 +2128,10 @@ class Window(QMainWindow):
             return
 
         if open_last:
-            schedule = self._Open_getSchedule()
-            print(schedule)
+            scheduled_mouse = self._Open_getSchedule()
+            print(scheduled_mouse)
             mice = self._Open_getListOfMice()
-            W = MouseSelectorDialog(self, schedule, mice)
+            W = MouseSelectorDialog(self, scheduled_mouse, mice)
 
             ok, mouse_id = (
                 W.exec_() == QtWidgets.QDialog.Accepted, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2058,10 +2058,12 @@ class Window(QMainWindow):
     
         # Schedule not found
         if not os.path.exists(self.ScheduleFile):
+            logging.warning('Schedule file not found at: {}'.format(self.ScheduleFile))
             return None
 
         # Load schedule
         try:
+            logging.info('Loading schedule file: {}'.format(self.ScheduleFile))
             schedule = pd.read_excel(self.ScheduleFile)
         except Exception as e:
             # Error, return None

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2134,7 +2134,7 @@ class Window(QMainWindow):
             if scheduled_mouse is not None:
                 W = MouseScheduleDialog(self, scheduled_mouse)
                 outcome = W.exec_()
-                if outcome == QtWidgets.QDialog.Accept:
+                if outcome == QtWidgets.QDialog.Accepted:
                     mouse_id = scheduled_mouse['Mouse ID']
                 print(mouse_id)
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -61,7 +61,7 @@ class Window(QMainWindow):
         # Load Settings that are specific to this computer  
         self.SettingFolder=os.path.join(os.path.expanduser("~"), "Documents","ForagingSettings")
         self.SettingFile=os.path.join(self.SettingFolder,'ForagingSettings.json')
-        self.ScheduleFile=os.path.join(self.SettingFolder,'ForagingSchedule.xlsx')
+        self.ScheduleFile=os.path.join(self.SettingFolder,'ForagingSchedule.csv')
         self._GetSettings()
 
         # Load Settings that are specific to this box 
@@ -2065,7 +2065,7 @@ class Window(QMainWindow):
         # Load schedule
         try:
             logging.info('Loading schedule file: {}'.format(self.ScheduleFile))
-            schedule = pd.read_excel(self.ScheduleFile)
+            schedule = pd.read_csv(self.ScheduleFile)
         except Exception as e:
             # Error, return None
             logging.error(str(e))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2080,7 +2080,7 @@ class Window(QMainWindow):
 
         print(self.current_box)
         
-        print(datetime.datetime.now())                     
+        print(datetime.now())                     
 
         return schedule
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2133,10 +2133,9 @@ class Window(QMainWindow):
             mouse_id = None
             if scheduled_mouse is not None:
                 W = MouseScheduleDialog(self, scheduled_mouse)
-                ok = W.exec_() == QtWidgets.QDialog.Accepted,
-                if ok:
-                    mouse_id == scheduled_mouse['Mouse ID']
-                print(ok)
+                outcome = W.exec_()
+                if outcome == QtWidgets.QDialog.Accept:
+                    mouse_id = scheduled_mouse['Mouse ID']
                 print(mouse_id)
  
             if mouse_id is None:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2129,23 +2129,30 @@ class Window(QMainWindow):
 
         if open_last:
             scheduled_mouse = self._Open_getSchedule()
+            mice = self._Open_getListOfMice()
 
             mouse_id = None
+            ok = False
+            
+            # Found a scheduled mouse, ask user
             if scheduled_mouse is not None:
                 W = MouseScheduleDialog(self, scheduled_mouse)
                 outcome = W.exec_()
                 if outcome == QtWidgets.QDialog.Accepted:
                     mouse_id = scheduled_mouse['Mouse ID']
+                    ok = True
                 print(mouse_id)
- 
+                 
+            # User rejected schedule mouse, or no scheduled mouse
             if mouse_id is None:
-                mice = self._Open_getListOfMice()
+
                 W = MouseSelectorDialog(self, mice)
                 ok, mouse_id = (
                     W.exec_() == QtWidgets.QDialog.Accepted, 
                     W.combo.currentText(),
                 )        
 
+            # We don't have a mouse id
             if not ok: 
                 logging.info('Quick load failed, user hit cancel or X')
                 return                                

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2131,8 +2131,8 @@ class Window(QMainWindow):
             scheduled_mouse = self._Open_getSchedule()
 
             mouse_id = None
-            if schedule_mouse is not None:
-                W = MouseScheduleDialog(self, schedule_mouse)
+            if scheduled_mouse is not None:
+                W = MouseScheduleDialog(self, scheduled_mouse)
                 ok = (
                     W.exec_() == QtWidgets.QDialog.Accepted,
                 )

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2114,7 +2114,7 @@ class Window(QMainWindow):
         ''' 
             Returns the string of the start window for the most recent start window
         '''
-        if datetime.now().time() > datetime.strptime('05:00 PM','%I:%M %p').time():
+        if datetime.now().time() > datetime.strptime('01:30 PM','%I:%M %p').time():
             logging.info('After 5pm, no scheduled time')
             slot = ''
             return slot

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -11,6 +11,7 @@ from datetime import date, datetime
 
 import serial 
 import numpy as np
+import pandas as pd
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 from scipy.io import savemat, loadmat
 from PyQt5.QtWidgets import QApplication, QMainWindow, QMessageBox
@@ -2084,9 +2085,6 @@ class Window(QMainWindow):
         return schedule
 
     def _Open(self,open_last = False):
-
-        # stop current session first
-        self._StopCurrentSession() 
 
         # Start new session
         new_session = self._NewSession()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2037,7 +2037,7 @@ class Window(QMainWindow):
         '''
         filepath = os.path.join(self.default_saveFolder,self.current_box)
         if not os.path.isdir(filepath):
-            return mice
+            return []
         mouse_dirs = os.listdir(filepath)      
         mice = []
         for m in mouse_dirs:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2076,6 +2076,7 @@ class Window(QMainWindow):
         # Clean up, check its current
         schedule_date =  schedule.iloc[0]['Mouse ID']  
         schedule = schedule[['Mouse ID','Box','Time Slot']].dropna()
+        schedule['Box'] = ['447-'+x[0]+'-'+x[1] for x in schedule['Box']]
 
         # Is this schedule current?
         print(schedule)
@@ -2083,7 +2084,7 @@ class Window(QMainWindow):
         print(self.current_box)
         
         print(datetime.now())                     
-
+    
         return schedule
 
     def _Open(self,open_last = False):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2114,8 +2114,9 @@ class Window(QMainWindow):
         ''' 
             Returns the string of the start window for the most recent start window
         '''
-        if datetime.now().time() > datetime.strptime('01:30 PM','%I:%M %p').time():
-            logging.info('After 5pm, no scheduled time')
+        afternoon_cutoff = '01:30 PM'
+        if datetime.now().time() > datetime.strptime(afternoon_cutoff,'%I:%M %p').time():
+            logging.info('After {}, no scheduled time'.format(afternoon cutoff))
             slot = ''
             return slot
         starts = [datetime.strptime(x,'%I:%M %p').time() for x in starts]

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2133,13 +2133,11 @@ class Window(QMainWindow):
             mouse_id = None
             if scheduled_mouse is not None:
                 W = MouseScheduleDialog(self, scheduled_mouse)
-                ok = (
-                    W.exec_() == QtWidgets.QDialog.Accepted,
-                )
+                ok = W.exec_() == QtWidgets.QDialog.Accepted,
                 if ok:
                     mouse_id == scheduled_mouse['Mouse ID']
                 print(ok)
-                print(W.exec_())           
+                print(mouse_id)
  
             if mouse_id is None:
                 mice = self._Open_getListOfMice()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2130,14 +2130,16 @@ class Window(QMainWindow):
         if open_last:
             scheduled_mouse = self._Open_getSchedule()
 
+            mouse_id = None
             if schedule_mouse is not None:
-            W = MouseScheduleDialog(self, schedule_mouse)
-            ok = (
-                W.exec_() == QtWidgets.QDialog.Accepted,
-            )
-            if ok:
-                mouse_id == scheduled_mouse['Mouse ID']
-            else:  
+                W = MouseScheduleDialog(self, schedule_mouse)
+                ok = (
+                    W.exec_() == QtWidgets.QDialog.Accepted,
+                )
+                if ok:
+                    mouse_id == scheduled_mouse['Mouse ID']
+            
+            if mouse_id is None:
                 mice = self._Open_getListOfMice()
                 W = MouseSelectorDialog(self, mice)
                 ok, mouse_id = (

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2102,7 +2102,10 @@ class Window(QMainWindow):
             logging.error(str(e))
             return None
     
-    def _Open_findScheduleSlot(starts):
+    def _Open_findScheduleSlot(self, starts):
+        ''' 
+            Returns the string of the start window for the most recent start window
+        '''
         starts = [datetime.strptime(x,'%I:%M %p').time() for x in starts]
         starts.sort()
         after_start = np.where(np.array(starts) < datetime.now().time())[0]

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2036,6 +2036,8 @@ class Window(QMainWindow):
             Returns a list of mice with data saved on this computer
         '''
         filepath = os.path.join(self.default_saveFolder,self.current_box)
+        if not os.path.isdir(filepath):
+            return mice
         mouse_dirs = os.listdir(filepath)      
         mice = []
         for m in mouse_dirs:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2138,7 +2138,9 @@ class Window(QMainWindow):
                 )
                 if ok:
                     mouse_id == scheduled_mouse['Mouse ID']
-            
+                print(ok)
+                print(W.exec_())           
+ 
             if mouse_id is None:
                 mice = self._Open_getListOfMice()
                 W = MouseSelectorDialog(self, mice)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -27,7 +27,7 @@ from foraging_gui.Visualization import PlotV,PlotLickDistribution,PlotTimeDistri
 from foraging_gui.Dialogs import OptogeneticsDialog,WaterCalibrationDialog,CameraDialog
 from foraging_gui.Dialogs import LaserCalibrationDialog
 from foraging_gui.Dialogs import LickStaDialog,TimeDistributionDialog
-from foraging_gui.Dialogs import AutoTrainDialog, MouseSelectorDialog
+from foraging_gui.Dialogs import AutoTrainDialog, MouseSelectorDialog, MouseScheduleDialog
 from foraging_gui.MyFunctions import GenerateTrials, Worker,TimerWorker, NewScaleSerialY
 from foraging_gui.stage import Stage
 
@@ -2129,14 +2129,21 @@ class Window(QMainWindow):
 
         if open_last:
             scheduled_mouse = self._Open_getSchedule()
-            print(scheduled_mouse)
-            mice = self._Open_getListOfMice()
-            W = MouseSelectorDialog(self, scheduled_mouse, mice)
 
-            ok, mouse_id = (
-                W.exec_() == QtWidgets.QDialog.Accepted, 
-                W.combo.currentText(),
-            )        
+            if schedule_mouse is not None:
+            W = MouseScheduleDialog(self, schedule_mouse)
+            ok = (
+                W.exec_() == QtWidgets.QDialog.Accepted,
+            )
+            if ok:
+                mouse_id == scheduled_mouse['Mouse ID']
+            else:  
+                mice = self._Open_getListOfMice()
+                W = MouseSelectorDialog(self, mice)
+                ok, mouse_id = (
+                    W.exec_() == QtWidgets.QDialog.Accepted, 
+                    W.combo.currentText(),
+                )        
 
             if not ok: 
                 logging.info('Quick load failed, user hit cancel or X')


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Uses the published behavior schedule to make a suggestion of which mouse to load. 
    - We determine the current time slot by looking at the most recent start time. If it's within 30 minutes of a start time, then we use that suggestion.  
- The user must accept or reject the suggestion
- If the user accepts the suggestion, then the user either verifies the mouse/last session (like before), or verifies that this is a new mouse (like before). 
- If the user rejects the suggestion, then we use the existing prompt for the user to select the mouse from a dropdown menu, or type in the ID
- If there is any problem loading the schedule, then we use the existing prompt for the user to select the mouse from a dropdown menu, or type in the ID
- Potential problems that are handled:
    - The schedule file is missing
    - An error loading the schedule
    - A formatting error in the schedule
    - The schedule is older than 1 week
    - Its more than 30 minutes before the first scheduled time of the day
    - Its after 4pm (so past the last schedule of the day)
    - The current box is not listed in the schedule at this time
    - More than one mouse listed in this time/box
- The schedule needs to have the following format:
    - the first column/second row contains the date in Month/Date/Year format
    - The "Box" column should have a format like "1A"
    - The "Time Slot" column should have format H:MIN-H:MIN
    - The "Mouse ID" column should have the mouse id
    - One "sheet", not multiple pages

### What issues or discussions does this update address?
- Typing in the mouse ID is cumbersome, slow, and error prone
- resolves #281 

### Describe the expected change in behavior from the perspective of the experimenter
- If we are able to make a suggestion based on the schedule, you will see this prompt: 

<img width="300" alt="MicrosoftTeams-image3c5ed85059848185023763c2e3b1cb2206c9625d1136f67de0d929e88588b4eb" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/83be45c0-02c8-4a10-ae9e-f4c4268ce8f5"><br>


### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447
- [ ] Feedback from RAs
- [ ] Handle late afternoon sessions (4-6, 6:15, make sure AM/PM computed correctly, change cutoff time)
- [ ] We need a way to place the schedule on each rig computer
    - [ ] by monday morning 6m
    - [ ] as a `.csv` file
    - [ ] https://github.com/smartsheet/smartsheet-python-sdk



