### PR TITLE
Remove outdated menu options

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -176,7 +176,6 @@ class Window(QMainWindow):
         self.action_Open.triggered.connect(self._Open)
         self.action_Save.triggered.connect(self._Save)
         self.actionForce_save.triggered.connect(self._ForceSave)
-        self.SaveContinue.triggered.connect(self._SaveContinue)
         self.SaveAs.triggered.connect(self._SaveAs)
         self.action_Exit.triggered.connect(self._Exit)
         self.action_New.triggered.connect(self._New)
@@ -939,10 +938,6 @@ class Window(QMainWindow):
     def _ForceSave(self):
         '''Save whether the current trial is complete or not'''
         self._Save(ForceSave=1)
-
-    def _SaveContinue(self):
-        '''Do not restart a session after saving'''
-        self._Save(SaveContinue=1)
 
     def _SaveAs(self):
         '''Do not restart a session after saving'''
@@ -1759,8 +1754,8 @@ class Window(QMainWindow):
             "<p></p>",
         )
    
-    def _Save(self,ForceSave=0,SaveContinue=1,SaveAs=0):
-        logging.info('Saving current session, ForceSave={},SaveContinue={}'.format(ForceSave,SaveContinue))
+    def _Save(self,ForceSave=0,SaveAs=0):
+        logging.info('Saving current session, ForceSave={}'.format(ForceSave))
         if ForceSave==0:
             self._StopCurrentSession() # stop the current session first
         if self.BaseWeight.text()=='' or self.WeightAfter.text()=='' or self.TargetRatio.text()=='':
@@ -1910,16 +1905,6 @@ class Window(QMainWindow):
         if self.Camera_dialog.AutoControl.currentText()=='Yes':
             self.Camera_dialog.StartCamera.setChecked(False)
             self.Camera_dialog._StartCamera()
-        if SaveContinue==0:
-            # must start a new session 
-            self.NewSession.setStyleSheet("background-color : green;")
-            self.NewSession.setDisabled(True) 
-            self.StartANewSession=1
-            self.CreateNewFolder=1
-            try:
-                self.Channel.StopLogging('s')
-            except Exception as e:
-                logging.error(str(e))
 
         # Toggle unsaved data to False
         self.unsaved_data=False

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4896,7 +4896,6 @@ Current pair:
     <addaction name="action_Exit"/>
     <addaction name="action_Clear"/>
     <addaction name="actionForce_save"/>
-    <addaction name="SaveContinue"/>
     <addaction name="SaveAs"/>
    </widget>
    <widget class="QMenu" name="menuTools">
@@ -5251,11 +5250,6 @@ Current pair:
    </property>
    <property name="text">
     <string>Licks distribution</string>
-   </property>
-  </action>
-  <action name="SaveContinue">
-   <property name="text">
-    <string>Save (without restarting a session)</string>
    </property>
   </action>
   <action name="SaveAs">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4892,7 +4892,6 @@ Current pair:
     </property>
     <addaction name="action_New"/>
     <addaction name="action_Open"/>
-    <addaction name="action_Open_Recent"/>
     <addaction name="action_Save"/>
     <addaction name="action_Exit"/>
     <addaction name="action_Clear"/>
@@ -5114,11 +5113,6 @@ Current pair:
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
-   </property>
-  </action>
-  <action name="action_Open_Recent">
-   <property name="text">
-    <string>Open &amp;Recent</string>
    </property>
   </action>
   <action name="action_Save">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4432,7 +4432,6 @@
     </property>
     <addaction name="action_New"/>
     <addaction name="action_Open"/>
-    <addaction name="action_Open_Recent"/>
     <addaction name="action_Save"/>
     <addaction name="action_Exit"/>
     <addaction name="action_Clear"/>
@@ -4654,11 +4653,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
-   </property>
-  </action>
-  <action name="action_Open_Recent">
-   <property name="text">
-    <string>Open &amp;Recent</string>
    </property>
   </action>
   <action name="action_Save">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4436,7 +4436,6 @@
     <addaction name="action_Exit"/>
     <addaction name="action_Clear"/>
     <addaction name="actionForce_save"/>
-    <addaction name="SaveContinue"/>
     <addaction name="SaveAs"/>
    </widget>
    <widget class="QMenu" name="menuTools">
@@ -4791,11 +4790,6 @@
    </property>
    <property name="text">
     <string>Licks distribution</string>
-   </property>
-  </action>
-  <action name="SaveContinue">
-   <property name="text">
-    <string>Save (without restarting a session)</string>
    </property>
   </action>
   <action name="SaveAs">

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1721,11 +1721,6 @@ class GenerateTrials():
                 # Set an attribute in self with the name 'TP_' followed by the child's object name
                 # and store whether the child is checked or not
                 setattr(self, 'TP_'+child.objectName(), child.isChecked())
-        # log folder
-        try:
-            self.TP_log_folder=win.Ot_log_folder
-        except Exception as e:
-            logging.error(str(e))
             
         # Manually attach auto training parameters 
         if hasattr(win, 'AutoTrain_dialog') and win.AutoTrain_dialog.auto_train_engaged:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "production_testing" into "main" should use the keyword "production merge" in the title for reliable indexing of updates
  
### Describe changes:
- Removes the `Open Recent` option in the file menu, that was never implemented
- Removes the `Save (without restarting)` option in the file menu, since this is redundant with `Save`
- Removes code mention of `TP_log_folder` in MyFunctions, because this attribute was never used, and generated errors when starting a new session

### What issues or discussions does this update address?
- Resolves #291 
- Resolves #290 

### Describe the expected change in behavior from the perspective of the experimenter
Removes outdated options in the file menu

### Describe the outcome of testing this update on a rig in 447
- [x] tested in 447




