### PR TITLE
Check for 0 choices, or 0 rewards before plotting matching plot

### DIFF
--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1498,7 +1498,7 @@ class GenerateTrials():
             if np.random.random(1)<0.1: # no response
                 self.B_AnimalCurrentResponse=2
             else:
-                self.B_AnimalCurrentResponse=0#random.choice(range(2)) ##DEBUGGING
+                self.B_AnimalCurrentResponse=random.choice(range(2))
 
         if self.B_AnimalCurrentResponse==2:
             self.B_CurrentRewarded[0]=False

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1498,7 +1498,7 @@ class GenerateTrials():
             if np.random.random(1)<0.1: # no response
                 self.B_AnimalCurrentResponse=2
             else:
-                self.B_AnimalCurrentResponse=random.choice(range(2))
+                self.B_AnimalCurrentResponse=0#random.choice(range(2)) ##DEBUGGING
 
         if self.B_AnimalCurrentResponse==2:
             self.B_CurrentRewarded[0]=False

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -269,7 +269,7 @@ class PlotV(FigureCanvas):
             choice_R_frac[idx]=LeftChoiceN/(LeftChoiceN+RightChoiceN)
             if LeftRewardN+RightRewardN!=0:
                 reward_R_frac[idx]=LeftRewardN/(LeftRewardN+RightRewardN)
-            if RightChoiceN and LeftChoiceN and RightRewardN and LeftRewardN:
+            if (RightChoiceN!=0) and (LeftChoiceN!=0) and (RightRewardN!=0) and (LeftRewardN!=0):
                 choice_log_ratio[idx]=np.log(RightChoiceN / LeftChoiceN)
                 reward_log_ratio[idx]=np.log(RightRewardN / LeftRewardN)
             WinStartN=WinStartN+StepSize

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -269,8 +269,7 @@ class PlotV(FigureCanvas):
             choice_R_frac[idx]=LeftChoiceN/(LeftChoiceN+RightChoiceN)
             if LeftRewardN+RightRewardN!=0:
                 reward_R_frac[idx]=LeftRewardN/(LeftRewardN+RightRewardN)
-            #if (RightChoiceN!=0) and (LeftChoiceN!=0) and (RightRewardN!=0) and (LeftRewardN!=0):
-            if RightChoiceN and LeftChoiceN and RightRewardN and LeftRewardN:
+            if (RightChoiceN!=0) and (LeftChoiceN!=0) and (RightRewardN!=0) and (LeftRewardN!=0):
                 choice_log_ratio[idx]=np.log(RightChoiceN / LeftChoiceN)
                 reward_log_ratio[idx]=np.log(RightRewardN / LeftRewardN)
             WinStartN=WinStartN+StepSize

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -269,7 +269,8 @@ class PlotV(FigureCanvas):
             choice_R_frac[idx]=LeftChoiceN/(LeftChoiceN+RightChoiceN)
             if LeftRewardN+RightRewardN!=0:
                 reward_R_frac[idx]=LeftRewardN/(LeftRewardN+RightRewardN)
-            if (RightChoiceN!=0) and (LeftChoiceN!=0) and (RightRewardN!=0) and (LeftRewardN!=0):
+            #if (RightChoiceN!=0) and (LeftChoiceN!=0) and (RightRewardN!=0) and (LeftRewardN!=0):
+            if RightChoiceN and LeftChoiceN and RightRewardN and LeftRewardN:
                 choice_log_ratio[idx]=np.log(RightChoiceN / LeftChoiceN)
                 reward_log_ratio[idx]=np.log(RightRewardN / LeftRewardN)
             WinStartN=WinStartN+StepSize


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Adds a check before `np.log(RightChoiceN / Left ChoiceN)` and `np.log(RightRewardN / LeftRewardN)`

### What issues or discussions does this update address?
- resolves #308

### Describe the expected change in behavior from the perspective of the experimenter
- No changes

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




