### PR TITLE
Quick check for default experimenter field

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2789,6 +2789,7 @@ class Window(QMainWindow):
             # check experimenter name
             if self.Experimenter.text() == "the ghost in the shell":
                 reply = QMessageBox.question(self,
+                    'Box {}, Start'.format(self.box_letter),    
                     'Experimenter field set to default, continue anyways?',
                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
                 if reply == QMessageBox.No:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2769,8 +2769,6 @@ class Window(QMainWindow):
 
         # Clear warnings
         self.WarningLabelInitializeBonsai.setText('')
-        #self.WarningLabel_SaveTrainingStage.setText('')
-        #self.WarningLabel_SaveTrainingStage.setStyleSheet("color: none;")
         self.NewSession.setDisabled(False)
             
         # Toggle button colors
@@ -2787,6 +2785,17 @@ class Window(QMainWindow):
                     self.Start.setChecked(False)
                     logging.info('User declines continuation of session')
                     return
+
+            # check experimenter name
+            if self.Experimenter.text() == "the ghost in the shell":
+                reply = QMessageBox.question(self,
+                    'Experimenter field set to default, continue anyways?',
+                    QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+                if reply == QMessageBox.No:
+                    self.Start.setChecked(False)
+                    logging.info('User declines using default name')
+                    return                
+            logging.info('Starting session, with experimenter: {}'.format(self.Experimenter.text()))
 
             # change button color and mark the state change
             self.Start.setStyleSheet("background-color : green;")


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Adds a check at session start for the experimenter field set to the default value. 

### What issues or discussions does this update address?
- partially resolves #294

### Describe the expected change in behavior from the perspective of the experimenter
If you forget to change the experimenter field for a mouse, it will prompt you. 

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




