### PR TITLE
Update camera node

### DIFF
--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -4,3 +4,6 @@ BonsaiOsc1,4002
 BonsaiOsc2,4003
 BonsaiOsc3,4004
 BonsaiOsc4,4005
+HighSpeedCamera,0
+SideCamera,23022724
+BottomCamera,23022709

--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -5,5 +5,5 @@ BonsaiOsc2,4003
 BonsaiOsc3,4004
 BonsaiOsc4,4005
 HighSpeedCamera,0
-SideCamera,23022724
-BottomCamera,23022709
+SideCamera,12345678
+BottomCamera,12345678

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -4,3 +4,6 @@ BonsaiOsc1,4012
 BonsaiOsc2,4013
 BonsaiOsc3,4014
 BonsaiOsc4,4015
+HighSpeedCamera,0
+SideCamera,23022724
+BottomCamera,23022709

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -5,5 +5,5 @@ BonsaiOsc2,4013
 BonsaiOsc3,4014
 BonsaiOsc4,4015
 HighSpeedCamera,0
-SideCamera,23022724
-BottomCamera,23022709
+SideCamera,12345678
+BottomCamera,12345678

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -5,5 +5,5 @@ BonsaiOsc2,4023
 BonsaiOsc3,4024
 BonsaiOsc4,4025
 HighSpeedCamera,0
-SideCamera,23022724
-BottomCamera,23022709
+SideCamera,12345678
+BottomCamera,12345678

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -4,3 +4,6 @@ BonsaiOsc1,4022
 BonsaiOsc2,4023
 BonsaiOsc3,4024
 BonsaiOsc4,4025
+HighSpeedCamera,0
+SideCamera,23022724
+BottomCamera,23022709

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -4,3 +4,6 @@ BonsaiOsc1,4032
 BonsaiOsc2,4033
 BonsaiOsc3,4034
 BonsaiOsc4,4035
+HighSpeedCamera,0
+SideCamera,23022724
+BottomCamera,23022709

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -5,5 +5,5 @@ BonsaiOsc2,4033
 BonsaiOsc3,4034
 BonsaiOsc4,4035
 HighSpeedCamera,0
-SideCamera,23022724
-BottomCamera,23022709
+SideCamera,12345678
+BottomCamera,12345678

--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -6865,308 +6865,361 @@
                 </Workflow>
               </Builder>
             </Expression>
-            <Expression xsi:type="Disable">
-              <Builder xsi:type="GroupWorkflow">
-                <Name>HighSpeedCamera</Name>
-                <Workflow>
-                  <Nodes>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>BottomCameraFrames</Name>
-                    </Expression>
-                    <Expression xsi:type="MemberSelector">
-                      <Selector>Item1.ChunkData.FrameID</Selector>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="dsp:Difference">
-                        <dsp:Order>1</dsp:Order>
-                      </Combinator>
-                    </Expression>
-                    <Expression xsi:type="Subtract">
-                      <Operand xsi:type="DoubleProperty">
-                        <Value>1</Value>
-                      </Operand>
-                    </Expression>
-                    <Expression xsi:type="rx:Accumulate" />
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>Camerafrequency</Name>
-                    </Expression>
-                    <Expression xsi:type="beh:Format">
-                      <harp:MessageType>Write</harp:MessageType>
-                      <harp:Register xsi:type="beh:Camera1Frequency" />
-                    </Expression>
-                    <Expression xsi:type="MulticastSubject">
-                      <Name>BehaviorCommands</Name>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>Cameracontrol</Name>
-                    </Expression>
-                    <Expression xsi:type="Equal">
-                      <Operand xsi:type="IntProperty">
-                        <Value>1</Value>
-                      </Operand>
-                    </Expression>
-                    <Expression xsi:type="rx:Condition">
-                      <Workflow>
-                        <Nodes>
-                          <Expression xsi:type="WorkflowInput">
-                            <Name>Source1</Name>
-                          </Expression>
-                          <Expression xsi:type="WorkflowOutput" />
-                        </Nodes>
-                        <Edges>
-                          <Edge From="0" To="1" Label="Source1" />
-                        </Edges>
-                      </Workflow>
-                    </Expression>
-                    <Expression xsi:type="beh:CreateMessage">
-                      <harp:MessageType>Write</harp:MessageType>
-                      <harp:Payload xsi:type="beh:CreateStartCamerasPayload">
-                        <beh:StartCameras>CameraOutput1</beh:StartCameras>
-                      </harp:Payload>
-                    </Expression>
-                    <Expression xsi:type="MulticastSubject">
-                      <Name>BehaviorCommands</Name>
-                    </Expression>
-                    <Expression xsi:type="Equal">
-                      <Operand xsi:type="IntProperty">
-                        <Value>2</Value>
-                      </Operand>
-                    </Expression>
-                    <Expression xsi:type="rx:Condition">
-                      <Workflow>
-                        <Nodes>
-                          <Expression xsi:type="WorkflowInput">
-                            <Name>Source1</Name>
-                          </Expression>
-                          <Expression xsi:type="WorkflowOutput" />
-                        </Nodes>
-                        <Edges>
-                          <Edge From="0" To="1" Label="Source1" />
-                        </Edges>
-                      </Workflow>
-                    </Expression>
-                    <Expression xsi:type="beh:CreateMessage">
-                      <harp:MessageType>Write</harp:MessageType>
-                      <harp:Payload xsi:type="beh:CreateStopCamerasPayload">
-                        <beh:StopCameras>CameraOutput1</beh:StopCameras>
-                      </harp:Payload>
-                    </Expression>
-                    <Expression xsi:type="MulticastSubject">
-                      <Name>BehaviorCommands</Name>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="spk:SpinnakerCapture">
-                        <spk:Index xsi:nil="true" />
-                        <spk:SerialNumber>23022717</spk:SerialNumber>
-                        <spk:ColorProcessing>Default</spk:ColorProcessing>
-                      </Combinator>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>BehaviorEvents</Name>
-                    </Expression>
-                    <Expression xsi:type="beh:Parse">
-                      <harp:Register xsi:type="beh:TimestampedCamera1Frame" />
-                    </Expression>
-                    <Expression xsi:type="MemberSelector">
-                      <Selector>Seconds</Selector>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="rx:Zip" />
-                    </Expression>
-                    <Expression xsi:type="rx:PublishSubject">
-                      <Name>SideCameraFrames</Name>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="spk:SpinnakerCapture">
-                        <spk:Index xsi:nil="true" />
-                        <spk:SerialNumber>23045805</spk:SerialNumber>
-                        <spk:ColorProcessing>Default</spk:ColorProcessing>
-                      </Combinator>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>BehaviorEvents</Name>
-                    </Expression>
-                    <Expression xsi:type="beh:Parse">
-                      <harp:Register xsi:type="beh:TimestampedCamera1Frame" />
-                    </Expression>
-                    <Expression xsi:type="MemberSelector">
-                      <Selector>Seconds</Selector>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="rx:Zip" />
-                    </Expression>
-                    <Expression xsi:type="rx:PublishSubject">
-                      <Name>BottomCameraFrames</Name>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>BottomCameraFrames</Name>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="harp:CreateTimestamped" />
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>RootPath</Name>
-                    </Expression>
-                    <Expression xsi:type="Format">
-                      <Format>{0}/../VideoFolder/bottom_camera.csv</Format>
-                      <Selector />
-                    </Expression>
-                    <Expression xsi:type="PropertyMapping">
-                      <PropertyMappings>
-                        <Property Name="FileName" />
-                      </PropertyMappings>
-                    </Expression>
-                    <Expression xsi:type="io:CsvWriter">
-                      <io:FileName>E:\DynamicForagingGUI\BehaviorData\Tower_EphysRig3\641733\641733_2023-12-08_15-48-06\HarpFolder/../VideoFolder/bottom_camera.csv</io:FileName>
-                      <io:Append>false</io:Append>
-                      <io:Overwrite>true</io:Overwrite>
-                      <io:Suffix>None</io:Suffix>
-                      <io:IncludeHeader>false</io:IncludeHeader>
-                      <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp,Value.ChunkData.Gain,Value.ChunkData.ExposureTime</io:Selector>
-                    </Expression>
-                    <Expression xsi:type="MemberSelector">
-                      <Selector>Value.Image</Selector>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>RootPath</Name>
-                    </Expression>
-                    <Expression xsi:type="Format">
-                      <Format>{0}/../VideoFolder/bottom_camera.avi</Format>
-                      <Selector />
-                    </Expression>
-                    <Expression xsi:type="PropertyMapping">
-                      <PropertyMappings>
-                        <Property Name="FileName" />
-                      </PropertyMappings>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>CameraFrequency</Name>
-                    </Expression>
-                    <Expression xsi:type="PropertyMapping">
-                      <PropertyMappings>
-                        <Property Name="FrameRate" />
-                      </PropertyMappings>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="ffmpeg:VideoWriter">
-                        <ffmpeg:FileName>E:\DynamicForagingGUI\BehaviorData\Tower_EphysRig3\641733\641733_2023-12-08_15-48-06\HarpFolder/../VideoFolder/bottom_camera.avi</ffmpeg:FileName>
-                        <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                        <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
-                        <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                        <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset fast</ffmpeg:OutputArguments>
-                      </Combinator>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>SideCameraFrames</Name>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="harp:CreateTimestamped" />
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>RootPath</Name>
-                    </Expression>
-                    <Expression xsi:type="Format">
-                      <Format>{0}/../VideoFolder/side_camera.csv</Format>
-                      <Selector />
-                    </Expression>
-                    <Expression xsi:type="PropertyMapping">
-                      <PropertyMappings>
-                        <Property Name="FileName" />
-                      </PropertyMappings>
-                    </Expression>
-                    <Expression xsi:type="io:CsvWriter">
-                      <io:FileName>E:\DynamicForagingGUI\BehaviorData\Tower_EphysRig3\641733\641733_2023-12-08_15-48-06\HarpFolder/../VideoFolder/side_camera.csv</io:FileName>
-                      <io:Append>false</io:Append>
-                      <io:Overwrite>true</io:Overwrite>
-                      <io:Suffix>None</io:Suffix>
-                      <io:IncludeHeader>false</io:IncludeHeader>
-                      <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp,Value.ChunkData.Gain,Value.ChunkData.ExposureTime</io:Selector>
-                    </Expression>
-                    <Expression xsi:type="MemberSelector">
-                      <Selector>Value.Image</Selector>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>RootPath</Name>
-                    </Expression>
-                    <Expression xsi:type="Format">
-                      <Format>{0}/../VideoFolder/side_camera.avi</Format>
-                      <Selector />
-                    </Expression>
-                    <Expression xsi:type="PropertyMapping">
-                      <PropertyMappings>
-                        <Property Name="FileName" />
-                      </PropertyMappings>
-                    </Expression>
-                    <Expression xsi:type="SubscribeSubject">
-                      <Name>CameraFrequency</Name>
-                    </Expression>
-                    <Expression xsi:type="PropertyMapping">
-                      <PropertyMappings>
-                        <Property Name="FrameRate" />
-                      </PropertyMappings>
-                    </Expression>
-                    <Expression xsi:type="Combinator">
-                      <Combinator xsi:type="ffmpeg:VideoWriter">
-                        <ffmpeg:FileName>E:\DynamicForagingGUI\BehaviorData\Tower_EphysRig3\641733\641733_2023-12-08_15-48-06\HarpFolder/../VideoFolder/side_camera.avi</ffmpeg:FileName>
-                        <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                        <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
-                        <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                        <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset fast</ffmpeg:OutputArguments>
-                      </Combinator>
-                    </Expression>
-                  </Nodes>
-                  <Edges>
-                    <Edge From="0" To="1" Label="Source1" />
-                    <Edge From="1" To="2" Label="Source1" />
-                    <Edge From="2" To="3" Label="Source1" />
-                    <Edge From="3" To="4" Label="Source1" />
-                    <Edge From="5" To="6" Label="Source1" />
-                    <Edge From="6" To="7" Label="Source1" />
-                    <Edge From="8" To="9" Label="Source1" />
-                    <Edge From="8" To="13" Label="Source1" />
-                    <Edge From="9" To="10" Label="Source1" />
-                    <Edge From="10" To="11" Label="Source1" />
-                    <Edge From="11" To="12" Label="Source1" />
-                    <Edge From="13" To="14" Label="Source1" />
-                    <Edge From="14" To="15" Label="Source1" />
-                    <Edge From="15" To="16" Label="Source1" />
-                    <Edge From="17" To="21" Label="Source1" />
-                    <Edge From="18" To="19" Label="Source1" />
-                    <Edge From="19" To="20" Label="Source1" />
-                    <Edge From="20" To="21" Label="Source2" />
-                    <Edge From="21" To="22" Label="Source1" />
-                    <Edge From="23" To="27" Label="Source1" />
-                    <Edge From="24" To="25" Label="Source1" />
-                    <Edge From="25" To="26" Label="Source1" />
-                    <Edge From="26" To="27" Label="Source2" />
-                    <Edge From="27" To="28" Label="Source1" />
-                    <Edge From="29" To="30" Label="Source1" />
-                    <Edge From="30" To="34" Label="Source1" />
-                    <Edge From="31" To="32" Label="Source1" />
-                    <Edge From="32" To="33" Label="Source1" />
-                    <Edge From="33" To="34" Label="Source2" />
-                    <Edge From="34" To="35" Label="Source1" />
-                    <Edge From="35" To="41" Label="Source1" />
-                    <Edge From="36" To="37" Label="Source1" />
-                    <Edge From="37" To="38" Label="Source1" />
-                    <Edge From="38" To="41" Label="Source2" />
-                    <Edge From="39" To="40" Label="Source1" />
-                    <Edge From="40" To="41" Label="Source3" />
-                    <Edge From="42" To="43" Label="Source1" />
-                    <Edge From="43" To="47" Label="Source1" />
-                    <Edge From="44" To="45" Label="Source1" />
-                    <Edge From="45" To="46" Label="Source1" />
-                    <Edge From="46" To="47" Label="Source2" />
-                    <Edge From="47" To="48" Label="Source1" />
-                    <Edge From="48" To="54" Label="Source1" />
-                    <Edge From="49" To="50" Label="Source1" />
-                    <Edge From="50" To="51" Label="Source1" />
-                    <Edge From="51" To="54" Label="Source2" />
-                    <Edge From="52" To="53" Label="Source1" />
-                    <Edge From="53" To="54" Label="Source3" />
-                  </Edges>
-                </Workflow>
-              </Builder>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>HighSpeedCamera</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>BottomCameraFrames</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Item1.ChunkData.FrameID</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="dsp:Difference">
+                      <dsp:Order>1</dsp:Order>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="Subtract">
+                    <Operand xsi:type="DoubleProperty">
+                      <Value>1</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="rx:Accumulate" />
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>Camerafrequency</Name>
+                  </Expression>
+                  <Expression xsi:type="beh:Format">
+                    <harp:MessageType>Write</harp:MessageType>
+                    <harp:Register xsi:type="beh:Camera1Frequency" />
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>BehaviorCommands</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>Cameracontrol</Name>
+                  </Expression>
+                  <Expression xsi:type="Equal">
+                    <Operand xsi:type="IntProperty">
+                      <Value>1</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="rx:Condition">
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="WorkflowInput">
+                          <Name>Source1</Name>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Delay">
+                      <rx:DueTime>PT2S</rx:DueTime>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="beh:CreateMessage">
+                    <harp:MessageType>Write</harp:MessageType>
+                    <harp:Payload xsi:type="beh:CreateStartCamerasPayload">
+                      <beh:StartCameras>CameraOutput1</beh:StartCameras>
+                    </harp:Payload>
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>BehaviorCommands</Name>
+                  </Expression>
+                  <Expression xsi:type="Equal">
+                    <Operand xsi:type="IntProperty">
+                      <Value>2</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="rx:Condition">
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="WorkflowInput">
+                          <Name>Source1</Name>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="beh:CreateMessage">
+                    <harp:MessageType>Write</harp:MessageType>
+                    <harp:Payload xsi:type="beh:CreateStopCamerasPayload">
+                      <beh:StopCameras>CameraOutput1</beh:StopCameras>
+                    </harp:Payload>
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>BehaviorCommands</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>ComPorts</Name>
+                  </Expression>
+                  <Expression xsi:type="Index">
+                    <Operand xsi:type="StringProperty">
+                      <Value>SideCamera</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="spk:SpinnakerCapture">
+                      <spk:Index xsi:nil="true" />
+                      <spk:SerialNumber>23022724</spk:SerialNumber>
+                      <spk:ColorProcessing>Default</spk:ColorProcessing>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>BehaviorEvents</Name>
+                  </Expression>
+                  <Expression xsi:type="beh:Parse">
+                    <harp:Register xsi:type="beh:TimestampedCamera1Frame" />
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Seconds</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="rx:PublishSubject">
+                    <Name>SideCameraFrames</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>ComPorts</Name>
+                  </Expression>
+                  <Expression xsi:type="Index">
+                    <Operand xsi:type="StringProperty">
+                      <Value>BottomCamera</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="spk:SpinnakerCapture">
+                      <spk:Index xsi:nil="true" />
+                      <spk:SerialNumber>23022709</spk:SerialNumber>
+                      <spk:ColorProcessing>Default</spk:ColorProcessing>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>BehaviorEvents</Name>
+                  </Expression>
+                  <Expression xsi:type="beh:Parse">
+                    <harp:Register xsi:type="beh:TimestampedCamera1Frame" />
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Seconds</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="rx:PublishSubject">
+                    <Name>BottomCameraFrames</Name>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>BottomCameraFrames</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="harp:CreateTimestamped" />
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>RootPath</Name>
+                  </Expression>
+                  <Expression xsi:type="Format">
+                    <Format>{0}/../VideoFolder/bottom_camera.csv</Format>
+                    <Selector />
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FileName" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="io:CsvWriter">
+                    <io:FileName>C:\Users\svc_aind_ephys\Documents\temporaryvideo\2024-03-21_09-52-50\HarpFolder/../VideoFolder/bottom_camera.csv</io:FileName>
+                    <io:Append>false</io:Append>
+                    <io:Overwrite>true</io:Overwrite>
+                    <io:Suffix>None</io:Suffix>
+                    <io:IncludeHeader>false</io:IncludeHeader>
+                    <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp,Value.ChunkData.Gain,Value.ChunkData.ExposureTime</io:Selector>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Value.Image</Selector>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>RootPath</Name>
+                  </Expression>
+                  <Expression xsi:type="Format">
+                    <Format>{0}/../VideoFolder/bottom_camera.avi</Format>
+                    <Selector />
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FileName" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>CameraFrequency</Name>
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FrameRate" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="ffmpeg:VideoWriter">
+                      <ffmpeg:FileName>C:\Users\svc_aind_ephys\Documents\temporaryvideo\2024-03-21_09-52-50\HarpFolder/../VideoFolder/bottom_camera.avi</ffmpeg:FileName>
+                      <ffmpeg:Suffix>None</ffmpeg:Suffix>
+                      <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
+                      <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
+                      <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset fast</ffmpeg:OutputArguments>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>SideCameraFrames</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="harp:CreateTimestamped" />
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>RootPath</Name>
+                  </Expression>
+                  <Expression xsi:type="Format">
+                    <Format>{0}/../VideoFolder/side_camera.csv</Format>
+                    <Selector />
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FileName" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="io:CsvWriter">
+                    <io:FileName>C:\Users\svc_aind_ephys\Documents\temporaryvideo\2024-03-21_09-52-50\HarpFolder/../VideoFolder/side_camera.csv</io:FileName>
+                    <io:Append>false</io:Append>
+                    <io:Overwrite>true</io:Overwrite>
+                    <io:Suffix>None</io:Suffix>
+                    <io:IncludeHeader>false</io:IncludeHeader>
+                    <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp,Value.ChunkData.Gain,Value.ChunkData.ExposureTime</io:Selector>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Value.Image</Selector>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>RootPath</Name>
+                  </Expression>
+                  <Expression xsi:type="Format">
+                    <Format>{0}/../VideoFolder/side_camera.avi</Format>
+                    <Selector />
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FileName" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>CameraFrequency</Name>
+                  </Expression>
+                  <Expression xsi:type="PropertyMapping">
+                    <PropertyMappings>
+                      <Property Name="FrameRate" />
+                    </PropertyMappings>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="ffmpeg:VideoWriter">
+                      <ffmpeg:FileName>C:\Users\svc_aind_ephys\Documents\temporaryvideo\2024-03-21_09-52-50\HarpFolder/../VideoFolder/side_camera.avi</ffmpeg:FileName>
+                      <ffmpeg:Suffix>None</ffmpeg:Suffix>
+                      <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
+                      <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
+                      <ffmpeg:OutputArguments>-vcodec libx264 -crf 23 -preset fast</ffmpeg:OutputArguments>
+                    </Combinator>
+                  </Expression>
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="4" Label="Source1" />
+                  <Edge From="5" To="6" Label="Source1" />
+                  <Edge From="6" To="7" Label="Source1" />
+                  <Edge From="8" To="9" Label="Source1" />
+                  <Edge From="8" To="14" Label="Source1" />
+                  <Edge From="9" To="10" Label="Source1" />
+                  <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="11" To="12" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="14" To="15" Label="Source1" />
+                  <Edge From="15" To="16" Label="Source1" />
+                  <Edge From="16" To="17" Label="Source1" />
+                  <Edge From="18" To="19" Label="Source1" />
+                  <Edge From="19" To="20" Label="Source1" />
+                  <Edge From="20" To="24" Label="Source1" />
+                  <Edge From="21" To="22" Label="Source1" />
+                  <Edge From="22" To="23" Label="Source1" />
+                  <Edge From="23" To="24" Label="Source2" />
+                  <Edge From="24" To="25" Label="Source1" />
+                  <Edge From="26" To="27" Label="Source1" />
+                  <Edge From="27" To="28" Label="Source1" />
+                  <Edge From="28" To="32" Label="Source1" />
+                  <Edge From="29" To="30" Label="Source1" />
+                  <Edge From="30" To="31" Label="Source1" />
+                  <Edge From="31" To="32" Label="Source2" />
+                  <Edge From="32" To="33" Label="Source1" />
+                  <Edge From="34" To="35" Label="Source1" />
+                  <Edge From="35" To="39" Label="Source1" />
+                  <Edge From="36" To="37" Label="Source1" />
+                  <Edge From="37" To="38" Label="Source1" />
+                  <Edge From="38" To="39" Label="Source2" />
+                  <Edge From="39" To="40" Label="Source1" />
+                  <Edge From="40" To="46" Label="Source1" />
+                  <Edge From="41" To="42" Label="Source1" />
+                  <Edge From="42" To="43" Label="Source1" />
+                  <Edge From="43" To="46" Label="Source2" />
+                  <Edge From="44" To="45" Label="Source1" />
+                  <Edge From="45" To="46" Label="Source3" />
+                  <Edge From="47" To="48" Label="Source1" />
+                  <Edge From="48" To="52" Label="Source1" />
+                  <Edge From="49" To="50" Label="Source1" />
+                  <Edge From="50" To="51" Label="Source1" />
+                  <Edge From="51" To="52" Label="Source2" />
+                  <Edge From="52" To="53" Label="Source1" />
+                  <Edge From="53" To="59" Label="Source1" />
+                  <Edge From="54" To="55" Label="Source1" />
+                  <Edge From="55" To="56" Label="Source1" />
+                  <Edge From="56" To="59" Label="Source2" />
+                  <Edge From="57" To="58" Label="Source1" />
+                  <Edge From="58" To="59" Label="Source3" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ComPorts</Name>
+            </Expression>
+            <Expression xsi:type="Index">
+              <Operand xsi:type="StringProperty">
+                <Value>HighSpeedCamera</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="NotEqual">
+              <Operand xsi:type="StringProperty">
+                <Value>0</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="rx:Condition">
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:SubscribeWhen" />
             </Expression>
           </Nodes>
           <Edges>
@@ -7195,6 +7248,11 @@
             <Edge From="32" To="33" Label="Source1" />
             <Edge From="34" To="35" Label="Source1" />
             <Edge From="36" To="37" Label="Source1" />
+            <Edge From="39" To="44" Label="Source1" />
+            <Edge From="40" To="41" Label="Source1" />
+            <Edge From="41" To="42" Label="Source1" />
+            <Edge From="42" To="43" Label="Source1" />
+            <Edge From="43" To="44" Label="Source2" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/workflows/foraging.bonsai.layout
+++ b/src/workflows/foraging.bonsai.layout
@@ -45,7 +45,7 @@
       </Location>
       <Size>
         <Width>1436</Width>
-        <Height>660</Height>
+        <Height>659</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -647,7 +647,7 @@
       </Location>
       <Size>
         <Width>1436</Width>
-        <Height>660</Height>
+        <Height>659</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -671,7 +671,7 @@
           </Location>
           <Size>
             <Width>1436</Width>
-            <Height>660</Height>
+            <Height>659</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -853,7 +853,7 @@
           </Location>
           <Size>
             <Width>1436</Width>
-            <Height>660</Height>
+            <Height>659</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -3245,7 +3245,7 @@
       </Location>
       <Size>
         <Width>1436</Width>
-        <Height>660</Height>
+        <Height>659</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -3751,7 +3751,7 @@
       </Location>
       <Size>
         <Width>1436</Width>
-        <Height>660</Height>
+        <Height>659</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -3775,7 +3775,7 @@
           </Location>
           <Size>
             <Width>1436</Width>
-            <Height>660</Height>
+            <Height>659</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -5517,7 +5517,7 @@
           </Location>
           <Size>
             <Width>1436</Width>
-            <Height>660</Height>
+            <Height>659</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -6438,7 +6438,7 @@
     </Size>
     <WindowState>Normal</WindowState>
   </DialogSettings>
-  <DialogSettings>
+  <DialogSettings xsi:type="WorkflowEditorSettings">
     <Visible>false</Visible>
     <Location>
       <X>0</X>
@@ -6449,6 +6449,560 @@
       <Height>0</Height>
     </Size>
     <WindowState>Normal</WindowState>
+    <EditorDialogSettings>
+      <Visible>true</Visible>
+      <Location>
+        <X>-1326</X>
+        <Y>229</Y>
+      </Location>
+      <Size>
+        <Width>864</Width>
+        <Height>608</Height>
+      </Size>
+      <WindowState>Normal</WindowState>
+    </EditorDialogSettings>
+    <EditorVisualizerLayout>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+    </EditorVisualizerLayout>
   </DialogSettings>
   <DialogSettings>
     <Visible>false</Visible>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Subscribe the` HighSpeedCamera` node based on the `HighSpeedCamera` (0 does not subscribe; otherwise subscribe) field in the `Settings_box#.csv`. 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/09a4dfca-f578-445d-8ba6-8a3a1ef5d005)
2. Read the camera Serial Number (BottomCamera and SideCamera) from the `Settings_box#.csv`. 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/6e7c68ca-8c3e-48b1-989c-70de05add6f3)

4. Updated the template `Settings_box#.csv`

### What issues or discussions does this update address?
Resolves: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/190#issuecomment-2013007954

### Describe the expected change in behavior from the perspective of the experimenter
1. We need to add `HighSpeedCamera` field to the Settings_box#.csv, and set the value to `0` in the training rig. 
2. In the ephys rig we should add the `HighSpeedCamera` field to `Settings_box#.csv` and set the value to `1` if we want to use the camera node. The serial numbers for `BottomCamera` and `SideCamera` should also be set in Settings_box#.csv.
### Describe the outcome of testing this update on a rig in 447
Tested in the ephys rig1. 




