### PR TITLE
Create a finished indicator when date is ready for upload

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1924,6 +1924,13 @@ class Window(QMainWindow):
         self.SessionlistSpin.setEnabled(True)
         self.Sessionlist.setEnabled(True)
 
+        # Drop `finished` file with date/time
+        filepath = os.path.join(self.SessionFolder, 'finished') 
+        contents = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        with open(filepath, 'w') as finished_file:
+            finished_file.write(contents)
+        
+
     def _GetSaveFolder(self):
         '''
         Create folders with structure requested by Sci.Comp.


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- When the `json` file is finished saving, we create a text file `finished`, in the main session directory, with the current date/time
- Format is `%Y-%m-%d_%H-%M-%S`, example: 2024-03-25_10-23-44
- The presence of this file is an indicator that the data can be uploaded 

### What issues or discussions does this update address?
- resolves #321 

### Describe the expected change in behavior from the perspective of the experimenter
- no changes

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447





