### PR TITLE
removing snipping tool

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -172,7 +172,6 @@ class Window(QMainWindow):
         self.actionTime_distribution.triggered.connect(self._TimeDistribution)
         self.action_Calibration.triggered.connect(self._WaterCalibration)
         self.actionLaser_Calibration.triggered.connect(self._LaserCalibration)
-        self.action_Snipping.triggered.connect(self._Snipping)
         self.action_Open.triggered.connect(self._Open)
         self.action_Save.triggered.connect(self._Save)
         self.actionForce_save.triggered.connect(self._ForceSave)
@@ -1643,10 +1642,6 @@ class Window(QMainWindow):
         logging.info('closing the GUI')
         self.close()      
  
-    def _Snipping(self):
-        '''Open the snipping tool'''
-        os.system("start %windir%\system32\SnippingTool.exe") 
-
     def _Optogenetics(self):
         '''will be triggered when the optogenetics icon is pressed'''
         if self.OpenOptogenetics==0:

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4920,7 +4920,6 @@ Current pair:
     </widget>
     <addaction name="action_Calibration"/>
     <addaction name="actionLaser_Calibration"/>
-    <addaction name="action_Snipping"/>
     <addaction name="separator"/>
     <addaction name="menuSimulation"/>
     <addaction name="actionDrawing_after_stopping"/>
@@ -5024,8 +5023,6 @@ Current pair:
    <addaction name="action_New"/>
    <addaction name="action_Open"/>
    <addaction name="action_Save"/>
-   <addaction name="separator"/>
-   <addaction name="action_Snipping"/>
    <addaction name="separator"/>
   </widget>
   <widget class="QToolBar" name="toolBar">
@@ -5133,18 +5130,6 @@ Current pair:
    </property>
    <property name="text">
     <string>&amp;Exit</string>
-   </property>
-  </action>
-  <action name="action_Snipping">
-   <property name="icon">
-    <iconset>
-     <normaloff>resources/edit-cut.png</normaloff>resources/edit-cut.png</iconset>
-   </property>
-   <property name="text">
-    <string>Snipping</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+X</string>
    </property>
   </action>
   <action name="action_About">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4460,7 +4460,6 @@
     </widget>
     <addaction name="action_Calibration"/>
     <addaction name="actionLaser_Calibration"/>
-    <addaction name="action_Snipping"/>
     <addaction name="separator"/>
     <addaction name="menuSimulation"/>
     <addaction name="actionDrawing_after_stopping"/>
@@ -4564,8 +4563,6 @@
    <addaction name="action_New"/>
    <addaction name="action_Open"/>
    <addaction name="action_Save"/>
-   <addaction name="separator"/>
-   <addaction name="action_Snipping"/>
    <addaction name="separator"/>
   </widget>
   <widget class="QToolBar" name="toolBar">
@@ -4673,18 +4670,6 @@
    </property>
    <property name="text">
     <string>&amp;Exit</string>
-   </property>
-  </action>
-  <action name="action_Snipping">
-   <property name="icon">
-    <iconset>
-     <normaloff>resources/edit-cut.png</normaloff>resources/edit-cut.png</iconset>
-   </property>
-   <property name="text">
-    <string>Snipping</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+X</string>
    </property>
   </action>
   <action name="action_About">


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- removes a link to the windows snipping tool, it was unused, and users can just as easily open from the start menu

### What issues or discussions does this update address?
- resolves #330 

### Describe the expected change in behavior from the perspective of the experimenter
- The link to the snipping tool will not exist

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447





