### PR TITLE
Stopping the photometry timer if Start is pressed

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2837,8 +2837,8 @@ class Window(QMainWindow):
                     #self.Time.connect(self.workertimer._Timer)
                     #self.workertimer.moveToThread(self.workertimer_thread)
                     #self.workertimer_thread.start()
-                    #self.workertimer.stop()
-                    self.workertimer_thread.quit()
+                    self.workertimer._stop()
+                    #self.workertimer_thread.quit()
                     #self.workertimer_thread.wait()
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2723,11 +2723,12 @@ class Window(QMainWindow):
     
     def _thread_complete_timer(self):
         '''complete of _Timer'''
-        self.finish_Timer=1
-        logging.info('Finished photometry baseline timer')
-        self.WarningLabelStop.setText('')
-        self.WarningLabelStop.setStyleSheet(self.default_warning_color)
-   
+        if not self.ignore_timer:
+            self.finish_Timer=1
+            logging.info('Finished photometry baseline timer')
+            self.WarningLabelStop.setText('')
+            self.WarningLabelStop.setStyleSheet(self.default_warning_color)
+
     def _update_photometery_timer(self,time):
         '''
             Updates photometry baseline timer
@@ -2736,8 +2737,9 @@ class Window(QMainWindow):
         seconds = np.remainder(time,60)
         if len(str(seconds)) == 1:
             seconds = '0{}'.format(seconds)
-        self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))
-        self.WarningLabelStop.setStyleSheet(self.default_warning_color)       
+        if not self.ignore_timer:
+            self.WarningLabelStop.setText('Running photometry baseline: {}:{}'.format(minutes,seconds))
+            self.WarningLabelStop.setStyleSheet(self.default_warning_color)       
      
     def _set_metadata_enabled(self, enable: bool):
         '''Enable or disable metadata fields'''
@@ -2819,6 +2821,13 @@ class Window(QMainWindow):
                 logging.info('Start button pressed: user continued session')               
                 self.Start.setChecked(True)
                 return 
+            
+            if self.finish_Timer==0:
+                self.ignore_timer=True
+                logging.info('canceling photometry baseline timer')
+                self.WarningLabelStop.setText('')
+                self.WarningLabelStop.setStyleSheet(self.default_warning_color)              
+ 
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish
@@ -2946,6 +2955,7 @@ class Window(QMainWindow):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1
+            self.ignore_timer=False
             
             # If we already created a workertimer and thread we can reuse them
             if not hasattr(self, 'workertimer'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2455,11 +2455,12 @@ class Window(QMainWindow):
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
             except Exception as e:
                 logging.error(str(e))
-                self.TeensyWarning.setText('Error: start excitation!')
-                self.TeensyWarning.setStyleSheet(self.default_warning_color)
-                reply = QMessageBox.critical(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
-                self.StartExcitation.setChecked(False)
-                self.StartExcitation.setStyleSheet("background-color : none")
+                # DEBUGGING CODE
+                #self.TeensyWarning.setText('Error: start excitation!')
+                #self.TeensyWarning.setStyleSheet(self.default_warning_color)
+                #reply = QMessageBox.critical(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
+                #self.StartExcitation.setChecked(False)
+                #self.StartExcitation.setStyleSheet("background-color : none")
             else:
                 self.TeensyWarning.setText('')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)               

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -111,6 +111,7 @@ class Window(QMainWindow):
         self.TimeDistribution_ToInitializeVisual=1
         self.finish_Timer=1     # for photometry baseline recordings
         self.PhotometryRun=0    # 1. Photometry has been run; 0. Photometry has not been carried out.
+        self.ignore_timer=False
         self._Optogenetics()    # open the optogenetics panel 
         self._LaserCalibration()# to open the laser calibration panel
         self._WaterCalibration()# to open the water calibration panel
@@ -2952,7 +2953,7 @@ class Window(QMainWindow):
                 logging.info('User selected not to start excitation')
   
         # collecting the base signal for photometry. Only run once
-        if self.PhotometryB.currentText()=='on' and self.PhotometryRun==0:
+        if self.PhotometryB.currentText()=='on' and (self.PhotometryRun==0 & not self.ignore_timer):
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2919,14 +2919,15 @@ class Window(QMainWindow):
         if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
             
-            if self.Teensy_COM == '':
-                logging.warning('No Teensy COM configured for this box, cannot start excitation')
-                msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'
-                reply = QMessageBox.information(self,'Box {}, Start'.format(self.box_letter), 
-                    msg, QMessageBox.Ok)
-                self.Start.setStyleSheet("background-color : none")
-                self.Start.setChecked(False)
-                return
+            # DEBUGGING CODE
+            #if self.Teensy_COM == '':
+            #    logging.warning('No Teensy COM configured for this box, cannot start excitation')
+            #    msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'
+            #    reply = QMessageBox.information(self,'Box {}, Start'.format(self.box_letter), 
+            #        msg, QMessageBox.Ok)
+            #    self.Start.setStyleSheet("background-color : none")
+            #    self.Start.setChecked(False)
+            #    return
 
             reply = QMessageBox.question(self, 
                 'Box {}, Start'.format(self.box_letter), 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2824,6 +2824,7 @@ class Window(QMainWindow):
             
             if self.finish_Timer==0:
                 self.ignore_timer=True
+                self.PhotometryRun=0
                 logging.info('canceling photometry baseline timer')
                 self.WarningLabelStop.setText('')
                 self.WarningLabelStop.setStyleSheet(self.default_warning_color)              

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2432,17 +2432,16 @@ class Window(QMainWindow):
         self._Clear()
 
     def _StartExcitation(self):
-        ## DEBUGGING CODE
-        #if self.Teensy_COM == '':
-        #    logging.warning('No Teensy COM configured for this box, cannot start excitation')
-        #    self.TeensyWarning.setText('No Teensy COM for this box')
-        #    self.TeensyWarning.setStyleSheet(self.default_warning_color)
-        #    msg = 'No Teensy COM configured for this box, cannot start excitation'
-        #    reply = QMessageBox.information(self, 
-        #        'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
-        #    self.StartExcitation.setChecked(False)
-        #    self.StartExcitation.setStyleSheet("background-color : none")
-        #    return
+        if self.Teensy_COM == '':
+            logging.warning('No Teensy COM configured for this box, cannot start excitation')
+            self.TeensyWarning.setText('No Teensy COM for this box')
+            self.TeensyWarning.setStyleSheet(self.default_warning_color)
+            msg = 'No Teensy COM configured for this box, cannot start excitation'
+            reply = QMessageBox.information(self, 
+                'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
+            self.StartExcitation.setChecked(False)
+            self.StartExcitation.setStyleSheet("background-color : none")
+            return
 
         if self.StartExcitation.isChecked():
             logging.info('StartExcitation is checked')
@@ -2456,12 +2455,11 @@ class Window(QMainWindow):
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
             except Exception as e:
                 logging.error(str(e))
-                # DEBUGGING CODE
-                #self.TeensyWarning.setText('Error: start excitation!')
-                #self.TeensyWarning.setStyleSheet(self.default_warning_color)
-                #reply = QMessageBox.critical(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
-                #self.StartExcitation.setChecked(False)
-                #self.StartExcitation.setStyleSheet("background-color : none")
+                self.TeensyWarning.setText('Error: start excitation!')
+                self.TeensyWarning.setStyleSheet(self.default_warning_color)
+                reply = QMessageBox.critical(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
+                self.StartExcitation.setChecked(False)
+                self.StartExcitation.setStyleSheet("background-color : none")
             else:
                 self.TeensyWarning.setText('')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)               
@@ -2936,15 +2934,14 @@ class Window(QMainWindow):
         if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
             
-            # DEBUGGING CODE
-            #if self.Teensy_COM == '':
-            #    logging.warning('No Teensy COM configured for this box, cannot start excitation')
-            #    msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'
-            #    reply = QMessageBox.information(self,'Box {}, Start'.format(self.box_letter), 
-            #        msg, QMessageBox.Ok)
-            #    self.Start.setStyleSheet("background-color : none")
-            #    self.Start.setChecked(False)
-            #    return
+            if self.Teensy_COM == '':
+                logging.warning('No Teensy COM configured for this box, cannot start excitation')
+                msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'
+                reply = QMessageBox.information(self,'Box {}, Start'.format(self.box_letter), 
+                    msg, QMessageBox.Ok)
+                self.Start.setStyleSheet("background-color : none")
+                self.Start.setChecked(False)
+                return
 
             reply = QMessageBox.question(self, 
                 'Box {}, Start'.format(self.box_letter), 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2822,7 +2822,8 @@ class Window(QMainWindow):
                 logging.info('Start button pressed: user continued session')               
                 self.Start.setChecked(True)
                 return 
-            
+           
+            # If the photometry timer is running, stop it 
             if self.finish_Timer==0:
                 self.ignore_timer=True
                 self.PhotometryRun=0
@@ -2830,16 +2831,10 @@ class Window(QMainWindow):
                 self.WarningLabelStop.setText('')
                 self.WarningLabelStop.setStyleSheet(self.default_warning_color)              
                 if hasattr(self, 'workertimer'):
-                    #self.workertimer = TimerWorker()
-                    #self.workertimer_thread = QThread()
-                    #self.workertimer.progress.connect(self._update_photometery_timer)
-                    #self.workertimer.finished.connect(self._thread_complete_timer)
-                    #self.Time.connect(self.workertimer._Timer)
-                    #self.workertimer.moveToThread(self.workertimer_thread)
-                    #self.workertimer_thread.start()
+                    # Stop the worker, this has a 1 second delay before taking effect
+                    # so we set the text to get ignored as well
                     self.workertimer._stop()
-                    #self.workertimer_thread.quit()
-                    #self.workertimer_thread.wait()
+
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -111,7 +111,7 @@ class Window(QMainWindow):
         self.TimeDistribution_ToInitializeVisual=1
         self.finish_Timer=1     # for photometry baseline recordings
         self.PhotometryRun=0    # 1. Photometry has been run; 0. Photometry has not been carried out.
-        self.ignore_timer=False
+        self.ignore_timer=False # Used for canceling the photometry baseline timer
         self._Optogenetics()    # open the optogenetics panel 
         self._LaserCalibration()# to open the laser calibration panel
         self._WaterCalibration()# to open the water calibration panel

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2833,7 +2833,6 @@ class Window(QMainWindow):
                     # so we set the text to get ignored as well
                     self.workertimer._stop()
 
-
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish
             self._StopCurrentSession() 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2829,6 +2829,17 @@ class Window(QMainWindow):
                 logging.info('canceling photometry baseline timer')
                 self.WarningLabelStop.setText('')
                 self.WarningLabelStop.setStyleSheet(self.default_warning_color)              
+                if hasattr(self, 'workertimer'):
+                    #self.workertimer = TimerWorker()
+                    #self.workertimer_thread = QThread()
+                    #self.workertimer.progress.connect(self._update_photometery_timer)
+                    #self.workertimer.finished.connect(self._thread_complete_timer)
+                    #self.Time.connect(self.workertimer._Timer)
+                    #self.workertimer.moveToThread(self.workertimer_thread)
+                    #self.workertimer_thread.start()
+                    self.workertimer.stop()
+                    self.workertimer_thread.quit()
+                    self.workertimer_thread.wait()
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2825,6 +2825,7 @@ class Window(QMainWindow):
             
             if self.finish_Timer==0:
                 self.ignore_timer=True
+                self.PhotometryRun=0
                 logging.info('canceling photometry baseline timer')
                 self.WarningLabelStop.setText('')
                 self.WarningLabelStop.setStyleSheet(self.default_warning_color)              

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2825,11 +2825,9 @@ class Window(QMainWindow):
             
             if self.finish_Timer==0:
                 self.ignore_timer=True
-                self.PhotometryRun=0
                 logging.info('canceling photometry baseline timer')
                 self.WarningLabelStop.setText('')
                 self.WarningLabelStop.setStyleSheet(self.default_warning_color)              
- 
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish
@@ -2953,7 +2951,7 @@ class Window(QMainWindow):
                 logging.info('User selected not to start excitation')
   
         # collecting the base signal for photometry. Only run once
-        if self.PhotometryB.currentText()=='on' and (self.PhotometryRun==0 & not self.ignore_timer):
+        if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and self.PhotometryRun==0:
             logging.info('Starting photometry baseline timer')
             self.finish_Timer=0
             self.PhotometryRun=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2838,9 +2838,8 @@ class Window(QMainWindow):
                     #self.workertimer.moveToThread(self.workertimer_thread)
                     #self.workertimer_thread.start()
                     #self.workertimer.stop()
-                    #self.workertimer_thread.quit()
+                    self.workertimer_thread.quit()
                     #self.workertimer_thread.wait()
-                    self.workertimer.requestInterruption()
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2431,16 +2431,17 @@ class Window(QMainWindow):
         self._Clear()
 
     def _StartExcitation(self):
-        if self.Teensy_COM == '':
-            logging.warning('No Teensy COM configured for this box, cannot start excitation')
-            self.TeensyWarning.setText('No Teensy COM for this box')
-            self.TeensyWarning.setStyleSheet(self.default_warning_color)
-            msg = 'No Teensy COM configured for this box, cannot start excitation'
-            reply = QMessageBox.information(self, 
-                'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
-            self.StartExcitation.setChecked(False)
-            self.StartExcitation.setStyleSheet("background-color : none")
-            return
+        ## DEBUGGING CODE
+        #if self.Teensy_COM == '':
+        #    logging.warning('No Teensy COM configured for this box, cannot start excitation')
+        #    self.TeensyWarning.setText('No Teensy COM for this box')
+        #    self.TeensyWarning.setStyleSheet(self.default_warning_color)
+        #    msg = 'No Teensy COM configured for this box, cannot start excitation'
+        #    reply = QMessageBox.information(self, 
+        #        'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
+        #    self.StartExcitation.setChecked(False)
+        #    self.StartExcitation.setStyleSheet("background-color : none")
+        #    return
 
         if self.StartExcitation.isChecked():
             logging.info('StartExcitation is checked')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2837,9 +2837,10 @@ class Window(QMainWindow):
                     #self.Time.connect(self.workertimer._Timer)
                     #self.workertimer.moveToThread(self.workertimer_thread)
                     #self.workertimer_thread.start()
-                    self.workertimer.stop()
-                    self.workertimer_thread.quit()
-                    self.workertimer_thread.wait()
+                    #self.workertimer.stop()
+                    #self.workertimer_thread.quit()
+                    #self.workertimer_thread.wait()
+                    self.workertimer.requestInterruption()
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1941,4 +1941,8 @@ class TimerWorker(QtCore.QObject):
         self.finished.emit()
 
     def _stop(self):
+        # Will halt the timer at the next interval
         self._isRunning=False
+
+
+

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1927,7 +1927,7 @@ class TimerWorker(QtCore.QObject):
         self.progress.emit(int(Time))
 
         # Iterate through intervals 
-        while (num_updates >0):
+        while num_updates >0:
             time.sleep(interval)
             if not self._isRunning:
                 return 
@@ -1942,6 +1942,4 @@ class TimerWorker(QtCore.QObject):
     def _stop(self):
         # Will halt the timer at the next interval
         self._isRunning=False
-
-
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1914,6 +1914,10 @@ class TimerWorker(QtCore.QObject):
     progress = QtCore.pyqtSignal(int)
     cancel = QtCore.pyqtSignal()
 
+    def __init__(self):
+        super(TimerWorker, self).__init__()
+        self._isRunning=True
+
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
         '''sleep some time'''
@@ -1925,6 +1929,8 @@ class TimerWorker(QtCore.QObject):
         # Iterate through intervals 
         while (num_updates >0):
             time.sleep(interval)
+            if not self._isRunning:
+                return 
             Time -=interval
             self.progress.emit(int(Time))
             num_updates -= 1
@@ -1933,3 +1939,5 @@ class TimerWorker(QtCore.QObject):
         time.sleep(Time)
         self.finished.emit()
 
+    def _stop(self):
+        self._isRunning=False

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1922,6 +1922,7 @@ class TimerWorker(QtCore.QObject):
     def _Timer(self,Time):
         '''sleep some time'''
         # Emit initial status
+        self._isRunning=True
         interval = 1
         num_updates = int(np.floor(Time/interval))
         self.progress.emit(int(Time))

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1913,6 +1913,10 @@ class TimerWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
     cancel = QtCore.pyqtSignal()
+    
+    def __init__(self):
+        super(TimerWorker, self).__init__()
+        self._isRunning=True
 
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
@@ -1923,7 +1927,7 @@ class TimerWorker(QtCore.QObject):
         self.progress.emit(int(Time))
 
         # Iterate through intervals 
-        while num_updates >0:
+        while (num_updates >0)and(self._isRunning):
             time.sleep(interval)
             Time -=interval
             self.progress.emit(int(Time))
@@ -1933,4 +1937,5 @@ class TimerWorker(QtCore.QObject):
         time.sleep(Time)
         self.finished.emit()
 
-
+    def stop(self):
+        self._isRunning=False

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1912,6 +1912,7 @@ class TimerWorker(QtCore.QObject):
     '''
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
+    cancel = QtCore.pyqtSignal()
 
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1913,10 +1913,6 @@ class TimerWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
     cancel = QtCore.pyqtSignal()
-    
-    def __init__(self):
-        super(TimerWorker, self).__init__()
-        self._isRunning=True
 
     @QtCore.pyqtSlot(int)
     def _Timer(self,Time):
@@ -1927,9 +1923,13 @@ class TimerWorker(QtCore.QObject):
         self.progress.emit(int(Time))
 
         # Iterate through intervals 
-        while (num_updates >0)and(self._isRunning):
+        while (num_updates >0):
             time.sleep(interval)
             Time -=interval
+            interrupt = self.isInterruptionRequested()
+            if interrupt:
+                print('breaking')
+                break
             self.progress.emit(int(Time))
             num_updates -= 1
         
@@ -1937,5 +1937,3 @@ class TimerWorker(QtCore.QObject):
         time.sleep(Time)
         self.finished.emit()
 
-    def stop(self):
-        self._isRunning=False

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1912,7 +1912,6 @@ class TimerWorker(QtCore.QObject):
     '''
     finished = QtCore.pyqtSignal()
     progress = QtCore.pyqtSignal(int)
-    cancel = QtCore.pyqtSignal()
 
     def __init__(self):
         super(TimerWorker, self).__init__()

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1926,10 +1926,6 @@ class TimerWorker(QtCore.QObject):
         while (num_updates >0):
             time.sleep(interval)
             Time -=interval
-            interrupt = self.isInterruptionRequested()
-            if interrupt:
-                print('breaking')
-                break
             self.progress.emit(int(Time))
             num_updates -= 1
         


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- If the session is stopped during the photometry baseline period, the timer is cancelled. This is useful if we notice a problem we need to correct. 
- If the session is restarted, or NewSession, or Load is pressed, then the timer will start as normal

### What issues or discussions does this update address?
- resolves #329 

### Describe the expected change in behavior from the perspective of the experimenter
- If you stop the session, the photometry baseline timer will stop

### Describe the outcome of testing this update on a rig in 447
- [x] tested in 447




