### PR TITLE
Fix loading infor

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1868,7 +1868,7 @@ class Window(QMainWindow):
                             Obj[attr_name]=Value
         # save other events, e.g. session start time
         for attr_name in dir(self):
-            if attr_name.startswith('Other_'):
+            if attr_name.startswith('Other_') or attr_name.startswith('info_'):
                 Obj[attr_name] = getattr(self, attr_name)
         # save laser calibration results (only for the calibration session)
         if hasattr(self, 'LaserCalibration_dialog'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2314,8 +2314,8 @@ class Window(QMainWindow):
             if self.default_ui=='ForagingGUI.ui':  
                 if 'info_task' in Obj:
                     self.label_info_task.setText(Obj['info_task'])
-                if 'info_other_perf' in Obj:
-                    self.label_info_performance_others.setText(Obj['info_other_perf'])
+                if 'info_performance_others' in Obj:
+                    self.label_info_performance_others.setText(Obj['info_performance_others'])
                 if 'info_performance_essential_1' in Obj:
                     self.label_info_performance_essential_1.setText(Obj['info_performance_essential_1'])
                 if 'info_performance_essential_2' in Obj:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2313,7 +2313,7 @@ class Window(QMainWindow):
             # show basic information
             if self.default_ui=='ForagingGUI.ui':  
                 if 'info_task' in Obj:
-                    self.label_info_task.setTitle(Obj['info_task'])
+                    self.label_info_task.setText(Obj['info_task'])
                 if 'info_other_perf' in Obj:
                     self.label_info_performance_others.setText(Obj['info_other_perf'])
             elif self.default_ui=='ForagingGUI_Ephys.ui':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2316,6 +2316,9 @@ class Window(QMainWindow):
                     self.label_info_task.setText(Obj['info_task'])
                 if 'info_other_perf' in Obj:
                     self.label_info_performance_others.setText(Obj['info_other_perf'])
+                if 'info_performance_essential_1' in Obj:
+                    self.label_info_performance_essential_1.setText(Obj['info_performance_essential_1'])
+
             elif self.default_ui=='ForagingGUI_Ephys.ui':
                 if 'Other_inforTitle' in Obj:
                     self.infor.setTitle(Obj['Other_inforTitle'])

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2318,7 +2318,8 @@ class Window(QMainWindow):
                     self.label_info_performance_others.setText(Obj['info_other_perf'])
                 if 'info_performance_essential_1' in Obj:
                     self.label_info_performance_essential_1.setText(Obj['info_performance_essential_1'])
-
+                if 'info_performance_essential_2' in Obj:
+                    self.label_info_performance_essential_2.setText(Obj['info_performance_essential_2'])
             elif self.default_ui=='ForagingGUI_Ephys.ui':
                 if 'Other_inforTitle' in Obj:
                     self.infor.setTitle(Obj['Other_inforTitle'])

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -7,6 +7,3 @@ BonsaiOsc4,4035
 HighSpeedCamera,0
 SideCamera,12345678
 BottomCamera,12345678
-AINDLickDetector,0
-LeftLickDetector,COM8
-RightLickDetector,COM9

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -7,3 +7,6 @@ BonsaiOsc4,4035
 HighSpeedCamera,0
 SideCamera,12345678
 BottomCamera,12345678
+AINDLickDetector,0
+LeftLickDetector,COM8
+RightLickDetector,COM9


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Updated behavior GUI to load basic statistics.

### What issues or discussions does this update address?
Resolves #282

### Describe the expected change in behavior from the perspective of the experimenter
Some statistics (same as we saw during training) will show when loading the json file.
Before 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/41366973-4ead-4515-b82f-e0d1bf63498f)

Updated
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/428b5680-4fb3-4a68-8726-1cdcdfcc77ea)


### Describe the outcome of testing this update on a rig in 447
I tested on my own computer and in 447. It works as expected.  




