### PR TITLE
Do not create a new folder after saving

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1787,7 +1787,7 @@ class Window(QMainWindow):
                 return
 
         # this should be improved in the future. Need to get the last LeftRewardDeliveryTime and RightRewardDeliveryTime
-        if hasattr(self, 'GeneratedTrials'):
+        if hasattr(self, 'GeneratedTrials') and self.InitializeBonsaiSuccessfully==1:
             self.GeneratedTrials._GetLicks(self.Channel2)
         
         # Create new folders

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1929,7 +1929,8 @@ class Window(QMainWindow):
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
             self._NewSession()
-        
+            # do not create a new folder
+            self.CreateNewFolder=0
 
     def _GetSaveFolder(self):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1787,7 +1787,7 @@ class Window(QMainWindow):
                 return
 
         # this should be improved in the future. Need to get the last LeftRewardDeliveryTime and RightRewardDeliveryTime
-        if hasattr(self, 'GeneratedTrials') and self.InitializeBonsaiSuccessfully==1:
+        if hasattr(self, 'GeneratedTrials'):
             self.GeneratedTrials._GetLicks(self.Channel2)
         
         # Create new folders


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Don't create a new folder every time clicking Save.

### What issues or discussions does this update address?
The pull request https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/360 will make the GUI to create a new folder every time we click the Save button, which may cause duplicated sessions. 

### Describe the expected change in behavior from the perspective of the experimenter
After saving, users can still change GUI parameters (e.g. weight information) and click the Save button again to save these changes to the same file. 

### Describe the outcome of testing this update on a rig in 447
Tested in 323_EPHYS3




