### PR TITLE
Fix save _GetLicks

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1787,7 +1787,7 @@ class Window(QMainWindow):
                 return
 
         # this should be improved in the future. Need to get the last LeftRewardDeliveryTime and RightRewardDeliveryTime
-        if hasattr(self, 'GeneratedTrials'):
+        if hasattr(self, 'GeneratedTrials') and self.InitializeBonsaiSuccessfully==1:
             self.GeneratedTrials._GetLicks(self.Channel2)
         
         # Create new folders


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Check the bonsai connection when running `self.GeneratedTrials._GetLicks(self.Channel2)` in `_Save`.

### What issues or discussions does this update address?
There is a rare edge case where we have `GeneratedTrials`, but the bonsai is not yet connected. In this case, running `self.GeneratedTrials._GetLicks(self.Channel2)` will cause an error. 

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe the outcome of testing this update on a rig in 447
Tested in 323_EPHYS3




