### PR TITLE
Type checking for Base weight and Post weight

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1351,14 +1351,14 @@ class Window(QMainWindow):
                         child.setStyleSheet('background-color: white;')
                         self._Task()
                     
-                    if child.objectName() in {'Experimenter','TotalWater','WeightAfter','ExtraWater'}:
+                    if child.objectName() in {'Experimenter','TotalWater','ExtraWater'}:
                         continue
                     if child.objectName()=='UncoupledReward':
                         Correct=self._CheckFormat(child)
                         if Correct ==0: # incorrect format; don't change
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
-                    if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight']) and
+                    if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight','WeightAfter']) and
                         (child.text() == '')):
                         # These attributes can have the empty string, but we can't set the value as the empty string, unless we allow resets
                         if allow_reset:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1440,7 +1440,10 @@ class Window(QMainWindow):
                         except Exception as e:
                             #logging.error(str(e))
                             # Invalid float. Do not change the parameter
-                            if isinstance(child, QtWidgets.QDoubleSpinBox):
+                            if child.objectName() in ['BaseWeight', 'WeightAfter']:
+                                child.setText(child.text()[:-1]) 
+                                print(child.text())
+                            elif isinstance(child, QtWidgets.QDoubleSpinBox):
                                 child.setValue(float(getattr(Parameters, 'TP_'+child.objectName())))
                             elif isinstance(child, QtWidgets.QSpinBox):
                                 child.setValue(int(getattr(Parameters, 'TP_'+child.objectName())))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3322,14 +3322,14 @@ class Window(QMainWindow):
         try:
             if self.BaseWeight.text()!='':
                 float(self.BaseWeight.text())
-        except:
-            print('error on baseweight')
+        except Exception as e:
+            logging.error(str(e))
             return
         try:
             if self.WeightAfter.text()!='':
                 float(self.WeightAfter.text())
-        except:
-            print('error on post weight')
+        except Exception as e:
+            logging.error(str(e))
             return
         try:
             if self.BaseWeight.text()!='' and self.TargetRatio.text()!='':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3323,13 +3323,13 @@ class Window(QMainWindow):
             if self.BaseWeight.text()!='':
                 float(self.BaseWeight.text())
         except Exception as e:
-            logging.error(str(e))
+            logging.warning(str(e))
             return
         try:
             if self.WeightAfter.text()!='':
                 float(self.WeightAfter.text())
         except Exception as e:
-            logging.error(str(e))
+            logging.warning(str(e))
             return
         try:
             if self.BaseWeight.text()!='' and self.TargetRatio.text()!='':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1358,6 +1358,7 @@ class Window(QMainWindow):
                         if Correct ==0: # incorrect format; don't change
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
+                    print('here: {}'.format(child.objectName()))
                     if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight','WeightAfter']) and
                         (child.text() == '')):
                         # These attributes can have the empty string, but we can't set the value as the empty string, unless we allow resets

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1442,7 +1442,9 @@ class Window(QMainWindow):
                             # Invalid float. Do not change the parameter
                             if child.objectName() in ['BaseWeight', 'WeightAfter']:
                                 child.setText(child.text()[:-1]) 
-                                print(child.text())
+                                print(child.text())        
+                                self.UpdateParameters=0
+                                continue
                             elif isinstance(child, QtWidgets.QDoubleSpinBox):
                                 child.setValue(float(getattr(Parameters, 'TP_'+child.objectName())))
                             elif isinstance(child, QtWidgets.QSpinBox):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1358,7 +1358,6 @@ class Window(QMainWindow):
                         if Correct ==0: # incorrect format; don't change
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
-                    print('here: {}'.format(child.objectName()))
                     if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight','WeightAfter']) and
                         (child.text() == '')):
                         # These attributes can have the empty string, but we can't set the value as the empty string, unless we allow resets
@@ -1417,7 +1416,7 @@ class Window(QMainWindow):
                 try:
                     if getattr(Parameters, 'TP_'+child.objectName())!=child.text() :
                         self.Continue=0
-                        if child.objectName() in {'Experimenter', 'UncoupledReward', 'WeightAfter', 'ExtraWater'}:
+                        if child.objectName() in {'Experimenter', 'UncoupledReward', 'ExtraWater'}:
                             child.setStyleSheet(self.default_text_color)
                             self.Continue=1
                         if child.text()=='': # If empty, change background color and wait for confirmation

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3320,6 +3320,16 @@ class Window(QMainWindow):
     def _UpdateSuggestedWater(self,ManualWater=0):
         '''Update the suggested water from the manually give water'''
         try:
+            float(self.BaseWeight.text())
+        except:
+            print('error on baseweight')
+            return
+        try:
+            float(self.WeightAfter.text())
+        except:
+            print('error on post weight')
+            return
+        try:
             if self.BaseWeight.text()!='' and self.TargetRatio.text()!='':
                 # set the target weight
                 target_weight=float(self.TargetRatio.text())*float(self.BaseWeight.text())

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1441,8 +1441,8 @@ class Window(QMainWindow):
                             #logging.error(str(e))
                             # Invalid float. Do not change the parameter
                             if child.objectName() in ['BaseWeight', 'WeightAfter']:
+                                # Strip the last character which triggered the invalid float
                                 child.setText(child.text()[:-1]) 
-                                print(child.text())        
                                 self.UpdateParameters=0
                                 continue
                             elif isinstance(child, QtWidgets.QDoubleSpinBox):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3320,12 +3320,14 @@ class Window(QMainWindow):
     def _UpdateSuggestedWater(self,ManualWater=0):
         '''Update the suggested water from the manually give water'''
         try:
-            float(self.BaseWeight.text())
+            if self.BaseWeight.text()!='':
+                float(self.BaseWeight.text())
         except:
             print('error on baseweight')
             return
         try:
-            float(self.WeightAfter.text())
+            if self.WeightAfter.text()!='':
+                float(self.WeightAfter.text())
         except:
             print('error on post weight')
             return


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Previously, `Base weight` and `Post weight` had inconsistent type checking. If a user incorrectly entered `20..2` or `20.d`, this value was accepted in `post weight`, but rejected by `base weight` and generated an error. Other text fields in the GUI simply do not allow the user to enter an incorrect value. 
- Now, the GUI will not allow the user to enter incorrect values for the weight fields

### What issues or discussions does this update address?
- resolves #384 

### Describe the expected change in behavior from the perspective of the experimenter
If you mis-type a value, like `20.f` or `20..`, then the offending characters will be removed and just `20.` will remain

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447




