### PR TITLE
Don’t delay 5 seconds for a non-high-speed video session

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -345,8 +345,6 @@ class Window(QMainWindow):
             use_default_folder_structure=0
             if save_tag==1:
                 # check the drop frames of the current session
-                # sleep some time to wait for the finish of saving video
-                time.sleep(5)
                 if hasattr(self,'HarpFolder'):
                     HarpFolder=self.HarpFolder
                     video_folder=self.VideoFolder
@@ -369,6 +367,8 @@ class Window(QMainWindow):
 
             camera_trigger_file=os.path.join(HarpFolder,'BehaviorEvents','Event_94.bin')
             if os.path.exists(camera_trigger_file):
+                # sleep some time to wait for the finish of saving video
+                time.sleep(5)
                 triggers = harp.read(camera_trigger_file)
                 self.trigger_length = len(triggers)
             else:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Previously, regardless of whether the session captured video, the code would sleep for 5 seconds waiting for the high-speed video data save to complete.

Now, only sleep 5 seconds for high-speed video session. 

### What issues or discussions does this update address?
Don't sleep 5s when saving data for non-high-speed video session.

### Describe the expected change in behavior from the perspective of the experimenter
For high-speed video session, the code will sleep 5s when saving the data. 
For non-high-speed video session, no influence. 

### Describe the outcome of testing this update on a rig in 447
Tested in 323_EPHYS3.




