### PR TITLE
Fix reward N

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1648,7 +1648,6 @@ class Window(QMainWindow):
             self.InitiallyInactiveN.setGeometry(QtCore.QRect(403, 128, 80, 20))
             # change name of min reward each block
             self.label_13.setText('RewardN=')
-            self.BlockMinReward.setText('5')
             # change the position of RewardN=/min reward each block=
             self.BlockMinReward.setGeometry(QtCore.QRect(191, 128, 80, 20))
             self.label_13.setGeometry(QtCore.QRect(40, 128, 146, 16))


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Removed the default setting of `RewardN` for RewardN task.

### What issues or discussions does this update address?
The parameter `RewardN` for RewardN task was set to 5 by default, and we can't change it. It seems to be related some recent updates. It was correct before.  

### Describe the expected change in behavior from the perspective of the experimenter
The `RewardN` can be changed normally. 

### Describe the outcome of testing this update on a rig in 447
Tested in 447




