### PR TITLE
updating PR template to include manual update section

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,6 +2,7 @@
 - Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
 - Answer the questions below in detail. Your responses will be emailed to experimenters. 
 - If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
+- If computer maintainers need to manually update anything, provide detailed step by step instructions
 - Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
 - If you use the keyword "skip email" in the title, it will skip the email updates
 - Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
@@ -13,7 +14,9 @@
 
 ### Describe the expected change in behavior from the perspective of the experimenter
 
-### Describe the outcome of testing this update on a rig in 447
+### Describe any manual update steps for task computers
+
+### Was this update tested in 446/447?
 
 
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Adds a section to the PR template for describing any manual steps required to make the updated code run on task computers. 
- These manual steps should be taken by the designated maintainer for each task computer (NOT the RAs)
    - 428: Kenta
    - Ephys: Kanghoon/Xinxin
    - 446/447: Alex/Han/Xinxin

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/393

### Describe the expected change in behavior from the perspective of the experimenter
- No changes for experimenters
- Computer maintainers must monitor for update steps

### Describe the outcome of testing this update on a rig in 447
- No testing, just policy updates




