### PR TITLE
Adding error tracking for untracked local files, and being on the wrong branch

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3685,11 +3685,6 @@ if __name__ == "__main__":
     win.current_branch=current_branch
     win.repo_url=repo_url
     win.repo_dirty_flag=repo_dirty_flag
-    win.commit_ID=None
-    win.current_branch=None
-    win.repo_url=None
-    win.repo_dirty_flag=None
-
     win.show()
    
      # Run your application's event loop and stop after closing all windows

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3685,6 +3685,11 @@ if __name__ == "__main__":
     win.current_branch=current_branch
     win.repo_url=repo_url
     win.repo_dirty_flag=repo_dirty_flag
+    win.commit_ID=None
+    win.current_branch=None
+    win.repo_url=None
+    win.repo_dirty_flag=None
+
     win.show()
    
      # Run your application's event loop and stop after closing all windows

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3519,6 +3519,12 @@ def log_git_hash():
         git_branch = subprocess.check_output(['git','branch','--show-current']).decode('ascii').strip()
         repo_url = subprocess.check_output(['git', 'remote', 'get-url', 'origin']).decode('ascii').strip()
         logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
+        print('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
+        
+        py_version = sys.version
+        logging.info('Python version: {}'.format(py_version))
+        print('Python version: {}'.format(py_version))       
+
         return git_hash, git_branch, repo_url
     except Exception as e:
         logging.error('Could not log git branch and hash: {}'.format(str(e)))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2987,7 +2987,7 @@ class Window(QMainWindow):
                     return                
                 else:
                     # Allow the session to continue, but log error
-                    logging.error('Starting session with untracked local changes: {}'.format(self.dirty_files)
+                    logging.error('Starting session with untracked local changes: {}'.format(self.dirty_files))
             elif self.repo_dirty_flag is None:
                 logging.error('Could not check for untracked local changes')
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3524,6 +3524,8 @@ def log_git_hash():
         py_version = sys.version
         logging.info('Python version: {}'.format(py_version))
         print('Python version: {}'.format(py_version))       
+        if py_version[0:3] != '3.9':
+            logging.error('Incorrect version of python! Should be 3.9, got {}'.format(py_version[0:3]))
 
         return git_hash, git_branch, repo_url
     except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2972,7 +2972,7 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch))
 
             # Check for untracked local changes
-            if repo_dirty_flag:
+            if repo_dirty_flag & (self.ID.text() != '0'):
                 # prompt user over untracked local changes
                 reply = QMessageBox.question(self,
                     'Box {}, Start'.format(self.box_letter),    

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2013,6 +2013,7 @@ class Window(QMainWindow):
         Obj['repo_url']=self.repo_url
         Obj['current_branch'] =self.current_branch
         Obj['repo_dirty_flag'] =self.repo_dirty_flag
+        Obj['dirty_files'] =self.dirty_files
         
         # save folders
         Obj['TrainingFolder']=self.TrainingFolder
@@ -2973,7 +2974,7 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch))
 
             # Check for untracked local changes
-            if repo_dirty_flag & (self.ID.text() != '0'):
+            if self.repo_dirty_flag & (self.ID.text() != '0'):
                 # prompt user over untracked local changes
                 reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
@@ -2986,8 +2987,8 @@ class Window(QMainWindow):
                     return                
                 else:
                     # Allow the session to continue, but log error
-                    logging.error('Starting session with untracked local changes')
-            elif repo_dirty_flag is None:
+                    logging.error('Starting session with untracked local changes: {}'.format(self.dirty_files)
+            elif self.repo_dirty_flag is None:
                 logging.error('Could not check for untracked local changes')
 
             # change button color and mark the state change
@@ -3562,7 +3563,7 @@ def log_git_hash():
         git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
         git_branch = subprocess.check_output(['git','branch','--show-current']).decode('ascii').strip()
         repo_url = subprocess.check_output(['git', 'remote', 'get-url', 'origin']).decode('ascii').strip()
-        repo_dirty = subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip()
+        dirty_files = subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip()
     except Exception as e:
         logging.error('Could not log git branch and hash: {}'.format(str(e)))
         return None, None, None, None
@@ -3572,16 +3573,16 @@ def log_git_hash():
     print('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
 
     # Check for untracked local changes
-    repo_dirty_flag = repo_dirty != ''
+    repo_dirty_flag = dirty_files != ''
     if repo_dirty_flag:
-        repo_dirty = repo_dirty.replace('\n',', ')
-        logging.warning('local repository has untracked changes to the following files: {}'.format(repo_dirty))
-        print('local repository has untracked changes to the following files: {}'.format(repo_dirty))
+        dirty_files = dirty_files.replace('\n',', ')
+        logging.warning('local repository has untracked changes to the following files: {}'.format(dirty_files))
+        print('local repository has untracked changes to the following files: {}'.format(dirty_files))
     else:
         logging.warning('local repository is clean')
         print('local repository is clean')
 
-    return git_hash, git_branch, repo_url, repo_dirty_flag
+    return git_hash, git_branch, repo_url, repo_dirty_flag, dirty_files
 
 
 def show_exception_box(log_msg):
@@ -3662,7 +3663,7 @@ if __name__ == "__main__":
    
     # Start logging
     start_gui_log_file(box_number)
-    commit_ID, current_branch, repo_url, repo_dirty_flag = log_git_hash()
+    commit_ID, current_branch, repo_url, repo_dirty_flag, dirty_files = log_git_hash()
 
     # Formating GUI graphics
     logging.info('Setting QApplication attributes')
@@ -3686,6 +3687,7 @@ if __name__ == "__main__":
     win.current_branch=current_branch
     win.repo_url=repo_url
     win.repo_dirty_flag=repo_dirty_flag
+    win.dirty_files=dirty_files
     win.show()
    
      # Run your application's event loop and stop after closing all windows

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3521,8 +3521,12 @@ def log_git_hash():
         repo_url = subprocess.check_output(['git', 'remote', 'get-url', 'origin']).decode('ascii').strip()
         local_dirty = subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip()
         if local_dirty != '':
+            local_dirty = local_dirty.replace('\n',', ')
             logging.warning('local repository has untracked changes to the following files: {}'.format(local_dirty))
             print('local repository has untracked changes to the following files: {}'.format(local_dirty))
+        else:
+            logging.warning('local repository is clean')
+            print('local repository is clean')
         logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         print('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2012,6 +2012,7 @@ class Window(QMainWindow):
         Obj['commit_ID']=self.commit_ID
         Obj['repo_url']=self.repo_url
         Obj['current_branch'] =self.current_branch
+        Obj['repo_dirty_flag'] =self.repo_dirty_flag
         
         # save folders
         Obj['TrainingFolder']=self.TrainingFolder

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3515,12 +3515,14 @@ def log_git_hash():
         Add a note to the GUI log about the current branch and hash. Assumes the local repo is clean
     '''
     try:
+        # Get information about task repository
         git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
         git_branch = subprocess.check_output(['git','branch','--show-current']).decode('ascii').strip()
         repo_url = subprocess.check_output(['git', 'remote', 'get-url', 'origin']).decode('ascii').strip()
         logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         print('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         
+        # Get information about python
         py_version = sys.version
         logging.info('Python version: {}'.format(py_version))
         print('Python version: {}'.format(py_version))       

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2960,7 +2960,7 @@ class Window(QMainWindow):
                 # Prompt user over off-pipeline branch
                 reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
-                    'Running on branch \"{}\", continue anyways?'.format(self.current_branch),
+                    'Running on branch <span style="color:purple;font-weight:bold">{}</span>, continue anyways?'.format(self.current_branch),
                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
                 if reply == QMessageBox.No:
                     # Stop session

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2945,7 +2945,7 @@ class Window(QMainWindow):
 
             # check experimenter name
             if self.Experimenter.text() == "the ghost in the shell":
-                reply = QMessageBox.question(self,
+                reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
                     'Experimenter field set to default, continue anyways?',
                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
@@ -2958,7 +2958,7 @@ class Window(QMainWindow):
             # check repo status
             if (self.current_branch not in ['main','production_testing']) & (self.ID.text() != '0'):
                 # Prompt user over off-pipeline branch
-                reply = QMessageBox.question(self,
+                reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
                     'Running on branch \"{}\", continue anyways?'.format(self.current_branch),
                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
@@ -2974,7 +2974,7 @@ class Window(QMainWindow):
             # Check for untracked local changes
             if repo_dirty_flag & (self.ID.text() != '0'):
                 # prompt user over untracked local changes
-                reply = QMessageBox.question(self,
+                reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
                     'Local repository has untracked changes, continue anyways?',
                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3519,6 +3519,8 @@ def log_git_hash():
         git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
         git_branch = subprocess.check_output(['git','branch','--show-current']).decode('ascii').strip()
         repo_url = subprocess.check_output(['git', 'remote', 'get-url', 'origin']).decode('ascii').strip()
+        local_dirty = subprocess.check_output(['git','diff-index','HEAD']).decode('ascii').strip()
+        print('<{}>'.format(local_dirty))
         logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         print('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3519,8 +3519,10 @@ def log_git_hash():
         git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
         git_branch = subprocess.check_output(['git','branch','--show-current']).decode('ascii').strip()
         repo_url = subprocess.check_output(['git', 'remote', 'get-url', 'origin']).decode('ascii').strip()
-        local_dirty = subprocess.check_output(['git','diff-index','HEAD']).decode('ascii').strip()
-        print('<{}>'.format(local_dirty))
+        local_dirty = subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip()
+        if local_dirty != '':
+            logging.warning('local repository has untracked changes to the following files: {}'.format(local_dirty))
+            print('local repository has untracked changes to the following files: {}'.format(local_dirty))
         logging.info('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         print('Current git commit branch, hash: {}, {}'.format(git_branch,git_hash))
         


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Right now, if a user has untracked local changes to the repository, or is running the GUI off the main branch we do not alert the user, or log that information as an error. 
- Now we add a note to the log on startup if there are untracked changes
- We log an error if the python version is not 3.9
- If a user starts a session AND the mouse is not "0", then:
    - we check for branch and untracked local changes. 
    - If the branch is not main or production testing, then the user is prompted. If they continue, an error is logged.
    - If the branch has untracked local changes, then the user is prompted. If they continue, an error is logged. 

### What issues or discussions does this update address?
- resolves #383 

### Describe the expected change in behavior from the perspective of the experimenter
- If you are running the code off pipeline, you will be alerted.
- If you are running the code with untracked changes to the code, you will be alerted

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447





