### PR TITLE
Fixing NewSession not prompting for unsaved data

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2766,6 +2766,7 @@ class Window(QMainWindow):
         self._StopCurrentSession() 
 
         if not override_unsaved_data:
+            print('debug')
             # If we have unsaved data, prompt to save
             if (self.ToInitializeVisual==0) and (self.unsaved_data): 
                 reply = QMessageBox.critical(self, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2761,12 +2761,13 @@ class Window(QMainWindow):
         except Exception as e:
             logging.error(str(e))
 
-    def _NewSession(self,override_unsaved_data=False):
+    def _NewSession(self):#,override_unsaved_data=False):
         logging.info('New Session pressed')
-        print('debug1: {}'.format(override_unsaved_data))
+        #print('debug1: {}'.format(override_unsaved_data))
         self._StopCurrentSession() 
+        #print('debug2: {}'.format(override_unsaved_data))
+        override_unsaved_data=False
         print('debug2: {}'.format(override_unsaved_data))
-
         if not override_unsaved_data:
             print('debug3')
             # If we have unsaved data, prompt to save

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3350,6 +3350,9 @@ class Window(QMainWindow):
 
     def _PostWeightChange(self):
         self.unsaved_data=True
+        self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
+        self.NewSession.setStyleSheet("background-color : none")
+        self.NewSession.setChecked(False)
         self.WarningLabel.setText('')
         self._UpdateSuggestedWater()
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -183,7 +183,7 @@ class Window(QMainWindow):
         self.SaveAs.triggered.connect(self._SaveAs)
         self.Save_continue.triggered.connect(self._Save_continue)
         self.action_Exit.triggered.connect(self._Exit)
-        self.action_New.triggered.connect(self._New)
+        self.action_New.triggered.connect(self._NewSession)
         self.action_Clear.triggered.connect(self._Clear)
         self.action_Start.triggered.connect(self.Start.click)
         self.action_NewSession.triggered.connect(self.NewSession.click)
@@ -2572,9 +2572,6 @@ class Window(QMainWindow):
             for child in self.TrainingParameters.findChildren(QtWidgets.QLineEdit)+ self.centralwidget.findChildren(QtWidgets.QLineEdit):
                 if child.isEnabled():
                     child.clear()
-
-    def _New(self):
-        self._Clear()
 
     def _StartExcitation(self):
         if self.Teensy_COM == '':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2022,7 +2022,7 @@ class Window(QMainWindow):
         
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
-            self._NewSession(override_unsaved_data=True)
+            self._NewSession(override_unsaved_data=False)
             # do not create a new folder
             self.CreateNewFolder=0
         # check drop of frames

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2763,11 +2763,12 @@ class Window(QMainWindow):
 
     def _NewSession(self,override_unsaved_data=False):
         logging.info('New Session pressed')
+        print('debug1: {}'.format(override_unsaved_data))
         self._StopCurrentSession() 
-        print('debug: {}'.format(override_unsaved_data))
+        print('debug2: {}'.format(override_unsaved_data))
 
         if not override_unsaved_data:
-            print('debug')
+            print('debug3')
             # If we have unsaved data, prompt to save
             if (self.ToInitializeVisual==0) and (self.unsaved_data): 
                 reply = QMessageBox.critical(self, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2022,7 +2022,7 @@ class Window(QMainWindow):
         
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
-            self._NewSession(override_unsaved_data=False)
+            self._NewSession()
             # do not create a new folder
             self.CreateNewFolder=0
         # check drop of frames
@@ -2761,26 +2761,20 @@ class Window(QMainWindow):
         except Exception as e:
             logging.error(str(e))
 
-    def _NewSession(self):#,override_unsaved_data=False):
+    def _NewSession(self):
         logging.info('New Session pressed')
-        #print('debug1: {}'.format(override_unsaved_data))
-        self._StopCurrentSession() 
-        #print('debug2: {}'.format(override_unsaved_data))
-        override_unsaved_data=False
-        print('debug2: {}'.format(override_unsaved_data))
-        if not override_unsaved_data:
-            print('debug3')
-            # If we have unsaved data, prompt to save
-            if (self.ToInitializeVisual==0) and (self.unsaved_data): 
-                reply = QMessageBox.critical(self, 
-                    'Box {}, New Session:'.format(self.box_letter), 
-                    'Start new session without saving?',
-                    QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-                if reply == QMessageBox.No:
-                    self.NewSession.setStyleSheet("background-color : none")
-                    self.NewSession.setChecked(False)
-                    logging.info('New Session declined')
-                    return False
+
+        # If we have unsaved data, prompt to save
+        if (self.ToInitializeVisual==0) and (self.unsaved_data): 
+            reply = QMessageBox.critical(self, 
+                'Box {}, New Session:'.format(self.box_letter), 
+                'Start new session without saving?',
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+            if reply == QMessageBox.No:
+                self.NewSession.setStyleSheet("background-color : none")
+                self.NewSession.setChecked(False)
+                logging.info('New Session declined')
+                return False
         
         # stop the camera 
         self._stop_camera()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2022,6 +2022,7 @@ class Window(QMainWindow):
         
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
+            self.unsaved_data=False 
             self._NewSession()
             # do not create a new folder
             self.CreateNewFolder=0

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -213,7 +213,7 @@ class Window(QMainWindow):
         self.Task.currentIndexChanged.connect(self._Task)
         self.AdvancedBlockAuto.currentIndexChanged.connect(self._AdvancedBlockAuto)
         self.TargetRatio.textChanged.connect(self._UpdateSuggestedWater)
-        self.WeightAfter.textChanged.connect(self._UpdateSuggestedWater)
+        self.WeightAfter.textChanged.connect(self._PostWeightChange)
         self.BaseWeight.textChanged.connect(self._UpdateSuggestedWater)
         self.Randomness.currentIndexChanged.connect(self._Randomness)
         self.TrainingStage.currentIndexChanged.connect(self._TrainingStage)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2764,6 +2764,7 @@ class Window(QMainWindow):
     def _NewSession(self,override_unsaved_data=False):
         logging.info('New Session pressed')
         self._StopCurrentSession() 
+        print('debug: {}'.format(override_unsaved_data))
 
         if not override_unsaved_data:
             print('debug')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3348,6 +3348,10 @@ class Window(QMainWindow):
         self.ManualWaterVolume[1]=self.ManualWaterVolume[1]+float(self.TP_GiveWaterR_volume)/1000
         self._UpdateSuggestedWater()
 
+    def _PostWeightChange(self):
+        self.unsaved_data=True
+        self.WarningLabel.setText('')
+        self._UpdateSuggestedWater()
 
     def _UpdateSuggestedWater(self,ManualWater=0):
         '''Update the suggested water from the manually give water'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2022,7 +2022,7 @@ class Window(QMainWindow):
         
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
-            self._NewSession(dont_ask=True)
+            self._NewSession(override_unsaved_data=True)
             # do not create a new folder
             self.CreateNewFolder=0
         # check drop of frames
@@ -2761,11 +2761,11 @@ class Window(QMainWindow):
         except Exception as e:
             logging.error(str(e))
 
-    def _NewSession(self,dont_ask=False):
+    def _NewSession(self,override_unsaved_data=False):
         logging.info('New Session pressed')
         self._StopCurrentSession() 
 
-        if dont_ask==False:
+        if not override_unsaved_data:
             # If we have unsaved data, prompt to save
             if (self.ToInitializeVisual==0) and (self.unsaved_data): 
                 reply = QMessageBox.critical(self, 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Recent changes introduced a bug in which pressing `New Session` did not prompt the user about unsaved data. This bug has been fixed. 
- after saving, if the `Post Weight` field is modified, the Save button toggles purple reminding users to save this value. 
- "File/New" was routed to "clear", I now routed it to "New Session", since we already have "File/Clear"

### What issues or discussions does this update address?
- resolves #396 

### Describe the expected change in behavior from the perspective of the experimenter
If you press `New Session` with unsaved data, you will be prompted to save

### Describe the outcome of testing this update on a rig in 447
- [ ] tested in 447





