### PR TITLE
Update camera delay & fix post weight

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1066,7 +1066,7 @@ class CameraDialog(QDialog):
             self.MainWindow.Channel.CameraFrequency(int(self.FrameRate.text()))
             # start the video triggers
             self.MainWindow.Channel.CameraControl(int(1))
-            time.sleep(2)
+            time.sleep(5)
             self.MainWindow.WarningLabelCamera.setText('Camera is on!')
             self.MainWindow.WarningLabelCamera.setStyleSheet(self.MainWindow.default_warning_color)
             self.WarningLabelCameraOn.setText('Camera is on!')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -332,74 +332,76 @@ class Window(QMainWindow):
 
     def _check_drop_frames(self,save_tag=1):
         '''check if there are any drop frames in the video'''
-        return_tag=0
-        if save_tag==0:
-            if "drop_frames_warning_text" in self.Obj:
-                self.drop_frames_warning_text=self.Obj['drop_frames_warning_text']
-                self.drop_frames_tag=self.Obj['drop_frames_tag']
-                self.trigger_length=self.Obj['trigger_length']
-                self.frame_num=self.Obj['frame_num']
-                return_tag=1
-        if return_tag==0:
-            self.drop_frames_tag=0
-            self.trigger_length=0
-            self.drop_frames_warning_text = ''
-            self.frame_num={}
-            use_default_folder_structure=0
-            if save_tag==1:
-                # check the drop frames of the current session
-                if hasattr(self,'HarpFolder'):
-                    HarpFolder=self.HarpFolder
-                    video_folder=self.VideoFolder
-                else:
-                    use_default_folder_structure=1
-            elif save_tag==0:
-                if 'HarpFolder' in self.Obj:
-                    # check the drop frames of the loaded session
-                    HarpFolder=self.Obj['HarpFolder']
-                    video_folder=self.Obj['VideoFolder']
-                else:
-                    use_default_folder_structure=1
-            if use_default_folder_structure:
-                # use the default folder structure
-                HarpFolder=os.path.join(os.path.dirname(os.path.dirname(self.fname)),'HarpFolder')# old folder structure
-                video_folder=os.path.join(os.path.dirname(os.path.dirname(self.fname)),'VideoFolder') # old folder structure
-                if not os.path.exists(HarpFolder):
-                    HarpFolder=os.path.join(os.path.dirname(self.fname),'raw.harp')# new folder structure
-                    video_folder=os.path.join(os.path.dirname(os.path.dirname(self.fname)),'behavior-videos') # new folder structure
-
-            camera_trigger_file=os.path.join(HarpFolder,'BehaviorEvents','Event_94.bin')
-            if os.path.exists(camera_trigger_file):
-                # sleep some time to wait for the finish of saving video
-                time.sleep(5)
-                triggers = harp.read(camera_trigger_file)
-                self.trigger_length = len(triggers)
-            else:
+        if self.to_check_drop_frames==1:
+            return_tag=0
+            if save_tag==0:
+                if "drop_frames_warning_text" in self.Obj:
+                    self.drop_frames_warning_text=self.Obj['drop_frames_warning_text']
+                    self.drop_frames_tag=self.Obj['drop_frames_tag']
+                    self.trigger_length=self.Obj['trigger_length']
+                    self.frame_num=self.Obj['frame_num']
+                    return_tag=1
+            if return_tag==0:
+                self.drop_frames_tag=0
                 self.trigger_length=0
-                self.WarningLabelCamera.setText('No camera trigger file found!')
-                self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
-                return
-            csv_files = [file for file in os.listdir(video_folder) if file.endswith(".csv")]
-            avi_files = [file for file in os.listdir(video_folder) if file.endswith(".avi")]
-
-            for avi_file in avi_files:
-                csv_file = avi_file.replace('.avi', '.csv')
-                if csv_file not in csv_files:
-                    self.drop_frames_warning_text+=f'No csv file found for {avi_file}\n'
-                else:
-                    current_frames = pd.read_csv(os.path.join(video_folder, csv_file), header=None)
-                    num_frames = len(current_frames)
-                    if num_frames != self.trigger_length:
-                        self.drop_frames_warning_text+=f"Error: {avi_file} has {num_frames} frames, but {self.trigger_length} triggers\n"
-                        self.drop_frames_tag=1
+                self.drop_frames_warning_text = ''
+                self.frame_num={}
+                use_default_folder_structure=0
+                if save_tag==1:
+                    # check the drop frames of the current session
+                    if hasattr(self,'HarpFolder'):
+                        HarpFolder=self.HarpFolder
+                        video_folder=self.VideoFolder
                     else:
-                        self.drop_frames_warning_text+=f"Correct: {avi_file} has {num_frames} frames and {self.trigger_length} triggers\n"
-                    self.frame_num[csv_file] = num_frames
-        self.WarningLabelCamera.setText(self.drop_frames_warning_text)
-        if self.drop_frames_tag:
-            self.WarningLabelCamera.setStyleSheet("color: red;")
-        else:
-            self.WarningLabelCamera.setStyleSheet("color: green;")  
+                        use_default_folder_structure=1
+                elif save_tag==0:
+                    if 'HarpFolder' in self.Obj:
+                        # check the drop frames of the loaded session
+                        HarpFolder=self.Obj['HarpFolder']
+                        video_folder=self.Obj['VideoFolder']
+                    else:
+                        use_default_folder_structure=1
+                if use_default_folder_structure:
+                    # use the default folder structure
+                    HarpFolder=os.path.join(os.path.dirname(os.path.dirname(self.fname)),'HarpFolder')# old folder structure
+                    video_folder=os.path.join(os.path.dirname(os.path.dirname(self.fname)),'VideoFolder') # old folder structure
+                    if not os.path.exists(HarpFolder):
+                        HarpFolder=os.path.join(os.path.dirname(self.fname),'raw.harp')# new folder structure
+                        video_folder=os.path.join(os.path.dirname(os.path.dirname(self.fname)),'behavior-videos') # new folder structure
+
+                camera_trigger_file=os.path.join(HarpFolder,'BehaviorEvents','Event_94.bin')
+                if os.path.exists(camera_trigger_file):
+                    # sleep some time to wait for the finish of saving video
+                    time.sleep(5)
+                    triggers = harp.read(camera_trigger_file)
+                    self.trigger_length = len(triggers)
+                else:
+                    self.trigger_length=0
+                    self.WarningLabelCamera.setText('No camera trigger file found!')
+                    self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
+                    return
+                csv_files = [file for file in os.listdir(video_folder) if file.endswith(".csv")]
+                avi_files = [file for file in os.listdir(video_folder) if file.endswith(".avi")]
+
+                for avi_file in avi_files:
+                    csv_file = avi_file.replace('.avi', '.csv')
+                    if csv_file not in csv_files:
+                        self.drop_frames_warning_text+=f'No csv file found for {avi_file}\n'
+                    else:
+                        current_frames = pd.read_csv(os.path.join(video_folder, csv_file), header=None)
+                        num_frames = len(current_frames)
+                        if num_frames != self.trigger_length:
+                            self.drop_frames_warning_text+=f"Error: {avi_file} has {num_frames} frames, but {self.trigger_length} triggers\n"
+                            self.drop_frames_tag=1
+                        else:
+                            self.drop_frames_warning_text+=f"Correct: {avi_file} has {num_frames} frames and {self.trigger_length} triggers\n"
+                        self.frame_num[csv_file] = num_frames
+            self.WarningLabelCamera.setText(self.drop_frames_warning_text)
+            if self.drop_frames_tag:
+                self.WarningLabelCamera.setStyleSheet("color: red;")
+            else:
+                self.WarningLabelCamera.setStyleSheet("color: green;")  
+            self.to_check_drop_frames=0
 
     def _warmup(self):
         '''warm up the session before starting.
@@ -2054,9 +2056,7 @@ class Window(QMainWindow):
             self.CreateNewFolder=0
         
         # check drop of frames only once
-        if self.to_check_drop_frames==1:
-            self._check_drop_frames(save_tag=1)
-            self.to_check_drop_frames=0
+        self._check_drop_frames(save_tag=1)
 
         # save drop frames information
         Obj['drop_frames_tag']=self.drop_frames_tag

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3417,6 +3417,7 @@ class Window(QMainWindow):
 
     def _PostWeightChange(self):
         self.unsaved_data=True
+        self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
         self.WarningLabel.setText('')
         self._UpdateSuggestedWater()
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3417,9 +3417,6 @@ class Window(QMainWindow):
 
     def _PostWeightChange(self):
         self.unsaved_data=True
-        self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
-        self.NewSession.setStyleSheet("background-color : none")
-        self.NewSession.setChecked(False)
         self.WarningLabel.setText('')
         self._UpdateSuggestedWater()
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2043,14 +2043,17 @@ class Window(QMainWindow):
         Obj['PhotometryFolder']=self.PhotometryFolder
         Obj['MetadataFolder']=self.MetadataFolder
         
-        if SaveContinue==0:
+        # only run once for each session
+        if SaveContinue==0 and self.unsaved_data==True:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
             self.unsaved_data=False 
             self._NewSession()
+            self.unsaved_data=True
             # do not create a new folder
             self.CreateNewFolder=0
-        # check drop of frames
-        self._check_drop_frames(save_tag=1)
+            # check drop of frames
+            self._check_drop_frames(save_tag=1)
+            
         # save drop frames information
         Obj['drop_frames_tag']=self.drop_frames_tag
         Obj['trigger_length']=self.trigger_length

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2056,7 +2056,6 @@ class Window(QMainWindow):
             # do not create a new folder
             self.CreateNewFolder=0
         
-        # check drop of frames only once
         self._check_drop_frames(save_tag=1)
 
         # save drop frames information

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -401,6 +401,7 @@ class Window(QMainWindow):
                 self.WarningLabelCamera.setStyleSheet("color: red;")
             else:
                 self.WarningLabelCamera.setStyleSheet("color: green;")  
+            # only check drop frames once each session
             self.to_check_drop_frames=0
 
     def _warmup(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -91,7 +91,8 @@ class Window(QMainWindow):
         self.UpdateParameters = 1   # permission to update parameters
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
- 
+        self.to_check_drop_frames = 0 # 1, to check drop frames during saving data; 0, not to check drop frames 
+
         # Connect to Bonsai
         self._InitializeBonsai()
 
@@ -2044,16 +2045,19 @@ class Window(QMainWindow):
         Obj['MetadataFolder']=self.MetadataFolder
         
         # only run once for each session
-        if SaveContinue==0 and self.unsaved_data==True:
+        if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
             self.unsaved_data=False 
             self._NewSession()
             self.unsaved_data=True
             # do not create a new folder
             self.CreateNewFolder=0
-            # check drop of frames
+        
+        # check drop of frames only once
+        if self.to_check_drop_frames==1:
             self._check_drop_frames(save_tag=1)
-            
+            self.to_check_drop_frames=0
+
         # save drop frames information
         Obj['drop_frames_tag']=self.drop_frames_tag
         Obj['trigger_length']=self.trigger_length
@@ -2937,6 +2941,9 @@ class Window(QMainWindow):
             self.Start.setChecked(False)
             self.Start.setStyleSheet('background-color:none;')
             return
+        
+        # set the flag to check drop frames
+        self.to_check_drop_frames=1
         
         # clear the session list
         self._connect_Sessionlist(connect=False)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2526,6 +2526,7 @@ class Window(QMainWindow):
                 self.SessionlistSpin.setValue(Ind+1)
                 self._connect_Sessionlist(connect=True)
             # check dropping frames
+            self.to_check_drop_frames=1
             self._check_drop_frames(save_tag=0)
         else:
             self.NewSession.setDisabled(False)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2048,7 +2048,7 @@ class Window(QMainWindow):
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
             self.unsaved_data=False 
-            self._NewSession()
+            self._NewSession(initialize_figure=False)
             self.unsaved_data=True
             # do not create a new folder
             self.CreateNewFolder=0
@@ -2792,7 +2792,7 @@ class Window(QMainWindow):
         except Exception as e:
             logging.error(str(e))
 
-    def _NewSession(self):
+    def _NewSession(self,initialize_figure=True):
         logging.info('New Session pressed')
 
         # If we have unsaved data, prompt to save
@@ -2834,7 +2834,7 @@ class Window(QMainWindow):
         self.ManualWaterVolume=[0,0]       
     
         # Clear Plots
-        if hasattr(self, 'PlotM'): 
+        if hasattr(self, 'PlotM') and initialize_figure==True: 
             self.PlotM._Update(GeneratedTrials=None,Channel=None)
 
         # Add note to log

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2051,7 +2051,7 @@ class Window(QMainWindow):
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
             self.unsaved_data=False 
-            self._NewSession(initialize_figure=False)
+            self._NewSession()
             self.unsaved_data=True
             # do not create a new folder
             self.CreateNewFolder=0
@@ -2793,7 +2793,7 @@ class Window(QMainWindow):
         except Exception as e:
             logging.error(str(e))
 
-    def _NewSession(self,initialize_figure=True):
+    def _NewSession(self):
         logging.info('New Session pressed')
 
         # If we have unsaved data, prompt to save
@@ -2835,7 +2835,7 @@ class Window(QMainWindow):
         self.ManualWaterVolume=[0,0]       
     
         # Clear Plots
-        if hasattr(self, 'PlotM') and initialize_figure==True: 
+        if hasattr(self, 'PlotM'): 
             self.PlotM._Update(GeneratedTrials=None,Channel=None)
 
         # Add note to log

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -91,7 +91,7 @@ class Window(QMainWindow):
         self.UpdateParameters = 1   # permission to update parameters
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
-        self.to_check_drop_frames = 0 # 1, to check drop frames during saving data; 0, not to check drop frames 
+        self.to_check_drop_frames = 1 # 1, to check drop frames during saving data; 0, not to check drop frames 
 
         # Connect to Bonsai
         self._InitializeBonsai()
@@ -3418,6 +3418,7 @@ class Window(QMainWindow):
     def _PostWeightChange(self):
         self.unsaved_data=True
         self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
+        self.NewSession.setStyleSheet("background-color : none")
         self.WarningLabel.setText('')
         self._UpdateSuggestedWater()
 

--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -7261,7 +7261,7 @@
                   </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:Delay">
-                      <rx:DueTime>PT2S</rx:DueTime>
+                      <rx:DueTime>PT5S</rx:DueTime>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="beh:CreateMessage">


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Change the delay from 2 seconds to 5 seconds to trigger the camera after starting logging. 5s is safer. 
2. Only run check drop of frames once.
3. Don't change the color of the new session button when the post weight changes.

### What issues or discussions does this update address?
1. The camera requires time to be ready to receive external triggers. The previous delay to send triggers after starting logging was 2s. Here, we changed it to 5s to make it safer. 
2. We only need to run it once to check drop of frames. Previously, it would run every time we clicked the "Save" button.
3. The post weight change was previously coupled with the new session button, which is not correct (e.g. after saving, we will start a new session by default. Then, we change the post weight, the new session button should still be selected).


### Describe the expected change in behavior from the perspective of the experimenter
1. For video session, the GUI will sleep 5s after clicking Start button. 


### Describe the outcome of testing this update on a rig in 447
- [x] 323_EPHYS3




