### PR TITLE
Control open ephys from the GUI

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -29,7 +29,7 @@ from foraging_gui.Dialogs import OptogeneticsDialog,WaterCalibrationDialog,Camer
 from foraging_gui.Dialogs import LaserCalibrationDialog
 from foraging_gui.Dialogs import LickStaDialog,TimeDistributionDialog
 from foraging_gui.Dialogs import AutoTrainDialog, MouseSelectorDialog
-from foraging_gui.MyFunctions import GenerateTrials, Worker,TimerWorker, NewScaleSerialY
+from foraging_gui.MyFunctions import GenerateTrials, Worker,TimerWorker, NewScaleSerialY, EphysRecording
 from foraging_gui.stage import Stage
 
 class NumpyEncoder(json.JSONEncoder):
@@ -243,7 +243,7 @@ class Window(QMainWindow):
         self.warmup.currentIndexChanged.connect(self._warmup)
         self.Sessionlist.currentIndexChanged.connect(self._session_list)
         self.SessionlistSpin.textChanged.connect(self._session_list_spin)
-
+        self.StartEphysRecording.clicked.connect(self._StartEphysRecording)
         # check the change of all of the QLineEdit, QDoubleSpinBox and QSpinBox
         for container in [self.TrainingParameters, self.centralwidget, self.Opto_dialog]:
             # Iterate over each child of the container that is a QLineEdit or QDoubleSpinBox
@@ -255,6 +255,15 @@ class Window(QMainWindow):
             for child in container.findChildren((QtWidgets.QLineEdit)):        
                 child.returnPressed.connect(self.keyPressEvent)
     
+    def _StartEphysRecording(self):
+        '''
+            Start ephys recording
+            
+           
+        '''
+
+        pass
+
     def _session_list(self):
         '''show all sessions of the current animal and load the selected session by drop down list'''
         if not hasattr(self,'fname'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -289,8 +289,9 @@ class Window(QMainWindow):
                 response['openephys_start_recording_time']=self.openephys_start_recording_time
                 response['openephys_stop_recording_time']=self.openephys_stop_recording_time
                 response['recording_type']=self.OpenEphysRecordingType.currentText()
-
                 self.open_ephys.append(response)
+                self.unsaved_data=True
+                self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -293,7 +293,7 @@ class Window(QMainWindow):
                 self.unsaved_data=True
                 self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
                 EphysControl.stop_open_ephys_recording()
-                QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
+                QMessageBox.warning(self, '', 'Open Ephys has stopped recording! Please save the data again!')
             except Exception as e:
                 logging.error(str(e))
                 QMessageBox.warning(self, 'Connection Error', 'Failed to stop Open Ephys recording. Please check: \n1) the open ephys software is still running')
@@ -2177,7 +2177,7 @@ class Window(QMainWindow):
         with open(filepath, 'w') as finished_file:
             finished_file.write(contents)
         if self.StartEphysRecording.isChecked():
-            QMessageBox.warning(self, '', 'Data saved successfully! However, the ephys recording is still running. Make sure to close ephys recording and save the data again!')
+            QMessageBox.warning(self, '', 'Data saved successfully! However, the ephys recording is still running. Make sure to stop ephys recording and save the data again!')
             self.unsaved_data=True
             self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -270,10 +270,8 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
-                self.r1,_=EphysControl.start_open_ephys_recording()
-                openephys_start_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
-                self.r1['recording_type']=self.OpenEphysRecordingType.currentText()
-                self.r1['openephys_start_recording_time']=openephys_start_recording_time
+                EphysControl.start_open_ephys_recording()
+                self.openephys_start_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
                 QMessageBox.warning(self, '', f'Open Ephys has started recording!\n Recording type: {self.OpenEphysRecordingType.currentText()}')
             except Exception as e:
                 logging.error(str(e))
@@ -286,9 +284,13 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
-                openephys_stop_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
-                self.r1['openephys_stop_recording_time']=openephys_stop_recording_time
-                self.open_ephys.append(self.r1)
+                self.openephys_stop_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+                response=self.get_open_ephys_recording_configuration()
+                response['openephys_start_recording_time']=self.openephys_start_recording_time
+                response['openephys_stop_recording_time']=self.openephys_stop_recording_time
+                response['recording_type']=self.OpenEphysRecordingType.currentText()
+
+                self.open_ephys.append(response)
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -822,7 +822,8 @@ class Window(QMainWindow):
             'newscale_serial_num_box3':'',
             'newscale_serial_num_box4':'',
             'show_log_info_in_console':False,
-            'default_ui':'ForagingGUI.ui'
+            'default_ui':'ForagingGUI.ui',
+            'open_ephys_machine_ip_address':''
         }
         
         # Try to load Settings_box#.csv
@@ -879,7 +880,8 @@ class Window(QMainWindow):
         self.newscale_serial_num_box3=self.Settings['newscale_serial_num_box3']
         self.newscale_serial_num_box4=self.Settings['newscale_serial_num_box4']
         self.default_ui=self.Settings['default_ui']
-
+        self.open_ephys_machine_ip_address=self.Settings['open_ephys_machine_ip_address']
+        
         # Also stream log info to the console if enabled
         if  self.Settings['show_log_info_in_console']:
             logger = logging.getLogger()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -262,7 +262,7 @@ class Window(QMainWindow):
            
         '''
 
-        pass
+        EphysRecording(open_ephys_machine_ip_address="10.128.53.45",mouse_id='12321312')
 
     def _session_list(self):
         '''show all sessions of the current animal and load the selected session by drop down list'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,7 +267,7 @@ class Window(QMainWindow):
             self._toggle_color(self.StartEphysRecording)
             return
         
-        if self.Start.isChecked() and self.StartEphysRecording.isChecked():
+        if self.ANewTrial==1 and self.StartEphysRecording.isChecked():
             reply = QMessageBox.question(self, '', 'Behavior has started! Do you want to start ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
             if reply == QMessageBox.Yes:
                 pass
@@ -299,11 +299,12 @@ class Window(QMainWindow):
                     self._toggle_color(self.StartEphysRecording)
                     return
                 
-                if self.Start.isChecked():
+                if self.ANewTrial==1:
                     reply = QMessageBox.question(self,  '','The behavior hasn’t stopped yet! Do you want to stop ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
                     if reply == QMessageBox.Yes:
                         pass
                     elif reply == QMessageBox.No:
+                        self.StartEphysRecording.setChecked(True)
                         self._toggle_color(self.StartEphysRecording)
                         return
                     

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -269,6 +269,30 @@ class Window(QMainWindow):
             EphysControl.stop_open_ephys_recording()
         
 
+    def _toggle_color(self,widget,check_color="background-color : green;",unchecked_color="background-color : none"):
+        '''
+        Toggle the color of the widget.
+
+        Parameters
+        ----------
+        widget : QtWidgets.QWidget
+
+            If Checked, sets the color to green. If unchecked, sets the color to None.
+
+        Returns
+        -------
+        None
+        '''
+
+
+        if widget.isChecked():
+            widget.setStyleSheet(check_color)
+        else:
+            widget.setStyleSheet(unchecked_color)
+
+
+
+
     def _session_list(self):
         '''show all sessions of the current animal and load the selected session by drop down list'''
         if not hasattr(self,'fname'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,6 +267,15 @@ class Window(QMainWindow):
             self._toggle_color(self.StartEphysRecording)
             return
         
+        if self.Start.isChecked():
+            reply = QMessageBox.question(self,  'Behavior has started! Do you want to start ephys recording?', QMessageBox,QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
+            if reply == QMessageBox.Yes:
+                pass
+            elif reply == QMessageBox.No:
+                self.StartEphysRecording.setChecked(False)
+                self._toggle_color(self.StartEphysRecording)
+                return
+        
         EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id=self.ID.text())
         if self.StartEphysRecording.isChecked():
             try:
@@ -302,7 +311,7 @@ class Window(QMainWindow):
             except Exception as e:
                 logging.error(str(e))
                 QMessageBox.warning(self, 'Connection Error', 'Failed to stop Open Ephys recording. Please check: \n1) the open ephys software is still running')
-        
+        self._toggle_color(self.StartEphysRecording)
 
     def _toggle_color(self,widget,check_color="background-color : green;",unchecked_color="background-color : none"):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -271,9 +271,9 @@ class Window(QMainWindow):
                     self._toggle_color(self.StartEphysRecording)
                     return
                 openephys_start_recording_time = datetime.now()
-                self.r1,_=EphysControl.start_open_ephys_recording()
                 self.r1['recording_type']=self.OpenEphysRecordingType.currentText()
-                self.r1['openephys_start_recording_time']=self.openephys_start_recording_time
+                self.r1['openephys_start_recording_time']=openephys_start_recording_time
+                self.r1,_=EphysControl.start_open_ephys_recording()
                 QMessageBox.warning(self, '', f'Open Ephys has started recording!\n Recording type: {self.OpenEphysRecordingType.currentText()}')
             except Exception as e:
                 logging.error(str(e))
@@ -287,7 +287,7 @@ class Window(QMainWindow):
                     self._toggle_color(self.StartEphysRecording)
                     return
                 openephys_stop_recording_time = datetime.now()
-                self.r1['openephys_start_recording_time']=self.openephys_stop_recording_time
+                self.r1['openephys_start_recording_time']=openephys_stop_recording_time
                 self.open_ephys.append(self.r1)
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
@@ -2130,7 +2130,7 @@ class Window(QMainWindow):
         
         # save the open ephys recording information
         Obj['open_ephys'] = self.open_ephys
-        
+
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 
             self.unsaved_data=False 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -290,6 +290,25 @@ class Window(QMainWindow):
         else:
             widget.setStyleSheet(unchecked_color)
 
+    def _manage_warning_labels(self,warning_labels,warning_text):
+        '''
+            Manage the warning labels. 
+
+            If there is a warning, set the color to self.default_warning_color. If there is no warning, set the text to ''. 
+        Parameters
+        ----------
+        warning_label : single QtWidgets.QLabel or list of QtWidgets.QLabel
+            The warning label to manage
+        warning_text : str
+            The warning text to display
+        Returns
+        -------
+        None
+        '''
+
+        for warning_label in warning_labels:
+            warning_label.setText(warning_text)
+            warning_label.setStyleSheet(self.default_warning_color)
 
     def _session_list(self):
         '''show all sessions of the current animal and load the selected session by drop down list'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -285,7 +285,7 @@ class Window(QMainWindow):
                     self._toggle_color(self.StartEphysRecording)
                     return
                 self.openephys_stop_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
-                response=self.get_open_ephys_recording_configuration()
+                response=EphysControl.get_open_ephys_recording_configuration()
                 response['openephys_start_recording_time']=self.openephys_start_recording_time
                 response['openephys_stop_recording_time']=self.openephys_stop_recording_time
                 response['recording_type']=self.OpenEphysRecordingType.currentText()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -298,6 +298,16 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
+                
+                if self.Start.isChecked():
+                    reply = QMessageBox.question(self,  'The behavior hasn’t stopped yet! Do you want to stop ephys logging?', QMessageBox,QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
+                    if reply == QMessageBox.Yes:
+                        pass
+                    elif reply == QMessageBox.No:
+                        self.StartEphysRecording.setChecked(False)
+                        self._toggle_color(self.StartEphysRecording)
+                        return
+                    
                 self.openephys_stop_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
                 response=EphysControl.get_open_ephys_recording_configuration()
                 response['openephys_start_recording_time']=self.openephys_start_recording_time

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -264,11 +264,19 @@ class Window(QMainWindow):
 
         EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id=self.ID.text())
         if self.StartEphysRecording.isChecked():
-            EphysControl.start_open_ephys_recording()  
+            try:
+                EphysControl.start_open_ephys_recording()
+            except Exception as e:
+                logging.error(str(e))
+                self.StartEphysRecording.setChecked(False)
+                if "No connection could be made because the target machine actively refused it" in str(e):
+                    QMessageBox.warning(self, 'Connection Error', 'Failed to connect to Open Ephys. Please check: \n1) the correct ip address is included in the settings json file. \n2) the Open Ephys software is open.')
+                                       
         else:
             EphysControl.stop_open_ephys_recording()
         self._toggle_color(self.StartEphysRecording)
         
+
     def _toggle_color(self,widget,check_color="background-color : green;",unchecked_color="background-color : none"):
         '''
         Toggle the color of the widget.

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,7 +267,7 @@ class Window(QMainWindow):
             self._toggle_color(self.StartEphysRecording)
             return
         
-        if self.Start.isChecked() and self.ANewTrial==0 and self.StartEphysRecording.isChecked():
+        if  (self.Start.isChecked() or self.ANewTrial==0) and self.StartEphysRecording.isChecked():
             reply = QMessageBox.question(self, '', 'Behavior has started! Do you want to start ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
             if reply == QMessageBox.Yes:
                 pass
@@ -299,7 +299,7 @@ class Window(QMainWindow):
                     self._toggle_color(self.StartEphysRecording)
                     return
                 
-                if  self.Start.isChecked() and self.ANewTrial==0:
+                if  self.Start.isChecked() or self.ANewTrial==0:
                     reply = QMessageBox.question(self,  '','The behavior hasn’t stopped yet! Do you want to stop ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
                     if reply == QMessageBox.Yes:
                         pass

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -262,7 +262,7 @@ class Window(QMainWindow):
 
         '''
 
-        EphysControl=EphysRecording(open_ephys_machine_ip_address="10.128.53.45",mouse_id='12321312')
+        EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id='12321312')
         if self.StartEphysRecording.isChecked():
             EphysControl.start_open_ephys_recording()  
         else:
@@ -881,7 +881,7 @@ class Window(QMainWindow):
         self.newscale_serial_num_box4=self.Settings['newscale_serial_num_box4']
         self.default_ui=self.Settings['default_ui']
         self.open_ephys_machine_ip_address=self.Settings['open_ephys_machine_ip_address']
-        
+
         # Also stream log info to the console if enabled
         if  self.Settings['show_log_info_in_console']:
             logger = logging.getLogger()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -268,7 +268,7 @@ class Window(QMainWindow):
                     QMessageBox.warning(self, '', 'Open Ephys is already recording! Please stop the recording first.')
                     self.StartEphysRecording.setChecked(False)
                     return
-                EphysControl.start_open_ephys_recording()
+                r1,r2=EphysControl.start_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has started recording!')
             except Exception as e:
                 logging.error(str(e))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,8 +267,8 @@ class Window(QMainWindow):
             self._toggle_color(self.StartEphysRecording)
             return
         
-        if self.Start.isChecked():
-            reply = QMessageBox.question(self,  'Behavior has started! Do you want to start ephys recording?', QMessageBox,QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
+        if self.Start.isChecked() and self.StartEphysRecording.isChecked():
+            reply = QMessageBox.question(self, '', 'Behavior has started! Do you want to start ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
             if reply == QMessageBox.Yes:
                 pass
             elif reply == QMessageBox.No:
@@ -300,11 +300,10 @@ class Window(QMainWindow):
                     return
                 
                 if self.Start.isChecked():
-                    reply = QMessageBox.question(self,  'The behavior hasn’t stopped yet! Do you want to stop ephys logging?', QMessageBox,QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
+                    reply = QMessageBox.question(self,  '','The behavior hasn’t stopped yet! Do you want to stop ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
                     if reply == QMessageBox.Yes:
                         pass
                     elif reply == QMessageBox.No:
-                        self.StartEphysRecording.setChecked(False)
                         self._toggle_color(self.StartEphysRecording)
                         return
                     

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -269,12 +269,14 @@ class Window(QMainWindow):
             except Exception as e:
                 logging.error(str(e))
                 self.StartEphysRecording.setChecked(False)
-                QMessageBox.warning(self, 'Connection Error', 'Failed to connect to Open Ephys. Please check: \n1) the correct ip address is included in the settings json file. \n2) the Open Ephys software is open.')
-                                       
+                QMessageBox.warning(self, 'Connection Error', 'Failed to connect to Open Ephys. Please check: \n1) the correct ip address is included in the settings json file. \n2) the Open Ephys software is open.')                            
         else:
-            EphysControl.stop_open_ephys_recording()
+            try:
+                EphysControl.stop_open_ephys_recording()
+            except Exception as e:
+                logging.error(str(e))
+                QMessageBox.warning(self, 'Connection Error', 'Failed to stop Open Ephys recording. Please check: \n1) the open ephys software is still running')
         self._toggle_color(self.StartEphysRecording)
-        
 
     def _toggle_color(self,widget,check_color="background-color : green;",unchecked_color="background-color : none"):
         '''
@@ -297,7 +299,7 @@ class Window(QMainWindow):
         else:
             widget.setStyleSheet(unchecked_color)
 
-    def _manage_warning_labels(self,warning_labels,warning_text):
+    def _manage_warning_labels(self,warning_labels,warning_text=''):
         '''
             Manage the warning labels. 
 
@@ -312,7 +314,8 @@ class Window(QMainWindow):
         -------
         None
         '''
-
+        if not isinstance(warning_labels,list):
+            warning_labels = [warning_labels]
         for warning_label in warning_labels:
             warning_label.setText(warning_text)
             warning_label.setStyleSheet(self.default_warning_color)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -276,6 +276,10 @@ class Window(QMainWindow):
                 QMessageBox.warning(self, 'Connection Error', 'Failed to connect to Open Ephys. Please check: \n1) the correct ip address is included in the settings json file. \n2) the Open Ephys software is open.')                            
         else:
             try:
+                if EphysControl.get_status()['mode']!='RECORD':
+                    QMessageBox.warning(self, '', 'Open Ephys is not recording! Please start the recording first.')
+                    self.StartEphysRecording.setChecked(False)
+                    return
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -269,6 +269,7 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
+                self.openephys_start_recording_time = datetime.now()
                 r1,r2=EphysControl.start_open_ephys_recording()
                 QMessageBox.warning(self, '', f'Open Ephys has started recording!\n Recording type: {self.OpenEphysRecordingType.currentText()}')
             except Exception as e:
@@ -282,6 +283,7 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
+                self.openephys_stop_recording_time = datetime.now()
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2176,7 +2176,10 @@ class Window(QMainWindow):
         contents = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         with open(filepath, 'w') as finished_file:
             finished_file.write(contents)
-        
+        if self.StartEphysRecording.isChecked():
+            QMessageBox.warning(self, '', 'Data saved successfully! However, the ephys recording is still running. Make sure to close ephys recording and save the data again!')
+            self.unsaved_data=True
+            self.Save.setStyleSheet("color: white;background-color : mediumorchid;")
 
     def _GetSaveFolder(self):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -257,15 +257,19 @@ class Window(QMainWindow):
     
     def _StartEphysRecording(self):
         '''
-            Start ephys recording
-
+            Start/stop ephys recording
 
         '''
 
         EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id=self.ID.text())
         if self.StartEphysRecording.isChecked():
             try:
+                if EphysControl.get_status()['mode']=='RECORD':
+                    QMessageBox.warning(self, '', 'Open Ephys is already recording! Please stop the recording first.')
+                    self.StartEphysRecording.setChecked(False)
+                    return
                 EphysControl.start_open_ephys_recording()
+                QMessageBox.warning(self, '', 'Open Ephys has started recording!')
             except Exception as e:
                 logging.error(str(e))
                 self.StartEphysRecording.setChecked(False)
@@ -273,6 +277,7 @@ class Window(QMainWindow):
         else:
             try:
                 EphysControl.stop_open_ephys_recording()
+                QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:
                 logging.error(str(e))
                 QMessageBox.warning(self, 'Connection Error', 'Failed to stop Open Ephys recording. Please check: \n1) the open ephys software is still running')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -136,7 +136,8 @@ class Window(QMainWindow):
         self.CreateNewFolder=1 # to create new folder structure (a new session)
         self.ManualWaterVolume=[0,0]
         self._StopPhotometry() # Make sure photoexcitation is stopped 
- 
+        # Initialize open ephys saving dictionary
+        self.open_ephys=[]
         if not self.start_bonsai_ide:
             '''
                 When starting bonsai without the IDE the connection is always unstable.
@@ -269,8 +270,10 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
-                self.openephys_start_recording_time = datetime.now()
-                r1,r2=EphysControl.start_open_ephys_recording()
+                openephys_start_recording_time = datetime.now()
+                self.r1,_=EphysControl.start_open_ephys_recording()
+                self.r1['recording_type']=self.OpenEphysRecordingType.currentText()
+                self.r1['openephys_start_recording_time']=self.openephys_start_recording_time
                 QMessageBox.warning(self, '', f'Open Ephys has started recording!\n Recording type: {self.OpenEphysRecordingType.currentText()}')
             except Exception as e:
                 logging.error(str(e))
@@ -283,7 +286,9 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
-                self.openephys_stop_recording_time = datetime.now()
+                openephys_stop_recording_time = datetime.now()
+                self.r1['openephys_start_recording_time']=self.openephys_stop_recording_time
+                self.open_ephys.append(self.r1)
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:
@@ -2122,6 +2127,9 @@ class Window(QMainWindow):
         Obj['VideoFolder']=self.VideoFolder
         Obj['PhotometryFolder']=self.PhotometryFolder
         Obj['MetadataFolder']=self.MetadataFolder
+        
+        # save the open ephys recording information
+        Obj['open_ephys'] = self.open_ephys
         
         if SaveContinue==0:
             # force to start a new session; Logging will stop and users cannot run new behaviors, but can still modify GUI parameters and save them.                 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,9 +267,10 @@ class Window(QMainWindow):
                 if EphysControl.get_status()['mode']=='RECORD':
                     QMessageBox.warning(self, '', 'Open Ephys is already recording! Please stop the recording first.')
                     self.StartEphysRecording.setChecked(False)
+                    self._toggle_color(self.StartEphysRecording)
                     return
                 r1,r2=EphysControl.start_open_ephys_recording()
-                QMessageBox.warning(self, '', 'Open Ephys has started recording!')
+                QMessageBox.warning(self, '', f'Open Ephys has started recording!\n Recording type: {self.OpenEphysRecordingType.currentText()}')
             except Exception as e:
                 logging.error(str(e))
                 self.StartEphysRecording.setChecked(False)
@@ -279,13 +280,14 @@ class Window(QMainWindow):
                 if EphysControl.get_status()['mode']!='RECORD':
                     QMessageBox.warning(self, '', 'Open Ephys is not recording! Please start the recording first.')
                     self.StartEphysRecording.setChecked(False)
+                    self._toggle_color(self.StartEphysRecording)
                     return
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')
             except Exception as e:
                 logging.error(str(e))
                 QMessageBox.warning(self, 'Connection Error', 'Failed to stop Open Ephys recording. Please check: \n1) the open ephys software is still running')
-        self._toggle_color(self.StartEphysRecording)
+        
 
     def _toggle_color(self,widget,check_color="background-color : green;",unchecked_color="background-color : none"):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -261,7 +261,12 @@ class Window(QMainWindow):
             Start/stop ephys recording
 
         '''
-
+        if self.open_ephys_machine_ip_address=='':
+            QMessageBox.warning(self, 'Connection Error', 'Empty ip address for Open Ephys Computer. Please check the settings file.')
+            self.StartEphysRecording.setChecked(False)
+            self._toggle_color(self.StartEphysRecording)
+            return
+        
         EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id=self.ID.text())
         if self.StartEphysRecording.isChecked():
             try:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,8 +267,8 @@ class Window(QMainWindow):
             EphysControl.start_open_ephys_recording()  
         else:
             EphysControl.stop_open_ephys_recording()
+        self._toggle_color(self.StartEphysRecording)
         
-
     def _toggle_color(self,widget,check_color="background-color : green;",unchecked_color="background-color : none"):
         '''
         Toggle the color of the widget.
@@ -289,8 +289,6 @@ class Window(QMainWindow):
             widget.setStyleSheet(check_color)
         else:
             widget.setStyleSheet(unchecked_color)
-
-
 
 
     def _session_list(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -267,7 +267,7 @@ class Window(QMainWindow):
             self._toggle_color(self.StartEphysRecording)
             return
         
-        if self.ANewTrial==1 and self.StartEphysRecording.isChecked():
+        if self.Start.isChecked() and self.ANewTrial==0 and self.StartEphysRecording.isChecked():
             reply = QMessageBox.question(self, '', 'Behavior has started! Do you want to start ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
             if reply == QMessageBox.Yes:
                 pass
@@ -299,7 +299,7 @@ class Window(QMainWindow):
                     self._toggle_color(self.StartEphysRecording)
                     return
                 
-                if self.ANewTrial==1:
+                if  self.Start.isChecked() and self.ANewTrial==0:
                     reply = QMessageBox.question(self,  '','The behavior hasn’t stopped yet! Do you want to stop ephys recording?', QMessageBox.No | QMessageBox.No, QMessageBox.Yes)
                     if reply == QMessageBox.Yes:
                         pass

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -270,10 +270,10 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
-                openephys_start_recording_time = datetime.now()
+                self.r1,_=EphysControl.start_open_ephys_recording()
+                openephys_start_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
                 self.r1['recording_type']=self.OpenEphysRecordingType.currentText()
                 self.r1['openephys_start_recording_time']=openephys_start_recording_time
-                self.r1,_=EphysControl.start_open_ephys_recording()
                 QMessageBox.warning(self, '', f'Open Ephys has started recording!\n Recording type: {self.OpenEphysRecordingType.currentText()}')
             except Exception as e:
                 logging.error(str(e))
@@ -286,8 +286,8 @@ class Window(QMainWindow):
                     self.StartEphysRecording.setChecked(False)
                     self._toggle_color(self.StartEphysRecording)
                     return
-                openephys_stop_recording_time = datetime.now()
-                self.r1['openephys_start_recording_time']=openephys_stop_recording_time
+                openephys_stop_recording_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+                self.r1['openephys_stop_recording_time']=openephys_stop_recording_time
                 self.open_ephys.append(self.r1)
                 EphysControl.stop_open_ephys_recording()
                 QMessageBox.warning(self, '', 'Open Ephys has stopped recording!')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -258,11 +258,16 @@ class Window(QMainWindow):
     def _StartEphysRecording(self):
         '''
             Start ephys recording
-            
-           
+
+
         '''
 
-        EphysRecording(open_ephys_machine_ip_address="10.128.53.45",mouse_id='12321312')
+        EphysControl=EphysRecording(open_ephys_machine_ip_address="10.128.53.45",mouse_id='12321312')
+        if self.StartEphysRecording.isChecked():
+            EphysControl.start_open_ephys_recording()  
+        else:
+            EphysControl.stop_open_ephys_recording()
+        
 
     def _session_list(self):
         '''show all sessions of the current animal and load the selected session by drop down list'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -262,7 +262,7 @@ class Window(QMainWindow):
 
         '''
 
-        EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id='12321312')
+        EphysControl=EphysRecording(open_ephys_machine_ip_address=self.open_ephys_machine_ip_address,mouse_id=self.ID.text())
         if self.StartEphysRecording.isChecked():
             EphysControl.start_open_ephys_recording()  
         else:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -269,8 +269,7 @@ class Window(QMainWindow):
             except Exception as e:
                 logging.error(str(e))
                 self.StartEphysRecording.setChecked(False)
-                if "No connection could be made because the target machine actively refused it" in str(e):
-                    QMessageBox.warning(self, 'Connection Error', 'Failed to connect to Open Ephys. Please check: \n1) the correct ip address is included in the settings json file. \n2) the Open Ephys software is open.')
+                QMessageBox.warning(self, 'Connection Error', 'Failed to connect to Open Ephys. Please check: \n1) the correct ip address is included in the settings json file. \n2) the Open Ephys software is open.')
                                        
         else:
             EphysControl.stop_open_ephys_recording()

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -79,7 +79,7 @@
            <x>0</x>
            <y>0</y>
            <width>894</width>
-           <height>236</height>
+           <height>226</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_17">
@@ -906,7 +906,7 @@
                   <x>0</x>
                   <y>0</y>
                   <width>627</width>
-                  <height>325</height>
+                  <height>303</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout">
@@ -1963,8 +1963,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>627</width>
-                  <height>325</height>
+                  <width>624</width>
+                  <height>326</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -2521,8 +2521,8 @@ Bias:</string>
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>340</width>
-                         <height>195</height>
+                         <width>349</width>
+                         <height>150</height>
                         </rect>
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_8">
@@ -2593,8 +2593,8 @@ Double dipping:
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>1072</width>
-                  <height>457</height>
+                  <width>1420</width>
+                  <height>504</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4642,10 +4642,10 @@ Current pair:
                <widget class="QWidget" name="scrollAreaWidgetContents_5">
                 <property name="geometry">
                  <rect>
-                  <x>0</x>
+                  <x>-261</x>
                   <y>0</y>
-                  <width>722</width>
-                  <height>308</height>
+                  <width>952</width>
+                  <height>286</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_16">
@@ -4875,6 +4875,9 @@ Current pair:
                           <verstretch>0</verstretch>
                          </sizepolicy>
                         </property>
+                        <property name="editable">
+                         <bool>true</bool>
+                        </property>
                         <item>
                          <property name="text">
                           <string>Behavior</string>
@@ -4936,7 +4939,7 @@ Current pair:
      <x>0</x>
      <y>0</y>
      <width>960</width>
-     <height>21</height>
+     <height>31</height>
     </rect>
    </property>
    <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -79,7 +79,7 @@
            <x>0</x>
            <y>0</y>
            <width>894</width>
-           <height>226</height>
+           <height>236</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_17">
@@ -906,7 +906,7 @@
                   <x>0</x>
                   <y>0</y>
                   <width>627</width>
-                  <height>303</height>
+                  <height>325</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout">
@@ -1963,8 +1963,8 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>624</width>
-                  <height>326</height>
+                  <width>627</width>
+                  <height>325</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -2521,8 +2521,8 @@ Bias:</string>
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>349</width>
-                         <height>150</height>
+                         <width>340</width>
+                         <height>195</height>
                         </rect>
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_8">
@@ -2593,8 +2593,8 @@ Double dipping:
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>1420</width>
-                  <height>504</height>
+                  <width>1072</width>
+                  <height>457</height>
                  </rect>
                 </property>
                 <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4642,10 +4642,10 @@ Current pair:
                <widget class="QWidget" name="scrollAreaWidgetContents_5">
                 <property name="geometry">
                  <rect>
-                  <x>-261</x>
+                  <x>-95</x>
                   <y>0</y>
-                  <width>952</width>
-                  <height>286</height>
+                  <width>722</width>
+                  <height>308</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_16">
@@ -4876,7 +4876,7 @@ Current pair:
                          </sizepolicy>
                         </property>
                         <property name="editable">
-                         <bool>true</bool>
+                         <bool>false</bool>
                         </property>
                         <item>
                          <property name="text">
@@ -4939,7 +4939,7 @@ Current pair:
      <x>0</x>
      <y>0</y>
      <width>960</width>
-     <height>31</height>
+     <height>21</height>
     </rect>
    </property>
    <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -595,7 +595,7 @@
                     <property name="geometry">
                      <rect>
                       <x>0</x>
-                      <y>-38</y>
+                      <y>0</y>
                       <width>178</width>
                       <height>211</height>
                      </rect>
@@ -888,7 +888,7 @@
             <string notr="true"/>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>3</number>
            </property>
            <widget class="QWidget" name="tab_2">
             <attribute name="title">
@@ -4644,8 +4644,8 @@ Current pair:
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>627</width>
-                  <height>325</height>
+                  <width>722</width>
+                  <height>308</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_16">
@@ -4698,57 +4698,6 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="1" column="1" colspan="2">
-                       <widget class="QComboBox" name="PhotometryB">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>50</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>10000</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <item>
-                         <property name="text">
-                          <string>off</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>on</string>
-                         </property>
-                        </item>
-                       </widget>
-                      </item>
-                      <item row="1" column="0">
-                       <widget class="QLabel" name="label_61">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>photometry =</string>
-                        </property>
-                        <property name="textFormat">
-                         <enum>Qt::AutoText</enum>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                        </property>
-                       </widget>
-                      </item>
                       <item row="0" column="0">
                        <widget class="QLabel" name="label_55">
                         <property name="sizePolicy">
@@ -4787,6 +4736,25 @@ Current pair:
                         </property>
                        </widget>
                       </item>
+                      <item row="1" column="0">
+                       <widget class="QLabel" name="label_61">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>photometry =</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
                       <item row="1" column="4">
                        <widget class="QLineEdit" name="baselinetime">
                         <property name="sizePolicy">
@@ -4804,6 +4772,38 @@ Current pair:
                         <property name="text">
                          <string>10</string>
                         </property>
+                       </widget>
+                      </item>
+                      <item row="1" column="1" colspan="2">
+                       <widget class="QComboBox" name="PhotometryB">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="minimumSize">
+                         <size>
+                          <width>50</width>
+                          <height>0</height>
+                         </size>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>10000</width>
+                          <height>16777215</height>
+                         </size>
+                        </property>
+                        <item>
+                         <property name="text">
+                          <string>off</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>on</string>
+                         </property>
+                        </item>
                        </widget>
                       </item>
                       <item row="0" column="1" colspan="2">
@@ -4834,6 +4834,65 @@ Current pair:
                         <item>
                          <property name="text">
                           <string>on</string>
+                         </property>
+                        </item>
+                       </widget>
+                      </item>
+                      <item row="2" column="1">
+                       <widget class="QPushButton" name="StartEphysRecording">
+                        <property name="text">
+                         <string>Start ephys recording</string>
+                        </property>
+                        <property name="checkable">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="3">
+                       <widget class="QLabel" name="label_65">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>recording type=</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="4">
+                       <widget class="QComboBox" name="OpenEphysRecordingType">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <item>
+                         <property name="text">
+                          <string>Behavior</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>Surface finding</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>Testing</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>NA</string>
                          </property>
                         </item>
                        </widget>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4890,6 +4890,11 @@ Current pair:
                         </item>
                         <item>
                          <property name="text">
+                          <string>Opto tagging</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
                           <string>Testing</string>
                          </property>
                         </item>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4449,6 +4449,11 @@
     </item>
     <item>
      <property name="text">
+      <string>Opto tagging</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
       <string>Testing</string>
      </property>
     </item>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4378,6 +4378,19 @@
      <string/>
     </property>
    </widget>
+   <widget class="QPushButton" name="StartEphysRecording">
+    <property name="geometry">
+     <rect>
+      <x>210</x>
+      <y>858</y>
+      <width>131</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Start ephys recording</string>
+    </property>
+   </widget>
    <zorder>PhotometryB</zorder>
    <zorder>infor</zorder>
    <zorder>line</zorder>
@@ -4410,6 +4423,7 @@
    <zorder>label_auto_train_stage</zorder>
    <zorder>pushButton_streamlit</zorder>
    <zorder>WarningLabel_uncoupled_task</zorder>
+   <zorder>StartEphysRecording</zorder>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4390,6 +4390,9 @@
     <property name="text">
      <string>Start ephys recording</string>
     </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
    </widget>
    <zorder>PhotometryB</zorder>
    <zorder>infor</zorder>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4381,7 +4381,7 @@
    <widget class="QPushButton" name="StartEphysRecording">
     <property name="geometry">
      <rect>
-      <x>210</x>
+      <x>260</x>
       <y>858</y>
       <width>131</width>
       <height>25</height>
@@ -4393,6 +4393,67 @@
     <property name="checkable">
      <bool>true</bool>
     </property>
+   </widget>
+   <widget class="QLabel" name="label_65">
+    <property name="geometry">
+     <rect>
+      <x>400</x>
+      <y>860</y>
+      <width>81</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>recording type=</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::AutoText</enum>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="OpenEphysRecordingType">
+    <property name="geometry">
+     <rect>
+      <x>490</x>
+      <y>860</y>
+      <width>131</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <item>
+     <property name="text">
+      <string>Behavior</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Surface finding</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Testing</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>NA</string>
+     </property>
+    </item>
    </widget>
    <zorder>PhotometryB</zorder>
    <zorder>infor</zorder>
@@ -4427,6 +4488,8 @@
    <zorder>pushButton_streamlit</zorder>
    <zorder>WarningLabel_uncoupled_task</zorder>
    <zorder>StartEphysRecording</zorder>
+   <zorder>label_65</zorder>
+   <zorder>OpenEphysRecordingType</zorder>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4324,9 +4324,9 @@
    <widget class="QLabel" name="label_auto_train_stage">
     <property name="geometry">
      <rect>
-      <x>780</x>
+      <x>830</x>
       <y>830</y>
-      <width>421</width>
+      <width>371</width>
       <height>81</height>
      </rect>
     </property>
@@ -4434,6 +4434,9 @@
       <verstretch>0</verstretch>
      </sizepolicy>
     </property>
+    <property name="editable">
+     <bool>true</bool>
+    </property>
     <item>
      <property name="text">
       <string>Behavior</string>
@@ -4497,7 +4500,7 @@
      <x>0</x>
      <y>0</y>
      <width>1875</width>
-     <height>21</height>
+     <height>31</height>
     </rect>
    </property>
    <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4435,7 +4435,7 @@
      </sizepolicy>
     </property>
     <property name="editable">
-     <bool>true</bool>
+     <bool>false</bool>
     </property>
     <item>
      <property name="text">
@@ -4500,7 +4500,7 @@
      <x>0</x>
      <y>0</y>
      <width>1875</width>
-     <height>31</height>
+     <height>21</height>
     </rect>
    </property>
    <property name="sizePolicy">

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -6,6 +6,7 @@ import sys
 from sys import platform as PLATFORM
 from datetime import datetime
 import logging
+import requests
 
 import numpy as np
 from itertools import accumulate
@@ -1934,4 +1935,59 @@ class TimerWorker(QtCore.QObject):
     def _stop(self):
         # Will halt the timer at the next interval
         self._isRunning=False
+
+
+class EphysRecording:
+
+    def __init__(self,
+                 open_ephys_machine_ip_address,
+                 mouse_id):
+
+        """
+        Runs an experiment with Open Ephys GUI,
+
+        Parameters
+        ----------
+
+        open_ephys_machine_ip_address : str
+            IP address of the machine running Open Ephys GUI
+        mouse_id : str
+            ID of the mouse for this experiment
+
+        Returns
+        -------
+        None.
+
+        """
+
+        self.api_endpoint = "http://" + self.open_ephys_machine_ip_address + ":37497/api/"
+        self.mouse_id = mouse_id
+
+    def start_open_ephys_recording(self):
+
+    	"""
+    	Changes the directory prepend text and starts recording
+
+    	"""
+
+    	r = requests.put(
+		    self.api_endpoint + "recording",
+		    json={"prepend_text" : self.mouse_id})
+        
+    	r = requests.put(
+    		self.api_endpoint + "status",
+    		json={"mode" : "RECORD"}
+    		)
+
+    def stop_open_ephys_recording(self):
+
+    	"""
+    	Stops recording
+
+    	"""
+
+    	r = requests.put(
+    		self.api_endpoint + "status",
+    		json={"mode" : "ACQUIRE"}
+    		)
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1986,6 +1986,7 @@ class EphysRecording:
     		    json={"mode" : "RECORD"}
     		    )
         return r1.json(), r2.json()
+    
     def stop_open_ephys_recording(self):
         '''
         Stops recording in Open Ephys GUI
@@ -1996,5 +1997,14 @@ class EphysRecording:
     		self.api_endpoint + "status",
     		json={"mode" : "ACQUIRE"}
     		)
+
+        return r.json()
+    
+    def get_open_ephys_recording_configuration(self):
+        '''
+        Get the recording configuration from Open Ephys GUI
+        
+        '''
+        r = requests.get(self.api_endpoint+"recording")
 
         return r.json()

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1970,11 +1970,11 @@ class EphysRecording:
 
     	"""
 
-    	r = requests.put(
+        requests.put(
 		    self.api_endpoint + "recording",
 		    json={"prepend_text" : self.mouse_id})
         
-    	r = requests.put(
+        r = requests.put(
     		self.api_endpoint + "status",
     		json={"mode" : "RECORD"}
     		)
@@ -1986,7 +1986,7 @@ class EphysRecording:
 
     	"""
 
-    	r = requests.put(
+        r = requests.put(
     		self.api_endpoint + "status",
     		json={"mode" : "ACQUIRE"}
     		)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1959,7 +1959,7 @@ class EphysRecording:
         None.
 
         """
-
+        self.open_ephys_machine_ip_address = open_ephys_machine_ip_address
         self.api_endpoint = "http://" + self.open_ephys_machine_ip_address + ":37497/api/"
         self.mouse_id = mouse_id
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1970,7 +1970,7 @@ class EphysRecording:
         '''
         r = requests.put(
 		        self.api_endpoint + "recording",
-		        json={"prepend_text" : self.mouse_id})
+		        json={"prepend_text" : self.mouse_id+ "_"})
         
         r = requests.put(
     		    self.api_endpoint + "status",

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1964,27 +1964,24 @@ class EphysRecording:
         self.mouse_id = mouse_id
 
     def start_open_ephys_recording(self):
-
-    	"""
-    	Changes the directory prepend text and starts recording
-
-    	"""
-
-        requests.put(
-		    self.api_endpoint + "recording",
-		    json={"prepend_text" : self.mouse_id})
+        '''
+        Starts recording in Open Ephys GUI
+        
+        '''
+        r = requests.put(
+		        self.api_endpoint + "recording",
+		        json={"prepend_text" : self.mouse_id})
         
         r = requests.put(
-    		self.api_endpoint + "status",
-    		json={"mode" : "RECORD"}
-    		)
+    		    self.api_endpoint + "status",
+    		    json={"mode" : "RECORD"}
+    		    )
 
     def stop_open_ephys_recording(self):
-
-    	"""
-    	Stops recording
-
-    	"""
+        '''
+        Stops recording in Open Ephys GUI
+        
+        '''
 
         r = requests.put(
     		self.api_endpoint + "status",

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1963,6 +1963,15 @@ class EphysRecording:
         self.api_endpoint = "http://" + self.open_ephys_machine_ip_address + ":37497/api/"
         self.mouse_id = mouse_id
 
+    def get_status(self):
+        '''
+        Get the status of the Open Ephys GUI
+
+        '''
+        r = requests.get(self.api_endpoint+"status")
+        
+        return r.json()
+    
     def start_open_ephys_recording(self):
         '''
         Starts recording in Open Ephys GUI

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1969,7 +1969,7 @@ class EphysRecording:
 
         '''
         r = requests.get(self.api_endpoint+"status")
-        
+
         return r.json()
     
     def start_open_ephys_recording(self):
@@ -1977,15 +1977,15 @@ class EphysRecording:
         Starts recording in Open Ephys GUI
         
         '''
-        r = requests.put(
+        r1 = requests.put(
 		        self.api_endpoint + "recording",
 		        json={"prepend_text" : self.mouse_id+ "_"})
         
-        r = requests.put(
+        r2 = requests.put(
     		    self.api_endpoint + "status",
     		    json={"mode" : "RECORD"}
     		    )
-
+        return r1.json(), r2.json()
     def stop_open_ephys_recording(self):
         '''
         Stops recording in Open Ephys GUI
@@ -1997,3 +1997,4 @@ class EphysRecording:
     		json={"mode" : "ACQUIRE"}
     		)
 
+        return r.json()

--- a/src/setting_templates/ForagingSettings.json
+++ b/src/setting_templates/ForagingSettings.json
@@ -13,5 +13,6 @@
     "newscale_serial_num_box2":"",
     "newscale_serial_num_box3":"",
     "newscale_serial_num_box4":"",
-    "default_ui":"ForagingGUI.ui"
+    "default_ui":"ForagingGUI.ui",
+    "open_ephys_machine_ip_address":""
 }


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Starting/Stopping the Open Ephys GUI from the behavior GUI. Adding `Start ephys recording` button and `recording type` combo box (types including behavior, surface finding, opto tagging, testing and NA). 
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/ad4acb4b-c1d7-4793-8a12-154e2d84728b)
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/46de1a34-6f55-49ce-99a8-764b2694def2)

2. Sending folder structure to the Open Ephys, and saving the folder structure to the behavior json. 

The logic is:
- When the `Start ephys recording` button is checked:
  - If the ip address is not provided.
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/9914183e-5578-44cd-8e04-88dce38978b9)
  - If the behavior has started,
  ![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/d0fd3c00-eb5e-45d6-9369-13d867d824b4)
  - If the open ephys software is not open or the ip address is not correct, a warning will pop up
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/acddb074-bafc-4807-a4d7-38d7eed1e803)
  - If the ephys recording has started, a warning will pop up
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/2f9d9cae-bdf7-41f1-bd96-e7a388434366)
  - If the ephys recording starts normally, a warning will also pop up
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/f5349ce2-1dc3-44e4-b689-9df2fa9f59db)

- When the `Start ephys recording` button is unchecked:
  - If the open ephys recording has stopped, a warning will pop up
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/ac61f9e9-9d86-4dcf-b11e-83ffde22b905)
   - If the behavior has not stopped yet
   ![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/7f0f06c6-8c8f-481c-b207-d55154008193)

   - If the open ephys recording stops normally. a warning will pop up to ask user save open ephys related data again.
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/e54f61ca-ea09-4ead-8de6-b47c0add0ab0)

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/401

### Describe the expected change in behavior from the perspective of the experimenter
1. We can use the behavioral GUI to control the Open Ephys GUI, the folder structure and some experiment information from open ephys (such as record and experiment numbers) will be saved in the behavioral json.
![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/109394934/08c66670-4cac-4c95-bf6a-6bb387d9d120)

3. Make sure to set the `open_ephys_machine_ip_address` in the  `ForagingSettings.json` to use this function. 

### Describe the outcome of testing this update on a rig in 447
Tested in 323_EPHYS3




