### PR TITLE
Accurate parsing of python version

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3704,10 +3704,14 @@ def log_git_hash():
 
     # Get information about python
     py_version = sys.version
+    # DEBUGGGGING CODE
+    py_version = '3.11.8 |Anaconda, Inc.|'
+    # DEBUGGING CODE
+    py_version_parsed = '.'.join(py_version.split('.')[0:2])
     logging.info('Python version: {}'.format(py_version))
     print('Python version: {}'.format(py_version))       
-    if py_version[0:3] != '3.9':
-        logging.error('Incorrect version of python! Should be 3.9, got {}'.format(py_version[0:3]))
+    if py_version_parsed != '3.9':
+        logging.error('Incorrect version of python! Should be 3.9, got {}'.format(py_version_parsed))
 
     try:
         # Get information about task repository

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3704,14 +3704,11 @@ def log_git_hash():
 
     # Get information about python
     py_version = sys.version
-    # DEBUGGGGING CODE
-    py_version = '3.11.8 |Anaconda, Inc.|'
-    # DEBUGGING CODE
-    py_version_parsed = '.'.join(py_version.split('.')[0:2])
+    py_version_parse = '.'.join(py_version.split('.')[0:2])
     logging.info('Python version: {}'.format(py_version))
     print('Python version: {}'.format(py_version))       
-    if py_version_parsed != '3.9':
-        logging.error('Incorrect version of python! Should be 3.9, got {}'.format(py_version_parsed))
+    if py_version_parse != '3.9':
+        logging.error('Incorrect version of python! Should be 3.9, got {}'.format(py_version_parse))
 
     try:
         # Get information about task repository


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Accurately parses `3.11` as `3.11` instead of `3.1` for error tracking

### What issues or discussions does this update address?
- Resolves #410 

### Describe the expected change in behavior from the perspective of the experimenter
- None

### Describe any manual update steps for task computers
- None

### Was this update tested in 446/447?
- [ ] tested in 447




