### PR TITLE
update python version to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "dynamic-foraging-task"
 description = "Dynamic Foraging Task used at the Allen Institute for Neural Dynamics"
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3707,8 +3707,8 @@ def log_git_hash():
     py_version_parse = '.'.join(py_version.split('.')[0:2])
     logging.info('Python version: {}'.format(py_version))
     print('Python version: {}'.format(py_version))       
-    if py_version_parse != '3.9':
-        logging.error('Incorrect version of python! Should be 3.9, got {}'.format(py_version_parse))
+    if py_version_parse != '3.11':
+        logging.error('Incorrect version of python! Should be 3.11, got {}'.format(py_version_parse))
 
     try:
         # Get information about task repository


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Updates the required python version to >=3.11

### What issues or discussions does this update address?
- We had inconsistent python versions across computers running the task
- New curriculum manager will require 3.11

### Describe the expected change in behavior from the perspective of the experimenter
- None

### Describe any manual update steps for task computers
- Each computer must be updated to use python 3.11
- Updates can be done early, before this PR is merged. Old code is compatible with 3.11
- [ ] 447 computers @alexpiet (1CD, 2CD updated, will update the rest after tuesday meeting)
- [ ] Ephys1 @KanghoonJ 
- [x] Ephys3 @XX-Yin 
- [ ] 428 @hagikent 

### Was this update tested in 446/447?
- [x] tested in 447





