### PR TITLE
Start FIP workflow from GUI

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -105,6 +105,7 @@ class Window(QMainWindow):
         self.threadpool_workertimer=QThreadPool() # for timing
 
         # Set up more parameters
+        self.FIP_started=False
         self.OpenOptogenetics=0
         self.WaterCalibration=0
         self.LaserCalibration=0
@@ -2723,6 +2724,32 @@ class Window(QMainWindow):
                 if child.isEnabled():
                     child.clear()
     def _StartFIP(self):
+
+
+
+        if self.Teensy_COM == '':
+            logging.warning('No Teensy COM configured for this box, cannot start FIP workflow')
+            self.TeensyWarning.setText('No Teensy COM for this box')
+            self.TeensyWarning.setStyleSheet(self.default_warning_color)
+            msg = 'No Teensy COM configured for this box, cannot start FIP workflow'
+            reply = QMessageBox.information(self, 
+                'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
+            self.StartFIP.setChecked(False)
+            self.StartFIP.setStyleSheet("background-color : none")
+            return
+        
+        if self.FIP_started:
+            logging.warning('FIP workflow already started, cannot restart')
+            reply = QMessageBox.information(self, 
+                'Box {}, Start FIP workflow:'.format(self.box_letter), 
+                'FIP workflow has already been started. If its not visible, please restart the GUI',
+                QMessageBox.Ok )                     
+            return
+
+        self.FIP_started=True 
+        logging.info('StartFIP is checked')
+        self.StartFIP.setStyleSheet("background-color : green;")
+
         reply = QMessageBox.information(self, 
            'Box {}, Start FIP workflow:'.format(self.box_letter), 
            'Starting FIP workflow now.',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2734,11 +2734,22 @@ class Window(QMainWindow):
             self.TeensyWarning.setStyleSheet(self.default_warning_color)
             msg = 'No Teensy COM configured for this box, cannot start FIP workflow'
             reply = QMessageBox.information(self, 
-                'Box {}, StartExcitation'.format(self.box_letter), msg, QMessageBox.Ok )
+                'Box {}, StartFIP'.format(self.box_letter), msg, QMessageBox.Ok )
             self.StartFIP.setChecked(False)
             self.StartFIP.setStyleSheet("background-color : none")
             return
         
+        if self.FIP_workflow_path == "":
+            logging.warning('No FIP workflow path defined in ForagingSettings.json')
+            self.TeensyWarning.setText('FIP workflow path not defined')
+            self.TeensyWarning.setStyleSheet(self.default_warning_color)
+            msg = 'FIP workflow path not defined, cannot start FIP workflow'
+            reply = QMessageBox.information(self, 
+                'Box {}, StartFIP'.format(self.box_letter), msg, QMessageBox.Ok )
+            self.StartFIP.setChecked(False)
+            self.StartFIP.setStyleSheet("background-color : none")                  
+            return
+ 
         if self.FIP_started:
             self.StartFIP.setChecked(True)             
             reply = QMessageBox.question(self, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3189,6 +3189,15 @@ class Window(QMainWindow):
             elif self.repo_dirty_flag is None:
                 logging.error('Could not check for untracked local changes')
 
+            if self.PhotometryB.currentText()=='on' and (not self.FIP_started): 
+                reply = QMessageBox.critical(self,
+                    'Box {}, Start'.format(self.box_letter),
+                    'Photometry is set to "on", but the FIP workflow has not been started',
+                    QMessageBox.Ok)
+                self.Start.setChecked(False)
+                logging.info('Cannot start session without starting FIP workflow')
+                return
+
             # change button color and mark the state change
             self.Start.setStyleSheet("background-color : green;")
             self.NewSession.setStyleSheet("background-color : none")
@@ -3327,7 +3336,6 @@ class Window(QMainWindow):
         if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
            
-            ## DEBUGGING, need something here 
             if self.Teensy_COM == '':
                 logging.warning('No Teensy COM configured for this box, cannot start excitation')
                 msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2948,6 +2948,7 @@ class Window(QMainWindow):
         if self.Teensy_COM == '':
             return
         logging.info('Checking that photometry is not running')
+        FIP_was_running=self.StartFIP.isChecked()
         try:
             ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
             # Trigger Teensy with the above specified exp mode
@@ -2968,7 +2969,13 @@ class Window(QMainWindow):
             self.StartExcitation.setChecked(False)
             self.StartFIP.setChecked(False)
             self.FIP_started=False
-           
+        
+        if FIP_was_running:
+            reply = QMessageBox.critical(self, 
+                'Box {}, New Session:'.format(self.box_letter), 
+                'Please restart the FIP workflow',
+                QMessageBox.Ok)
+
     def _AutoReward(self):
         if self.AutoReward.isChecked():
             self.AutoReward.setStyleSheet("background-color : green;")

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2776,7 +2776,7 @@ class Window(QMainWindow):
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
 
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path,cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p String={}'.format(self.PhotometryFolder),cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2148,7 +2148,7 @@ class Window(QMainWindow):
                 end_time = self.fiber_photometry_end_time
             else:
                 end_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") 
-            Obj['fiber_photometry_end_time'] = self.fiber_photometry_end_time
+            Obj['fiber_photometry_end_time'] = end_time
 
         # Save the current box
         Obj['box'] = self.current_box

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2769,6 +2769,10 @@ class Window(QMainWindow):
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
             folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
             camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
+            print(self.bonsai_path)
+            print(self.FIP_workflow_path)
+            print(folder_path)
+            print(camera)
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2774,7 +2774,7 @@ class Window(QMainWindow):
         try:
             CWD=os.path.dirname(self.FIP_workflow_path)
             logging.info('Starting FIP workflow in directory: {}'.format(CWD))
-            folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
+            folder_path = ' -p session="{}"'.format(self.SessionFolder)
             camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             # We will want to start the workflow, and not open the editor
             # DEBUGGING - Need to test on a computer where I can start the workflow

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3055,9 +3055,11 @@ class Window(QMainWindow):
         self.CreateNewFolder=1
         self.PhotometryRun=0
         self.unsaved_data=False
-        self.ManualWaterVolume=[0,0]      
-        del self.fiber_photometry_start_time
-        del self.fiber_photometry_end_time 
+        self.ManualWaterVolume=[0,0]     
+        if hasattr(self, 'fiber_photometry_start_time'): 
+            del self.fiber_photometry_start_time
+        if hasattr(self, 'fiber_photometry_end_time'): 
+            del self.fiber_photometry_end_time 
     
         # Clear Plots
         if hasattr(self, 'PlotM'): 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2775,8 +2775,10 @@ class Window(QMainWindow):
 
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
-
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p Value="{}"'.format(self.PhotometryFolder),cwd=CWD,shell=True)
+            folder_path = ' -p session_folder="{}"'.format(self.PhotometryFolder)
+            self.camera_running=False ## DEBUGGING
+            camera = ' -p RunCamera="{}"'.format(not self.camera_running)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2768,7 +2768,16 @@ class Window(QMainWindow):
             return
 
         if self.StartExcitation.isChecked():
-            logging.info('StartExcitation is checked')
+            reply = QMessageBox.question(self, 
+                'Box {}, Start FIP'.format(self.box_letter), 
+                'Is the FIP workflow running?', 
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes )
+            if reply == QMessageBox.No:
+                self.StartExcitation.setChecked(False)
+                self.StartExcitation.setStyleSheet("background-color : none")
+                logging.info('User says FIP workflow is not open')
+                return
+            logging.info('StartExcitation is checked, user confirms workflow is running')
             self.StartExcitation.setStyleSheet("background-color : green;")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2963,9 +2963,13 @@ class Window(QMainWindow):
             self.TeensyWarning.setStyleSheet(self.default_warning_color)      
             self.StartBleaching.setStyleSheet("background-color : none")
             self.StartExcitation.setStyleSheet("background-color : none")
+            self.StartFIP.setStyleSheet("background-color : green;")
             self.StartBleaching.setChecked(False)
             self.StartExcitation.setChecked(False)
+            self.StartFIP.setChecked(False)
             self.FIP_started=False
+
+
            
     def _AutoReward(self):
         if self.AutoReward.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2776,7 +2776,7 @@ class Window(QMainWindow):
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
             folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
-            self.camera_running=False ## DEBUGGING
+            self.camera_running=True ## DEBUGGING
             camera = ' -p RunCamera="{}"'.format(not self.camera_running)
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2764,20 +2764,11 @@ class Window(QMainWindow):
             CWD=os.path.dirname(self.FIP_workflow_path)
             logging.info('Starting FIP workflow in directory: {}'.format(CWD))
         
-            # Notes on passing in parameters
-            # can use "-p <propertyName>=<string>" 
-            # or "-p <NestedNodeName.propertyName>=<string>"
-            # example: ' -p intProperty=100 -p NestedNode.FlipMode="Horizontal"'
-            
-            # We want to pass in the folder for the session
-            # We want to pass in whether the FIP workflow needs to handle video, or not
-            # Are there any other settings, or parameters want to merge in?
-
             # We will want to start the workflow, and not open the editor
+            # DEBUGGING - Need to test on a computer where I can start the workflow
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
             folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
-            self.camera_running=True ## DEBUGGING
-            camera = ' -p RunCamera="{}"'.format(not self.camera_running)
+            camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3304,7 +3304,7 @@ class Window(QMainWindow):
             # start a new logging
             try:
                 # Do not start a new session if the camera is already open, this means the session log has been started or the existing session has not been completed.
-                if (not (self.Camera_dialog.StartCamera.isChecked() and self.Camera_dialog.CollectVideo.currentText()=='Yes' and self.Camera_dialog.AutoControl.currentText()=='No')) or (not self.FIP_started):
+                if (not (self.Camera_dialog.StartCamera.isChecked() and self.Camera_dialog.CollectVideo.currentText()=='Yes' and self.Camera_dialog.AutoControl.currentText()=='No')) and (not self.FIP_started):
                     self.CreateNewFolder=1
                     self.Ot_log_folder=self._restartlogging()
             except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2776,7 +2776,7 @@ class Window(QMainWindow):
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
 
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p String.Value="{}"'.format(self.PhotometryFolder),cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p Value="{}"'.format(self.PhotometryFolder),cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2779,11 +2779,8 @@ class Window(QMainWindow):
             # DEBUGGING - Need to test on a computer where I can start the workflow
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
             folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
-            camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
-            print(self.bonsai_path)
-            print(self.FIP_workflow_path)
-            print(folder_path)
-            print(camera)
+            camera = ' -p RunCamera="False"')
+            #camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2745,7 +2745,7 @@ class Window(QMainWindow):
                 'Box {}, Start FIP workflow:'.format(self.box_letter), 
                 'FIP workflow has already been started. Start again?',
                 QMessageBox.Yes | QMessageBox.No, QMessageBox.No )       
-            if QMessageBox.No:
+            if reply == QMessageBox.No:
                 self.StartFIP.setChecked(True)             
                 logging.warning('FIP workflow already started, user declines to restart')
                 return

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1863,7 +1863,7 @@ class Window(QMainWindow):
             self.client3.close()
             self.client4.close()
         self.Opto_dialog.close()
-        self._StopPhotometry()  # Make sure photo excitation is stopped 
+        self._StopPhotometry(closing=True)  # Make sure photo excitation is stopped 
         print('GUI Window closed')
         logging.info('GUI Window closed') 
 
@@ -2775,7 +2775,7 @@ class Window(QMainWindow):
 
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
-            folder_path = ' -p session_folder="{}"'.format(self.PhotometryFolder)
+            folder_path = ' -p Value="{}"'.format(self.PhotometryFolder)
             self.camera_running=False ## DEBUGGING
             camera = ' -p RunCamera="{}"'.format(not self.camera_running)
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
@@ -2943,7 +2943,7 @@ class Window(QMainWindow):
                 self.TeensyWarning.setText('Error: stop bleaching!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
     
-    def _StopPhotometry(self):
+    def _StopPhotometry(self,closing=False):
         '''
             Stop either bleaching or photometry
         '''
@@ -2972,7 +2972,7 @@ class Window(QMainWindow):
             self.StartFIP.setChecked(False)
             self.FIP_started=False
         
-        if FIP_was_running:
+        if (FIP_was_running)&(not closing):
             reply = QMessageBox.critical(self, 
                 'Box {}, New Session:'.format(self.box_letter), 
                 'Please restart the FIP workflow',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2774,14 +2774,13 @@ class Window(QMainWindow):
         try:
             CWD=os.path.dirname(self.FIP_workflow_path)
             logging.info('Starting FIP workflow in directory: {}'.format(CWD))
-        
+            folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
+            camera = ' -p RunCamera="False"'       
+            #camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             # We will want to start the workflow, and not open the editor
             # DEBUGGING - Need to test on a computer where I can start the workflow
-            #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
-            folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
-            camera = ' -p RunCamera="False"'
-            #camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
+            #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2723,9 +2723,8 @@ class Window(QMainWindow):
             for child in self.TrainingParameters.findChildren(QtWidgets.QLineEdit)+ self.centralwidget.findChildren(QtWidgets.QLineEdit):
                 if child.isEnabled():
                     child.clear()
+
     def _StartFIP(self):
-
-
 
         if self.Teensy_COM == '':
             logging.warning('No Teensy COM configured for this box, cannot start FIP workflow')
@@ -2743,7 +2742,8 @@ class Window(QMainWindow):
             reply = QMessageBox.information(self, 
                 'Box {}, Start FIP workflow:'.format(self.box_letter), 
                 'FIP workflow has already been started. If its not visible, please restart the GUI',
-                QMessageBox.Ok )                     
+                QMessageBox.Ok )       
+            self.StartFIP.setChecked(False)             
             return
 
         self.FIP_started=True 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2141,6 +2141,14 @@ class Window(QMainWindow):
         for attr_name in dir(self):
             if attr_name.startswith('Ot_'):
                 Obj[attr_name]=getattr(self, attr_name)
+        
+        if hasattr(self, 'fiber_photometry_start_time'):
+            Obj['fiber_photometry_start_time'] = self.fiber_photometry_start_time
+            if hasattr(self, 'fiber_photometry_end_time'):
+                end_time = self.fiber_photometry_end_time
+            else:
+                end_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") 
+            Obj['fiber_photometry_end_time'] = self.fiber_photometry_end_time
 
         # Save the current box
         Obj['box'] = self.current_box
@@ -2770,6 +2778,7 @@ class Window(QMainWindow):
         self.CreateNewFolder=1
         self.Ot_log_folder=self._restartlogging()
 
+
         # Start the FIP workflow
         try:
             CWD=os.path.dirname(self.FIP_workflow_path)
@@ -2837,6 +2846,7 @@ class Window(QMainWindow):
             else:
                 self.TeensyWarning.setText('')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)               
+                self.fiber_photometry_start_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
         else:
             logging.info('StartExcitation is unchecked')
@@ -2856,7 +2866,8 @@ class Window(QMainWindow):
                 return 0 
             else:
                 self.TeensyWarning.setText('')
-                self.TeensyWarning.setStyleSheet(self.default_warning_color)               
+                self.TeensyWarning.setStyleSheet(self.default_warning_color)              
+                self.fiber_photometry_end_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
         return 1
     
@@ -2968,7 +2979,7 @@ class Window(QMainWindow):
             self.StartExcitation.setChecked(False)
             self.StartFIP.setChecked(False)
             self.FIP_started=False
-        
+
         if (FIP_was_running)&(not closing):
             reply = QMessageBox.critical(self, 
                 'Box {}, New Session:'.format(self.box_letter), 
@@ -3044,7 +3055,9 @@ class Window(QMainWindow):
         self.CreateNewFolder=1
         self.PhotometryRun=0
         self.unsaved_data=False
-        self.ManualWaterVolume=[0,0]       
+        self.ManualWaterVolume=[0,0]      
+        del self.fiber_photometry_start_time
+        del self.fiber_photometry_end_time 
     
         # Clear Plots
         if hasattr(self, 'PlotM'): 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2740,13 +2740,17 @@ class Window(QMainWindow):
             return
         
         if self.FIP_started:
-            logging.warning('FIP workflow already started, cannot restart')
-            reply = QMessageBox.information(self, 
+
+            reply = QMessageBox.question(self, 
                 'Box {}, Start FIP workflow:'.format(self.box_letter), 
-                'FIP workflow has already been started. If its not visible, please restart the GUI',
-                QMessageBox.Ok )       
-            self.StartFIP.setChecked(True)             
-            return
+                'FIP workflow has already been started. Start again?',
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No )       
+            if QMessageBox.No:
+                self.StartFIP.setChecked(True)             
+                logging.warning('FIP workflow already started, user declines to restart')
+                return
+            else:
+                logging.warning('FIP workflow already started, user restarts')
 
         self.FIP_started=True 
         logging.info('StartFIP is checked')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3214,6 +3214,10 @@ class Window(QMainWindow):
                     logging.info('User selected to start excitation')
                     started = self._StartExcitation()
                     if started == 0:
+                        reply = QMessageBox.critical(self,
+                            'Box {}, Start'.format(self.box_letter),
+                            'Could not start excitation, therefore cannot start the session',
+                            QMessageBox.Ok)
                         logging.info('could not start session, due to failure to start excitation')
                         self.Start.setChecked(False)
                         return 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2756,6 +2756,15 @@ class Window(QMainWindow):
            QMessageBox.Ok )               
 
     def _StartExcitation(self):
+
+        if not self.FIP_started:
+            logging.warning('FIP workflow is not running, cannot start excitation')
+            reply = QMessageBox.information(self, 
+                'Box {}, Start Excitation:'.format(self.box_letter), 
+                'Please start the FIP workflow before running excitation',
+                QMessageBox.Ok )                     
+            return      
+ 
         if self.Teensy_COM == '':
             logging.warning('No Teensy COM configured for this box, cannot start excitation')
             self.TeensyWarning.setText('No Teensy COM for this box')
@@ -3315,7 +3324,8 @@ class Window(QMainWindow):
         # Check if photometry excitation is running or not
         if self.Start.isChecked() and self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
             logging.warning('photometry is set to "on", but excitation is not running')
-            
+           
+            ## DEBUGGING, need something here 
             if self.Teensy_COM == '':
                 logging.warning('No Teensy COM configured for this box, cannot start excitation')
                 msg = 'Photometry is set to "on", but no Teensy COM configured for this box, cannot start excitation.'

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2775,7 +2775,7 @@ class Window(QMainWindow):
 
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
-            folder_path = ' -p Value="{}"'.format(self.PhotometryFolder)
+            folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
             self.camera_running=False ## DEBUGGING
             camera = ' -p RunCamera="{}"'.format(not self.camera_running)
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2754,7 +2754,8 @@ class Window(QMainWindow):
 
         try:
             CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
+            #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -start --no-editor',cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path,cwd=CWD,shell=True)
         except Exception as e:
             print(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -976,6 +976,7 @@ class Window(QMainWindow):
         self.current_box=self.Settings['current_box']
         self.temporary_video_folder=self.Settings['temporary_video_folder']
         self.Teensy_COM = self.Settings['Teensy_COM_box'+str(self.box_number)]
+        self.FIP_workflow_path = self.Settings['FIP_workflow_path']
         self.bonsai_path=self.Settings['bonsai_path']
         self.bonsaiworkflow_path=self.Settings['bonsaiworkflow_path']
         self.newscale_serial_num_box1=self.Settings['newscale_serial_num_box1']

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2776,17 +2776,13 @@ class Window(QMainWindow):
             logging.info('Starting FIP workflow in directory: {}'.format(CWD))
             folder_path = ' -p session="{}"'.format(self.SessionFolder)
             camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
-            # We will want to start the workflow, and not open the editor
-            # DEBUGGING - Need to test on a computer where I can start the workflow
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera+' --start',cwd=CWD,shell=True)
-            #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
-        
-        reply = QMessageBox.information(self, 
-           'Box {}, Start FIP workflow:'.format(self.box_letter), 
-           'Starting FIP workflow now.',
-           QMessageBox.Ok )               
+            reply = QMessageBox.information(self, 
+               'Box {}, Start FIP workflow:'.format(self.box_letter), 
+               'Could not start FIP workflow: {}'.format(e),
+               QMessageBox.Ok )               
 
     def _StartExcitation(self):
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2740,13 +2740,12 @@ class Window(QMainWindow):
             return
         
         if self.FIP_started:
-
+            self.StartFIP.setChecked(True)             
             reply = QMessageBox.question(self, 
                 'Box {}, Start FIP workflow:'.format(self.box_letter), 
                 'FIP workflow has already been started. Start again?',
                 QMessageBox.Yes | QMessageBox.No, QMessageBox.No )       
             if reply == QMessageBox.No:
-                self.StartFIP.setChecked(True)             
                 logging.warning('FIP workflow already started, user declines to restart')
                 return
             else:
@@ -2756,14 +2755,15 @@ class Window(QMainWindow):
         logging.info('StartFIP is checked')
         self.StartFIP.setStyleSheet("background-color : green;")
 
+        # Start the FIP workflow
         try:
-            CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
+            CWD=os.path.dirname(self.FIP_workflow_path)
+            print(CWD)
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -start --no-editor',cwd=CWD,shell=True)
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path,cwd=CWD,shell=True)
         except Exception as e:
-            print(e)
+            logging.error(e)
         
-
         reply = QMessageBox.information(self, 
            'Box {}, Start FIP workflow:'.format(self.box_letter), 
            'Starting FIP workflow now.',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -917,6 +917,7 @@ class Window(QMainWindow):
             'Teensy_COM_box2':'',
             'Teensy_COM_box3':'',
             'Teensy_COM_box4':'',
+            'FIP_workflow_path':'',
             'bonsai_path':os.path.join(os.path.dirname(os.path.dirname(os.getcwd())),'bonsai','Bonsai.exe'),
             'bonsaiworkflow_path':os.path.join(os.path.dirname(os.getcwd()),'workflows','foraging.bonsai'),
             'newscale_serial_num_box1':'',
@@ -2749,6 +2750,13 @@ class Window(QMainWindow):
         self.FIP_started=True 
         logging.info('StartFIP is checked')
         self.StartFIP.setStyleSheet("background-color : green;")
+
+        try:
+            CWD=os.path.join(os.path.dirname(os.getcwd()),'workflows')
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
+        except Exception as e:
+            print(e)
+        
 
         reply = QMessageBox.information(self, 
            'Box {}, Start FIP workflow:'.format(self.box_letter), 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2776,7 +2776,7 @@ class Window(QMainWindow):
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
 
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p String="{}"'.format(self.PhotometryFolder),cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p String.Value="{}"'.format(self.PhotometryFolder),cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2758,8 +2758,20 @@ class Window(QMainWindow):
         # Start the FIP workflow
         try:
             CWD=os.path.dirname(self.FIP_workflow_path)
-            print(CWD)
-            #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -start --no-editor',cwd=CWD,shell=True)
+            logging.info('Starting FIP workflow in directory: {}'.format(CWD))
+        
+            # Notes on passing in parameters
+            # can use "-p <propertyName>=<string>" 
+            # or "-p <NestedNodeName.propertyName>=<string>"
+            # example: ' -p intProperty=100 -p NestedNode.FlipMode="Horizontal"'
+            
+            # We want to pass in the folder for the session
+            # We want to pass in whether the FIP workflow needs to handle video, or not
+            # Are there any other settings, or parameters want to merge in?
+
+            # We will want to start the workflow, and not open the editor
+            #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
+
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2775,11 +2775,10 @@ class Window(QMainWindow):
             CWD=os.path.dirname(self.FIP_workflow_path)
             logging.info('Starting FIP workflow in directory: {}'.format(CWD))
             folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
-            camera = ' -p RunCamera="False"'       
-            #camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
+            camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             # We will want to start the workflow, and not open the editor
             # DEBUGGING - Need to test on a computer where I can start the workflow
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start',cwd=CWD,shell=True)
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -199,6 +199,7 @@ class Window(QMainWindow):
         self.GiveRight.clicked.connect(self._GiveRight)
         self.NewSession.clicked.connect(self._NewSession)
         self.AutoReward.clicked.connect(self._AutoReward)
+        self.StartFIP.clicked.connect(self._StartFIP)
         self.StartExcitation.clicked.connect(self._StartExcitation)
         self.StartBleaching.clicked.connect(self._StartBleaching)
         self.NextBlock.clicked.connect(self._NextBlock)
@@ -2721,6 +2722,11 @@ class Window(QMainWindow):
             for child in self.TrainingParameters.findChildren(QtWidgets.QLineEdit)+ self.centralwidget.findChildren(QtWidgets.QLineEdit):
                 if child.isEnabled():
                     child.clear()
+    def _StartFIP(self):
+        reply = QMessageBox.information(self, 
+           'Box {}, Start FIP workflow:'.format(self.box_letter), 
+           'Starting FIP workflow now.',
+           QMessageBox.Ok )               
 
     def _StartExcitation(self):
         if self.Teensy_COM == '':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2755,6 +2755,10 @@ class Window(QMainWindow):
         logging.info('StartFIP is checked')
         self.StartFIP.setStyleSheet("background-color : green;")
 
+        # Start logging
+        self.CreateNewFolder=1
+        self.Ot_log_folder=self._restartlogging()
+
         # Start the FIP workflow
         try:
             CWD=os.path.dirname(self.FIP_workflow_path)
@@ -3300,7 +3304,7 @@ class Window(QMainWindow):
             # start a new logging
             try:
                 # Do not start a new session if the camera is already open, this means the session log has been started or the existing session has not been completed.
-                if not (self.Camera_dialog.StartCamera.isChecked() and self.Camera_dialog.CollectVideo.currentText()=='Yes' and self.Camera_dialog.AutoControl.currentText()=='No'):
+                if (not (self.Camera_dialog.StartCamera.isChecked() and self.Camera_dialog.CollectVideo.currentText()=='Yes' and self.Camera_dialog.AutoControl.currentText()=='No')) or (not self.FIP_started):
                     self.CreateNewFolder=1
                     self.Ot_log_folder=self._restartlogging()
             except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2963,13 +2963,11 @@ class Window(QMainWindow):
             self.TeensyWarning.setStyleSheet(self.default_warning_color)      
             self.StartBleaching.setStyleSheet("background-color : none")
             self.StartExcitation.setStyleSheet("background-color : none")
-            self.StartFIP.setStyleSheet("background-color : green;")
+            self.StartFIP.setStyleSheet("background-color : none;")
             self.StartBleaching.setChecked(False)
             self.StartExcitation.setChecked(False)
             self.StartFIP.setChecked(False)
             self.FIP_started=False
-
-
            
     def _AutoReward(self):
         if self.AutoReward.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2779,7 +2779,7 @@ class Window(QMainWindow):
             # DEBUGGING - Need to test on a computer where I can start the workflow
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
             folder_path = ' -p session="{}"'.format(self.PhotometryFolder)
-            camera = ' -p RunCamera="False"')
+            camera = ' -p RunCamera="False"'
             #camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2743,7 +2743,7 @@ class Window(QMainWindow):
                 'Box {}, Start FIP workflow:'.format(self.box_letter), 
                 'FIP workflow has already been started. If its not visible, please restart the GUI',
                 QMessageBox.Ok )       
-            self.StartFIP.setChecked(False)             
+            self.StartFIP.setChecked(True)             
             return
 
         self.FIP_started=True 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2776,7 +2776,7 @@ class Window(QMainWindow):
             # We will want to start the workflow, and not open the editor
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start --no-editor',cwd=CWD,shell=True)
 
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p String={}'.format(self.PhotometryFolder),cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' -p String="{}"'.format(self.PhotometryFolder),cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2965,6 +2965,7 @@ class Window(QMainWindow):
             self.StartExcitation.setStyleSheet("background-color : none")
             self.StartBleaching.setChecked(False)
             self.StartExcitation.setChecked(False)
+            self.FIP_started=False
            
     def _AutoReward(self):
         if self.AutoReward.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2778,7 +2778,7 @@ class Window(QMainWindow):
             camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             # We will want to start the workflow, and not open the editor
             # DEBUGGING - Need to test on a computer where I can start the workflow
-            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+' --start',cwd=CWD,shell=True)
+            subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera+' --start',cwd=CWD,shell=True)
             #subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera,cwd=CWD,shell=True)
         except Exception as e:
             logging.error(e)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2763,6 +2763,8 @@ class Window(QMainWindow):
                 'Box {}, Start Excitation:'.format(self.box_letter), 
                 'Please start the FIP workflow before running excitation',
                 QMessageBox.Ok )                     
+            self.StartExcitation.setChecked(False)
+            self.StartExcitation.setStyleSheet("background-color : none")
             return      
  
         if self.Teensy_COM == '':

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4666,7 +4666,7 @@ Current pair:
                    <layout class="QHBoxLayout" name="horizontalLayout_15">
                     <item>
                      <layout class="QGridLayout" name="gridLayout_6">
-                      <item row="1" column="5">
+                      <item row="2" column="5">
                        <widget class="QPushButton" name="StartExcitation">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4682,7 +4682,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="1" column="6">
+                      <item row="2" column="6">
                        <widget class="QPushButton" name="StartBleaching">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4682,7 +4682,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="2">
+                      <item row="2" column="3">
                        <widget class="QPushButton" name="StartExcitation">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4698,7 +4698,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="3">
+                      <item row="2" column="4">
                        <widget class="QPushButton" name="StartBleaching">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4675,7 +4675,7 @@ Current pair:
                          </sizepolicy>
                         </property>
                         <property name="text">
-                         <string>Start FIP</string>
+                         <string>Start FIP workflow</string>
                         </property>
                         <property name="checkable">
                          <bool>true</bool>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4666,7 +4666,23 @@ Current pair:
                    <layout class="QHBoxLayout" name="horizontalLayout_15">
                     <item>
                      <layout class="QGridLayout" name="gridLayout_6">
-                      <item row="2" column="5">
+                      <item row="2" column="1">
+                       <widget class="QPushButton" name="StartFIP">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>Start FIP</string>
+                        </property>
+                        <property name="checkable">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="2" column="2">
                        <widget class="QPushButton" name="StartExcitation">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4682,7 +4698,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="6">
+                      <item row="2" column="3">
                        <widget class="QPushButton" name="StartBleaching">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4838,7 +4838,7 @@ Current pair:
                         </item>
                        </widget>
                       </item>
-                      <item row="2" column="1">
+                      <item row="3" column="1">
                        <widget class="QPushButton" name="StartEphysRecording">
                         <property name="text">
                          <string>Start ephys recording</string>
@@ -4848,7 +4848,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="3">
+                      <item row="3" column="3">
                        <widget class="QLabel" name="label_65">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4867,7 +4867,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="2" column="4">
+                      <item row="3" column="4">
                        <widget class="QComboBox" name="OpenEphysRecordingType">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3855,9 +3855,9 @@
     <property name="geometry">
      <rect>
       <x>380</x>
-      <y>901</y>
-      <width>91</width>
-      <height>21</height>
+      <y>900</y>
+      <width>100</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="sizePolicy">
@@ -3876,10 +3876,10 @@
    <widget class="QPushButton" name="StartExcitation">
     <property name="geometry">
      <rect>
-      <x>480</x>
-      <y>901</y>
-      <width>91</width>
-      <height>21</height>
+      <x>500</x>
+      <y>900</y>
+      <width>100</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="sizePolicy">
@@ -3898,10 +3898,10 @@
    <widget class="QPushButton" name="StartBleaching">
     <property name="geometry">
      <rect>
-      <x>590</x>
+      <x>620</x>
       <y>900</y>
-      <width>91</width>
-      <height>22</height>
+      <width>100</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3851,6 +3851,28 @@
      <string>10</string>
     </property>
    </widget>
+   <widget class="QPushButton" name="StartFIP">
+    <property name="geometry">
+     <rect>
+      <x>380</x>
+      <y>901</y>
+      <width>91</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>Start FIP workflow</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
    <widget class="QPushButton" name="StartExcitation">
     <property name="geometry">
      <rect>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Allows the user to start the FIP workflow from the GUI, and removes the need to manually enter the mouse ID into the FIP workflow. 
- Adds a new entry into `ForagingSettings.json`,  `FIP_workflow_path` with default value of `""`.  This entry is not required unless FIP is running from the GUI. 
- Passes the session path, and whether the camera is running to the FIP workflow

### What issues or discussions does this update address?
- resolves #419 
- resolves #285 

### Describe the expected change in behavior from the perspective of the experimenter

Adds a `Start FIP workflow` button to the Optogenetics and fiber photometry tab. Reorganizes the `Start Excitation` and `Start bleaching` buttons

<img width="600" alt="MicrosoftTeams-imagedf302bb83b1c0bfb2c0ffebe972ae414704ffa98c7f1978db3544cf6ad1704b9" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/e79bc2c6-c295-4415-a2ad-b29cac0c15bf">


To start the FIP workflow:
- Open the GUI and load the mouse
- Click "Start FIP workflow"
- Once the workflow has opened, click "Start excitation", you will be asked to confirm the FIP workflow is running
- Click "Start" to start the session, and the baseline timer will begin. 

To end the session:
- Click "Start" to stop trials
- Click "Start Excitation" to stop excitation
- click "Stop" in the workflow window
- Save the GUI, close the GUI

### Describe any manual update steps for task computers
FIP rigs must:
- update to the newest version of `FIP_DAQ_Control` repo
- Add `FIP_workflow_path` to `ForagingSettings.json`. This should be a string path to the `ThorFIP.bonsai` workflow in the FIP_DAQ_Control repo
- [x] Ephys 1/3
- [ ] 447 1D, 2D, 3D @hagikent @alexpiet 
- [ ] 428 @hagikent @alexpiet 
- [ ] 446 ? @hagikent 

### Was this update tested in 446/447?
- [ ] tested in 447
- [x] tested in 428




