### PR TITLE
Minor improves of the autotrain GUI

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2050,7 +2050,7 @@ class AutoTrainDialog(QDialog):
     def _show_curriculum_in_streamlit(self):
         if self.selected_curriculum is not None:
             webbrowser.open(
-                'https://foraging-behavior-browser.streamlit.app/'
+                'https://foraging-behavior-browser.allenneuraldynamics-test.org/'
                 '?tab_id=tab_auto_train_curriculum'
                 f'&auto_training_curriculum_name={self.selected_curriculum["curriculum"].curriculum_name}'
                 f'&auto_training_curriculum_version={self.selected_curriculum["curriculum"].curriculum_version}'
@@ -2059,10 +2059,10 @@ class AutoTrainDialog(QDialog):
                         
     def _show_auto_training_history_in_streamlit(self):
         webbrowser.open(
-            'https://foraging-behavior-browser.streamlit.app/?'
+            'https://foraging-behavior-browser.allenneuraldynamics-test.org/?'
             f'&filter_subject_id={self.selected_subject_id}'
             f'&tab_id=tab_auto_train_history'
-            f'&auto_training_history_x_axis=date'
+            f'&auto_training_history_x_axis=session'
             f'&auto_training_history_sort_by=subject_id'
             f'&auto_training_history_sort_order=descending'
         )

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2086,6 +2086,7 @@ class AutoTrainDialog(QDialog):
 
                 
     def _override_stage_clicked(self, state):
+        logger.info(f"Override stage clicked: state={state}")
         if state:
             self.comboBox_override_stage.setEnabled(True)
         else:
@@ -2093,6 +2094,7 @@ class AutoTrainDialog(QDialog):
         self._update_stage_to_apply()
         
     def _override_curriculum_clicked(self, state):
+        logger.info(f"Override stage clicked: state={state}")
         if state:
             self.pushButton_apply_curriculum.setEnabled(True)
             self._add_border_curriculum_selection()
@@ -2106,6 +2108,7 @@ class AutoTrainDialog(QDialog):
     def _update_stage_to_apply(self):
         if self.checkBox_override_stage.isChecked():
             self.stage_in_use = self.comboBox_override_stage.currentText()
+            logger.info(f"Stage overridden to: {self.stage_in_use}")
         elif self.last_session is not None:
             self.stage_in_use = self.last_session['next_stage_suggested']
         else:
@@ -2116,6 +2119,9 @@ class AutoTrainDialog(QDialog):
             + '\n'.join(get_curriculum_string(self.curriculum_in_use).split('(')).strip(')') 
             + f"\n{self.stage_in_use}"
         )
+        
+        logger.info(f"Current stage to apply: {self.stage_in_use} @"
+                    f"{get_curriculum_string(self.curriculum_in_use)}")
                 
     def _apply_curriculum(self):
         # Check if a curriculum is selected
@@ -2241,6 +2247,8 @@ class AutoTrainDialog(QDialog):
                     
     def update_auto_train_lock(self, engaged):
         if engaged:
+            logger.info(f"AutoTrain engaged! {self.stage_in_use} @ {get_curriculum_string(self.curriculum_in_use)}")
+            
             # Update the flag
             self.auto_train_engaged = True
 
@@ -2289,6 +2297,8 @@ class AutoTrainDialog(QDialog):
             self.pushButton_preview_auto_train_paras.setEnabled(False)
                                     
         else:
+            logger.info("AutoTrain disengaged!")
+
             # Update the flag
             self.auto_train_engaged = False
             

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3747,11 +3747,10 @@ class Window(QMainWindow):
     def _open_mouse_on_streamlit(self):
         '''open the training history of the current mouse on the streamlit app'''
         # See this PR: https://github.com/AllenNeuralDynamics/foraging-behavior-browser/pull/25
-        webbrowser.open(f'https://foraging-behavior-browser.streamlit.app/?filter_subject_id={self.ID.text()}'
-                         '&tab_id=tab_session_x_y&x_y_plot_xname=session&x_y_plot_yname=foraging_eff'
-                         '&x_y_plot_group_by=h2o&x_y_plot_if_show_dots=True&x_y_plot_if_aggr_each_group=True&x_y_plot_aggr_method_group=lowess'
-                         '&x_y_plot_if_aggr_all=False&x_y_plot_smooth_factor=5'
-                         '&x_y_plot_dot_size=20&x_y_plot_dot_opacity=0.8&x_y_plot_line_width=3.0'
+        webbrowser.open(f'https://foraging-behavior-browser.allenneuraldynamics-test.org/?filter_subject_id={self.ID.text()}'
+                         '&tab_id=tab_session_inspector'
+                         '&session_plot_mode=all+sessions+filtered+from+sidebar'
+                         '&session_plot_selected_draw_types=1.+Choice+history'
         )
 
 def start_gui_log_file(box_number):


### PR DESCRIPTION
### Describe changes:
1. Fixed and improved Streamlit links in the GUI. For example, click the "Streamlit!!" button in the GUI will open up all previous sessions of the mouse in the Streamlit app
    ![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/b2cee43f-3b9b-4292-ac15-8059a500d716)

    ![image](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/24734299/1ea8d2b0-54ec-4702-bb92-eb26b284b82c)

2. Improved logging of the AutoTrain dialog for diagnostic purposes

### What issues or discussions does this update address?
- may help debug issues https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/356 and https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/331.

### Describe the expected change in behavior from the perspective of the experimenter
See above.

### Describe any manual update steps for task computers
NA

### Was this update tested in 446/447?
- [x] Tested on my own PC




