### PR TITLE
FIP updates

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2803,14 +2803,14 @@ class Window(QMainWindow):
             return 0 
 
         if self.StartExcitation.isChecked():
-            logging.info('StartExcitation is checked, photometry mode: {}'.format(self.FIPMode.CurrentText()))
+            logging.info('StartExcitation is checked, photometry mode: {}'.format(self.FIPMode.currentText()))
             self.StartExcitation.setStyleSheet("background-color : green;")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
                 # Trigger Teensy with the above specified exp mode
-                if self.FIPMode.CurrentText() == "Normal":
+                if self.FIPMode.currentText() == "Normal":
                     ser.write(b'c')
-                elif self.FIPMode.CurrentText() == "Axon":
+                elif self.FIPMode.currentText() == "Axon":
                     ser.write(b'e')       
                 ser.close()
                 self.TeensyWarning.setText('Started FIP excitation')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1472,6 +1472,9 @@ class Window(QMainWindow):
             self.UpdateParameters=1 # Changes are allowed
             # change color to black
             for container in [self.TrainingParameters, self.centralwidget, self.Opto_dialog]:
+                for child in container.findChildren((QtWidegets.QComboBox)):
+                    print(child.objectName())
+
                 # Iterate over each child of the container that is a QLineEdit or QDoubleSpinBox
                 for child in container.findChildren((QtWidgets.QLineEdit,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox)):
                     if child.objectName()=='qt_spinbox_lineedit':

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2782,16 +2782,6 @@ class Window(QMainWindow):
                QMessageBox.Ok )               
 
     def _StartExcitation(self):
-
-        if not self.FIP_started:
-            logging.warning('FIP workflow is not running, cannot start excitation')
-            reply = QMessageBox.information(self, 
-                'Box {}, Start Excitation:'.format(self.box_letter), 
-                'Please start the FIP workflow before running excitation',
-                QMessageBox.Ok )                     
-            self.StartExcitation.setChecked(False)
-            self.StartExcitation.setStyleSheet("background-color : none")
-            return 0  
  
         if self.Teensy_COM == '':
             logging.warning('No Teensy COM configured for this box, cannot start excitation')
@@ -2805,16 +2795,7 @@ class Window(QMainWindow):
             return 0 
 
         if self.StartExcitation.isChecked():
-            reply = QMessageBox.question(self, 
-                'Box {}, Start FIP'.format(self.box_letter), 
-                'Is the FIP workflow running?', 
-                QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes )
-            if reply == QMessageBox.No:
-                self.StartExcitation.setChecked(False)
-                self.StartExcitation.setStyleSheet("background-color : none")
-                logging.info('User says FIP workflow is not open')
-                return 0 
-            logging.info('StartExcitation is checked, user confirms workflow is running')
+            logging.info('StartExcitation is checked')
             self.StartExcitation.setStyleSheet("background-color : green;")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2801,7 +2801,7 @@ class Window(QMainWindow):
             return 0 
 
         if self.StartExcitation.isChecked():
-            logging.info('StartExcitation is checked, photometry mode: {}'.format(self.FIPMode.CurrentText())
+            logging.info('StartExcitation is checked, photometry mode: {}'.format(self.FIPMode.CurrentText()))
             self.StartExcitation.setStyleSheet("background-color : green;")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2740,8 +2740,6 @@ class Window(QMainWindow):
             msg = 'No Teensy COM configured for this box, cannot start FIP workflow'
             reply = QMessageBox.information(self, 
                 'Box {}, StartFIP'.format(self.box_letter), msg, QMessageBox.Ok )
-            self.StartFIP.setChecked(False)
-            self.StartFIP.setStyleSheet("background-color : none")
             return
         
         if self.FIP_workflow_path == "":
@@ -2751,12 +2749,9 @@ class Window(QMainWindow):
             msg = 'FIP workflow path not defined, cannot start FIP workflow'
             reply = QMessageBox.information(self, 
                 'Box {}, StartFIP'.format(self.box_letter), msg, QMessageBox.Ok )
-            self.StartFIP.setChecked(False)
-            self.StartFIP.setStyleSheet("background-color : none")                  
             return
  
         if self.FIP_started:
-            self.StartFIP.setChecked(True)             
             reply = QMessageBox.question(self, 
                 'Box {}, Start FIP workflow:'.format(self.box_letter), 
                 'FIP workflow has already been started. Start again?',
@@ -2767,14 +2762,9 @@ class Window(QMainWindow):
             else:
                 logging.warning('FIP workflow already started, user restarts')
 
-        self.FIP_started=True 
-        logging.info('StartFIP is checked')
-        self.StartFIP.setStyleSheet("background-color : green;")
-
         # Start logging
         self.CreateNewFolder=1
         self.Ot_log_folder=self._restartlogging()
-
 
         # Start the FIP workflow
         try:
@@ -2783,6 +2773,7 @@ class Window(QMainWindow):
             folder_path = ' -p session="{}"'.format(self.SessionFolder)
             camera = ' -p RunCamera="{}"'.format(not self.Camera_dialog.StartCamera.isChecked())
             subprocess.Popen(self.bonsai_path+' '+self.FIP_workflow_path+folder_path+camera+' --start',cwd=CWD,shell=True)
+            self.FIP_started=True 
         except Exception as e:
             logging.error(e)
             reply = QMessageBox.information(self, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -205,9 +205,9 @@ class Window(QMainWindow):
         self.StartBleaching.clicked.connect(self._StartBleaching)
         self.NextBlock.clicked.connect(self._NextBlock)
         self.OptogeneticsB.activated.connect(self._OptogeneticsB) # turn on/off optogenetics
-        self.OptogeneticsB.currentIndexChanged.connect(self._keyPressEvent)
-        self.PhotometryB.currentIndexChanged.connect(self._keyPressEvent)
-        self.FIPMode.currentIndexChanged.connect(self._keyPressEvent)
+        self.OptogeneticsB.currentIndexChanged.connect(self._QComboBoxUpdate, 'Optogenetics',self.OptogeneticsB.currentText())
+        self.PhotometryB.currentIndexChanged.connect(self._QComboBoxUpdate, 'Photometry',self.PhotometryB.currentText())
+        self.FIPMode.currentIndexChanged.connect(self._QComboBoxUpdate, 'FIPMode', self.FIPMode.currentText())
         self.AdvancedBlockAuto.currentIndexChanged.connect(self._keyPressEvent)
         self.AutoWaterType.currentIndexChanged.connect(self._keyPressEvent)
         self.UncoupledReward.textChanged.connect(self._ShowRewardPairs)
@@ -1438,6 +1438,10 @@ class Window(QMainWindow):
             self.SwitchThr.setEnabled(True)
             self.PointsInARow.setEnabled(True)
 
+    def _QComboBoxUpdate(self, parameter,value):
+        logging.info('Field updated: {}:{}'.format(parameter, value))       
+ 
+
     def keyPressEvent(self, event=None,allow_reset=False):
         '''
             Enter press to allow change of parameters
@@ -1472,8 +1476,6 @@ class Window(QMainWindow):
             self.UpdateParameters=1 # Changes are allowed
             # change color to black
             for container in [self.TrainingParameters, self.centralwidget, self.Opto_dialog]:
-                for child in container.findChildren((QtWidgets.QComboBox)):
-                    print(child.objectName())
 
                 # Iterate over each child of the container that is a QLineEdit or QDoubleSpinBox
                 for child in container.findChildren((QtWidgets.QLineEdit,QtWidgets.QDoubleSpinBox,QtWidgets.QSpinBox)):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -205,9 +205,9 @@ class Window(QMainWindow):
         self.StartBleaching.clicked.connect(self._StartBleaching)
         self.NextBlock.clicked.connect(self._NextBlock)
         self.OptogeneticsB.activated.connect(self._OptogeneticsB) # turn on/off optogenetics
-        self.OptogeneticsB.currentIndexChanged.connect(self._QComboBoxUpdate, 'Optogenetics',self.OptogeneticsB.currentText())
-        self.PhotometryB.currentIndexChanged.connect(self._QComboBoxUpdate, 'Photometry',self.PhotometryB.currentText())
-        self.FIPMode.currentIndexChanged.connect(self._QComboBoxUpdate, 'FIPMode', self.FIPMode.currentText())
+        self.OptogeneticsB.currentIndexChanged.connect(lambda: self._QComboBoxUpdate('Optogenetics',self.OptogeneticsB.currentText()))
+        self.PhotometryB.currentIndexChanged.connect(lambda: self._QComboBoxUpdate('Photometry',self.PhotometryB.currentText()))
+        self.FIPMode.currentIndexChanged.connect(lambda: self._QComboBoxUpdate('FIPMode', self.FIPMode.currentText()))
         self.AdvancedBlockAuto.currentIndexChanged.connect(self._keyPressEvent)
         self.AutoWaterType.currentIndexChanged.connect(self._keyPressEvent)
         self.UncoupledReward.textChanged.connect(self._ShowRewardPairs)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2663,6 +2663,7 @@ class Window(QMainWindow):
         else:
             self.NewSession.setDisabled(False)
         self.StartExcitation.setChecked(False)
+        self.keyPressEvent() # Accept all updates
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2801,18 +2801,21 @@ class Window(QMainWindow):
             return 0 
 
         if self.StartExcitation.isChecked():
-            logging.info('StartExcitation is checked')
+            logging.info('StartExcitation is checked, photometry mode: {}'.format(self.FIPMode.CurrentText())
             self.StartExcitation.setStyleSheet("background-color : green;")
             try:
                 ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
                 # Trigger Teensy with the above specified exp mode
-                ser.write(b'c')
+                if self.FIPMode.CurrentText() == "Normal":
+                    ser.write(b'c')
+                elif self.FIPMode.CurrentText() == "Axon":
+                    ser.write(b'e')       
                 ser.close()
-                self.TeensyWarning.setText('Start excitation!')
+                self.TeensyWarning.setText('Started FIP excitation')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
             except Exception as e:
                 logging.error(str(e))
-                self.TeensyWarning.setText('Error: start excitation!')
+                self.TeensyWarning.setText('Error: starting excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
                 reply = QMessageBox.critical(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when starting excitation: {}'.format(e), QMessageBox.Ok)
                 self.StartExcitation.setChecked(False)
@@ -2831,11 +2834,11 @@ class Window(QMainWindow):
                 # Trigger Teensy with the above specified exp mode
                 ser.write(b's')
                 ser.close()
-                self.TeensyWarning.setText('Stop excitation!')
+                self.TeensyWarning.setText('Stopped FIP excitation')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
             except Exception as e:
                 logging.error(str(e))
-                self.TeensyWarning.setText('Error: stop excitation!')
+                self.TeensyWarning.setText('Error stopping excitation!')
                 self.TeensyWarning.setStyleSheet(self.default_warning_color)
                 reply = QMessageBox.critical(self, 'Box {}, Start excitation:'.format(self.box_letter), 'error when stopping excitation: {}'.format(e), QMessageBox.Ok)
                 return 0 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -207,6 +207,7 @@ class Window(QMainWindow):
         self.OptogeneticsB.activated.connect(self._OptogeneticsB) # turn on/off optogenetics
         self.OptogeneticsB.currentIndexChanged.connect(self._keyPressEvent)
         self.PhotometryB.currentIndexChanged.connect(self._keyPressEvent)
+        self.FIPMode.currentIndexChanged.connect(self._keyPressEvent)
         self.AdvancedBlockAuto.currentIndexChanged.connect(self._keyPressEvent)
         self.AutoWaterType.currentIndexChanged.connect(self._keyPressEvent)
         self.UncoupledReward.textChanged.connect(self._ShowRewardPairs)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2738,6 +2738,7 @@ class Window(QMainWindow):
                     child.clear()
 
     def _StartFIP(self):
+        self.StartFIP.setChecked(False)
 
         if self.Teensy_COM == '':
             logging.warning('No Teensy COM configured for this box, cannot start FIP workflow')
@@ -2936,7 +2937,7 @@ class Window(QMainWindow):
         if self.Teensy_COM == '':
             return
         logging.info('Checking that photometry is not running')
-        FIP_was_running=self.StartFIP.isChecked()
+        FIP_was_running=self.FIP_started
         try:
             ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
             # Trigger Teensy with the above specified exp mode
@@ -2952,10 +2953,8 @@ class Window(QMainWindow):
             self.TeensyWarning.setStyleSheet(self.default_warning_color)      
             self.StartBleaching.setStyleSheet("background-color : none")
             self.StartExcitation.setStyleSheet("background-color : none")
-            self.StartFIP.setStyleSheet("background-color : none;")
             self.StartBleaching.setChecked(False)
             self.StartExcitation.setChecked(False)
-            self.StartFIP.setChecked(False)
             self.FIP_started=False
 
         if (FIP_was_running)&(not closing):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1472,7 +1472,7 @@ class Window(QMainWindow):
             self.UpdateParameters=1 # Changes are allowed
             # change color to black
             for container in [self.TrainingParameters, self.centralwidget, self.Opto_dialog]:
-                for child in container.findChildren((QtWidegets.QComboBox)):
+                for child in container.findChildren((QtWidgets.QComboBox)):
                     print(child.objectName())
 
                 # Iterate over each child of the container that is a QLineEdit or QDoubleSpinBox

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4714,6 +4714,54 @@ Current pair:
                         </property>
                        </widget>
                       </item>
+                      <item row="3" column="3">
+                       <widget class="QLabel" name="label_65">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>FIP mode=</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="3" column="4">
+                       <widget class="QComboBox" name="FIPMode">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="editable">
+                         <bool>false</bool>
+                        </property>
+                        <item>
+                         <property name="text">
+                          <string>Normal</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>Axon</string>
+                         </property>
+                        </item>
+                       </widget>
+                      </item>
+
+
+
+
+
+
                       <item row="0" column="0">
                        <widget class="QLabel" name="label_55">
                         <property name="sizePolicy">
@@ -4854,7 +4902,7 @@ Current pair:
                         </item>
                        </widget>
                       </item>
-                      <item row="3" column="1">
+                      <item row="4" column="1">
                        <widget class="QPushButton" name="StartEphysRecording">
                         <property name="text">
                          <string>Start ephys recording</string>
@@ -4864,7 +4912,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="3" column="3">
+                      <item row="4" column="3">
                        <widget class="QLabel" name="label_65">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4883,7 +4931,7 @@ Current pair:
                         </property>
                        </widget>
                       </item>
-                      <item row="3" column="4">
+                      <item row="4" column="4">
                        <widget class="QComboBox" name="OpenEphysRecordingType">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4756,12 +4756,6 @@ Current pair:
                         </item>
                        </widget>
                       </item>
-
-
-
-
-
-
                       <item row="0" column="0">
                        <widget class="QLabel" name="label_55">
                         <property name="sizePolicy">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3945,7 +3945,7 @@
    <widget class="QComboBox" name="FIPMode">
     <property name="geometry">
      <rect>
-      <x>860</x>
+      <x>820</x>
       <y>900</y>
       <width>81</width>
       <height>20</height>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3920,7 +3920,7 @@
    <widget class="QLabel" name="label_65">
     <property name="geometry">
      <rect>
-      <x>740</x>
+      <x>720</x>
       <y>900</y>
       <width>81</width>
       <height>20</height>
@@ -3945,7 +3945,7 @@
    <widget class="QComboBox" name="FIPMode">
     <property name="geometry">
      <rect>
-      <x>820</x>
+      <x>810</x>
       <y>900</y>
       <width>81</width>
       <height>20</height>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3920,7 +3920,7 @@
    <widget class="QLabel" name="label_65">
     <property name="geometry">
      <rect>
-      <x>720</x>
+      <x>710</x>
       <y>900</y>
       <width>81</width>
       <height>20</height>
@@ -3945,7 +3945,7 @@
    <widget class="QComboBox" name="FIPMode">
     <property name="geometry">
      <rect>
-      <x>810</x>
+      <x>795</x>
       <y>900</y>
       <width>81</width>
       <height>20</height>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -3917,6 +3917,60 @@
      <bool>true</bool>
     </property>
    </widget>
+   <widget class="QLabel" name="label_65">
+    <property name="geometry">
+     <rect>
+      <x>740</x>
+      <y>900</y>
+      <width>81</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>FIP mode=</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::AutoText</enum>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="FIPMode">
+    <property name="geometry">
+     <rect>
+      <x>860</x>
+      <y>900</y>
+      <width>81</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="editable">
+     <bool>false</bool>
+    </property>
+    <item>
+     <property name="text">
+      <string>Normal</string>
+     </property>
+    </item>
+    <item>
+     <property name="text">
+      <string>Axon</string>
+     </property>
+    </item>
+   </widget>
    <widget class="QLabel" name="TeensyWarning">
     <property name="geometry">
      <rect>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Previously, when a user pressed `Start FIP workflow` the button toggled colors. But this was confusing because the workflow could not be stopped from the GUI. Now the color will not change
- Previously, `Start Excitation` could not be pressed unless the FIP workflow had already been started. However, @hagikent requests that users check the cables (using excitation) before starting the workflow. So I removed the requirement that the FIP workflow had been started before allowing for excitation. The `Start` button still checks that the FIP workflow has been started. 
- Users can now the FIP mode between `Normal` and `Axon`. The only difference is the excitation power. `Normal` sends the Teensy command `c`, whereas `Axon` sends the teensy command `e` (@hagikent can you double check I got that mapping correct)
- Previously when QComboBox fields were modified by the user, the slot was connected to keyPressEvent which took no action. I added a function that simply logs the new value for debugging purposes. 
- Also resolves a small issue where loading a mouse does not "accept" the ID or experimenter fields (the text remain purple). I added a keyPressEvent which accepts them

### What issues or discussions does this update address?
- resolves #433 
- resolves #435 

### Describe the expected change in behavior from the perspective of the experimenter
- The `Start FIP Workflow` button will not change color after you press it
- You can press `Start Excitation` without starting the workflow first, to allow for checking cables. 
- When running an FIP mouse you need to set the `FIP mode`. This will default to `Normal`. Some mice for @ZhixiaoSu will have FIP mode = `Axon` for axonal imaging. An individual mouse will always have the same FIP mode. 

Standard UI
<img width="400" alt="MicrosoftTeams-image3364726d096d2306de4288df6c20b2dcd57fa989631de8d5e32431472fb46a03" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/bd92eb22-7b9a-46e4-90a9-d33192d619b0">

Xinxin's UI
<img width="400" alt="MicrosoftTeams-image863c161a49bff4edff2a3921ab24d1b6971627c7796dbaed2d3bd880ebce4ac4" src="https://github.com/AllenNeuralDynamics/dynamic-foraging-task/assets/7605170/024fbf13-5a51-47aa-9bd2-5016ff472782">


### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested in 428
- [x] Make sure it accurately changes the teensy command, and FIP power
- [x] Make sure the parameter is saved and loaded correctly




