### PR TITLE
Checks for the presence of saved data before warning about missing trigger file

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -481,8 +481,15 @@ class Window(QMainWindow):
                     time.sleep(5)
                     triggers = harp.read(camera_trigger_file)
                     self.trigger_length = len(triggers)
+                elif len(os.listdir(video_folder)) == 0:
+                    # no video data saved.
+                    self.trigger_length=0
+                    self.WarningLabelCamera.setText('')
+                    self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
+                    return
                 else:
                     self.trigger_length=0
+                    logging.error('Saved video data, but no camera trigger file found')
                     self.WarningLabelCamera.setText('No camera trigger file found!')
                     self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
                     return


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Right now the GUI generates a warning if there is a missing camera trigger file. However if no video data was collected, then this file wont exist. Now we check for saved video data before issuing a warning. If saved video data does exist, the warning is logged as an error

### What issues or discussions does this update address?
- resolves #442 

### Describe the expected change in behavior from the perspective of the experimenter
- Removes confusing warning message in 447 rigs

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested in 447




