### PR TITLE
Add rwd delay to nwb (test PR)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "requests",
     "harp-python",
     "deepdiff",
+    "aind-data-schema==0.36.0",
+    "aind-data-schema-models==0.1.1"
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ pynwb
 requests
 harp-python
 deepdiff
+aind-data-schema==0.36.0
+aind-data-schema-models==0.1.1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1186,8 +1186,10 @@ class Window(QMainWindow):
         rig_settings = self.Settings.copy()
         rig_settings['rig_name'] = self.rig_name 
         rig_settings['box_number'] = self.box_number
-        df = pd.read_csv(self.SettingsBoxFile,index_col=None)
-        rig_settings['box_settings'] = {row[0]: row[1] for _, row in df.iterrows()}
+        df = pd.read_csv(self.SettingsBoxFile,index_col=None).to_dict()
+        for row in df:
+            print(row)
+        rig_settings['box_settings'] = df
         rig_settings['rig_specification'] = rig_specification
  
         build_rig_json(existing_rig_json, rig_settings, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1149,7 +1149,7 @@ class Window(QMainWindow):
 
         # See if rig metadata folder exists 
         if not os.path.exists(self.Settings['rig_metadata_folder']):
-            print('making directory: {}'.format(self.Settings['rig_metadata_folder'])
+            print('making directory: {}'.format(self.Settings['rig_metadata_folder']))
             os.makedirs(self.Settings['rig_metadata_folder'])
               
         # Load rig_specification.json

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1187,9 +1187,7 @@ class Window(QMainWindow):
         rig_settings['rig_name'] = self.rig_name 
         rig_settings['box_number'] = self.box_number
         df = pd.read_csv(self.SettingsBoxFile,index_col=None,header=None)
-        df = {row[0]:row[1] for index, row in df.iterrows()}
-        print(df)
-        rig_settings['box_settings'] = df
+        rig_settings['box_settings'] = {row[0]:row[1] for index, row in df.iterrows()}
         rig_settings['rig_specification'] = rig_specification
  
         build_rig_json(existing_rig_json, rig_settings, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -927,7 +927,7 @@ class Window(QMainWindow):
             'show_log_info_in_console':False,
             'default_ui':'ForagingGUI.ui',
             'open_ephys_machine_ip_address':'',
-            'rig_metadata_folder':os.path.join(self.SettingFolder,'rig_metadata')+'\\'
+            'rig_metadata_folder':os.path.join(self.SettingFolder,'rig_metadata')+'\\',
             'create_rig_metadata':True,
         }
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1186,7 +1186,7 @@ class Window(QMainWindow):
         rig_settings = self.Settings.copy()
         rig_settings['rig_name'] = self.rig_name 
         rig_settings['box_number'] = self.box_number
-        df = pd.read_csv(self.SettingsBoxFile,index_col=None).to_dict()
+        df = pd.read_csv(self.SettingsBoxFile,index_col=None).to_dict(orient='series')
         for row in df:
             print(row)
         rig_settings['box_settings'] = df

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1003,8 +1003,7 @@ class Window(QMainWindow):
                 4:'D'
             }
             self.current_box='{}-{}'.format(self.current_box,mapper[self.box_number])
-        window_title = '{}'.format(self.current_box)
-        self.rig_name = window_title
+        self.rig_name = '{}'.format(self.current_box)
 
     def _InitializeBonsai(self):
         '''
@@ -1144,9 +1143,6 @@ class Window(QMainWindow):
             subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start --no-editor',cwd=CWD,shell=True)
 
     def _LoadRigJson(self):     
-        #RIG ID: rig_name+YYYYMMDD (323_EPHYS3_20240512)
-        #RIG JSON name: 'rig_<rig_name>_<YYY-MM-DD.json'
-
         # See if rig metadata folder exists 
         if not os.path.exists(self.Settings['rig_metadata_folder']):
             print('making directory: {}'.format(self.Settings['rig_metadata_folder']))
@@ -1170,6 +1166,7 @@ class Window(QMainWindow):
         for f in files:
             print(f)
         if len(files) ==0:
+            # No rig.jsons found, this will trigger saving the new one
             old_rig_json = {}
         else:
             #old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
@@ -1177,7 +1174,7 @@ class Window(QMainWindow):
             with open(old_rig_json_path, 'r') as f:
                 old_rig_json = json.load(f)      
 
-        # Build, but don't save!
+        # Builds a new rig.json, and saves if there are changes with the most recent
         self.Settings['rig_name'] = self.rig_name 
         build_rig_json(old_rig_json,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1165,6 +1165,7 @@ class Window(QMainWindow):
         
         # Load most recent rig_json
         files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
+        files = [f.__str__().split('\\')[-1] for f in files]
         files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
         for f in files:
             print(f)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -996,7 +996,7 @@ class Window(QMainWindow):
             logger.addHandler(handler)
             
         # Determine box
-        if self.current_box in ['447-1','447-2','447-3','alex_laptop']:
+        if self.current_box in ['447-1','447-2','447-3']:
             mapper={
                 1:'A',
                 2:'B',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1184,6 +1184,10 @@ class Window(QMainWindow):
         rig_settings = self.Settings.copy()
         rig_settings['rig_name'] = self.rig_name 
         rig_settings['box_number'] = self.box_number
+        df = pd.read_csv(self.SettingsBoxFile,index_col=None)
+        rig_settings['box_settings'] = {row[0]: row[1] for _, row in df.iterrows()}
+        print(rig_settings)
+ 
         build_rig_json(existing_rig_json, rig_settings, 
             self.WaterCalibrationResults, 
             self.LaserCalibrationResults)        

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -928,6 +928,7 @@ class Window(QMainWindow):
             'default_ui':'ForagingGUI.ui',
             'open_ephys_machine_ip_address':'',
             'rig_metadata_folder':os.path.join(self.SettingFolder,'rig_metadata')+'\\'
+            'create_rig_metadata':True,
         }
         
         # Try to load Settings_box#.csv
@@ -1142,7 +1143,13 @@ class Window(QMainWindow):
         else:
             subprocess.Popen(self.bonsai_path+' '+self.bonsaiworkflow_path+' -p '+'SettingsPath='+self.SettingFolder+'\\'+SettingsBox+ ' --start --no-editor',cwd=CWD,shell=True)
 
-    def _LoadRigJson(self):     
+    def _LoadRigJson(self):    
+    
+        # User can skip this step if they make rig metadata themselves
+        if not self.Settings['create_rig_metadata']: 
+            logging.info('Skipping rig metadata creation because create_rig_metadata=True')
+            return
+
         # See if rig metadata folder exists 
         if not os.path.exists(self.Settings['rig_metadata_folder']):
             print('making directory: {}'.format(self.Settings['rig_metadata_folder']))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1170,13 +1170,13 @@ class Window(QMainWindow):
         files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
         files = [f.__str__().split('\\')[-1] for f in files]
         files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
-        for f in files:
-            print(f)
         if len(files) ==0:
             # No rig.jsons found, this will trigger saving the new one
             existing_rig_json = {}
+            logging.info('Did not find any existing rig.json files')
         else:
             existing_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],files[-1])
+            logging.info('Found existing rig.json: {}'.format(files[-1]))
             with open(existing_rig_json_path, 'r') as f:
                 existing_rig_json = json.load(f)      
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1165,11 +1165,9 @@ class Window(QMainWindow):
         
         # Load most recent rig_json
         files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
-        #dates = []
-        print(files)
-        #for f in files:
-        #    if (f.startswith('rig_'+self.rig_name)) and (f.endswith('.json')):
-        #        date_str = f.split('_')[-1].split(
+        for f in files:
+            print(f)
+
         old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
         with open(old_rig_json_path, 'r') as f:
             old_rig_json = json.load(f)      

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1165,20 +1165,20 @@ class Window(QMainWindow):
         
         # Load most recent rig_json
         files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
+        files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
         for f in files:
             print(f)
+        if len(files) ==0:
+            old_rig_json = {}
+        else:
+            #old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
+            old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],files[-1])
+            with open(old_rig_json_path, 'r') as f:
+                old_rig_json = json.load(f)      
 
-        old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
-        with open(old_rig_json_path, 'r') as f:
-            old_rig_json = json.load(f)      
-
- 
         # Build, but don't save!
         self.Settings['rig_name'] = self.rig_name 
         build_rig_json(old_rig_json,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
-
-        # Compare with most recent rig_json
-        # if updated, save new version
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -996,7 +996,7 @@ class Window(QMainWindow):
             logger.addHandler(handler)
             
         # Determine box
-        if self.current_box in ['447-1','447-2','447-3']:
+        if self.current_box in ['447-1','447-2','447-3','alex_laptop']:
             mapper={
                 1:'A',
                 2:'B',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1161,10 +1161,17 @@ class Window(QMainWindow):
         else:
             raise Exception('Cannot find rig specification file at: {}'.format(self.rig_specification))
         
+        # Load most recent rig_json
+        self.Settings['rig_metadata_folder'] = os.path.join(self.SettingFolder, 'rig_metadata')
+        old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
+        with open(old_rig_json_path, 'r') as f:
+            old_rig_json = json.load(f)      
+
+ 
         # Build, but don't save!
         self.Settings['rig_metadata_folder'] = os.path.join(self.SettingFolder, 'rig_metadata')
         self.Settings['rig_name'] = self.rig_name 
-        build_rig_json({},self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
+        build_rig_json(old_rig_json,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
 
         # Compare with most recent rig_json
         # if updated, save new version

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -73,6 +73,7 @@ class Window(QMainWindow):
         self.WaterCalibrationFiles=os.path.join(self.SettingFolder,'WaterCalibration_{}.json'.format(box_number))
         self.WaterCalibrationParFiles=os.path.join(self.SettingFolder,'WaterCalibrationPar_{}.json'.format(box_number))
         self.TrainingStageFiles=os.path.join(self.SettingFolder,'TrainingStagePar.json')
+        self.rig_specification = os.path.join(self.SettingFolder, 'rig_specification.json')
 
         # Load Laser and Water Calibration Files
         self._GetLaserCalibration()
@@ -926,9 +927,7 @@ class Window(QMainWindow):
             'show_log_info_in_console':False,
             'default_ui':'ForagingGUI.ui',
             'open_ephys_machine_ip_address':'',
-            'rig_metadata_folder':os.path.join(self.SettingFolder,'rig_metadata')+'\\',
-            'rig_specification':os.path.join(self.SettingFolder, 'rig_specification.json')
-
+            'rig_metadata_folder':os.path.join(self.SettingFolder,'rig_metadata')+'\\'
         }
         
         # Try to load Settings_box#.csv
@@ -985,7 +984,6 @@ class Window(QMainWindow):
         self.default_ui=self.Settings['default_ui']
         self.open_ephys_machine_ip_address=self.Settings['open_ephys_machine_ip_address']
         self.rig_metadata_folder=self.Settings['rig_metadata_folder']
-        self.rig_specification=self.Settings['rig_specification']
 
         # Also stream log info to the console if enabled
         if  self.Settings['show_log_info_in_console']:
@@ -1151,10 +1149,10 @@ class Window(QMainWindow):
 
         # See if rig metadata folder exists 
         if not os.path.exists(self.Settings['rig_metadata_folder']):
+            print('making directory: {}'.format(self.Settings['rig_metadata_folder'])
             os.makedirs(self.Settings['rig_metadata_folder'])
               
         # Load rig_specification.json
-        self.rig_specification
         if os.path.isfile(self.rig_specification):
             logging.info('Loading rig specification file')
             try:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1181,8 +1181,12 @@ class Window(QMainWindow):
                 existing_rig_json = json.load(f)      
 
         # Builds a new rig.json, and saves if there are changes with the most recent
-        self.Settings['rig_name'] = self.rig_name 
-        build_rig_json(existing_rig_json,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
+        rig_settings = self.Settings.copy()
+        rig_settings['rig_name'] = self.rig_name 
+        rig_settings['box_number'] = self.box_number
+        build_rig_json(existing_rig_json, rig_settings, 
+            self.WaterCalibrationResults, 
+            self.LaserCalibrationResults)        
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1186,9 +1186,9 @@ class Window(QMainWindow):
         rig_settings = self.Settings.copy()
         rig_settings['rig_name'] = self.rig_name 
         rig_settings['box_number'] = self.box_number
-        df = pd.read_csv(self.SettingsBoxFile,index_col=None).to_dict(orient='series')
-        for row in df:
-            print(row)
+        df = pd.read_csv(self.SettingsBoxFile,index_col=None,header=None).to_dict(orient='series')
+        df = {row[0]:row[1] for index, row in df.iterrows()}
+        print(df)
         rig_settings['box_settings'] = df
         rig_settings['rig_specification'] = rig_specification
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1186,7 +1186,6 @@ class Window(QMainWindow):
         rig_settings['box_number'] = self.box_number
         df = pd.read_csv(self.SettingsBoxFile,index_col=None)
         rig_settings['box_settings'] = {row[0]: row[1] for _, row in df.iterrows()}
-        print(rig_settings)
  
         build_rig_json(existing_rig_json, rig_settings, 
             self.WaterCalibrationResults, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1163,8 +1163,10 @@ class Window(QMainWindow):
                     rig_specification = json.load(f)
             except Exception as e:
                 logging.error('Error loading rig specification file: {}'.format(e))
+                rig_specification = {}
         else:
-            raise Exception('Cannot find rig specification file: {}'.format(self.rig_specification))
+            logging.info'Cannot find rig specification file: {}'.format(self.rig_specification))
+            rig_specification = {}
         
         # Load most recent rig_json
         files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
@@ -1186,6 +1188,7 @@ class Window(QMainWindow):
         rig_settings['box_number'] = self.box_number
         df = pd.read_csv(self.SettingsBoxFile,index_col=None)
         rig_settings['box_settings'] = {row[0]: row[1] for _, row in df.iterrows()}
+        rig_settings['rig_specification'] = rig_specification
  
         build_rig_json(existing_rig_json, rig_settings, 
             self.WaterCalibrationResults, 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1147,7 +1147,7 @@ class Window(QMainWindow):
     
         # User can skip this step if they make rig metadata themselves
         if not self.Settings['create_rig_metadata']: 
-            logging.info('Skipping rig metadata creation because create_rig_metadata=True')
+            logging.info('Skipping rig metadata creation because create_rig_metadata=False')
             return
 
         # See if rig metadata folder exists 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -73,7 +73,7 @@ class Window(QMainWindow):
         self.WaterCalibrationFiles=os.path.join(self.SettingFolder,'WaterCalibration_{}.json'.format(box_number))
         self.WaterCalibrationParFiles=os.path.join(self.SettingFolder,'WaterCalibrationPar_{}.json'.format(box_number))
         self.TrainingStageFiles=os.path.join(self.SettingFolder,'TrainingStagePar.json')
-        self.rig_specification = os.path.join(self.SettingFolder, 'rig_specification.json')
+        self.rig_specification = os.path.join(self.SettingFolder, 'rig_specification_{}.json'.format(box_number))
 
         # Load Laser and Water Calibration Files
         self._GetLaserCalibration()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -996,7 +996,7 @@ class Window(QMainWindow):
             logger.addHandler(handler)
             
         # Determine box
-        if self.current_box in ['447-1','447-2','447-3','alex_laptop']:
+        if self.current_box in ['447-1','447-2','447-3']:
             mapper={
                 1:'A',
                 2:'B',
@@ -1174,16 +1174,15 @@ class Window(QMainWindow):
             print(f)
         if len(files) ==0:
             # No rig.jsons found, this will trigger saving the new one
-            old_rig_json = {}
+            existing_rig_json = {}
         else:
-            #old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
-            old_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],files[-1])
-            with open(old_rig_json_path, 'r') as f:
-                old_rig_json = json.load(f)      
+            existing_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],files[-1])
+            with open(existing_rig_json_path, 'r') as f:
+                existing_rig_json = json.load(f)      
 
         # Builds a new rig.json, and saves if there are changes with the most recent
         self.Settings['rig_name'] = self.rig_name 
-        build_rig_json(old_rig_json,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
+        build_rig_json(existing_rig_json,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1165,7 +1165,7 @@ class Window(QMainWindow):
                 logging.error('Error loading rig specification file: {}'.format(e))
                 rig_specification = {}
         else:
-            logging.info'Cannot find rig specification file: {}'.format(self.rig_specification))
+            logging.info('Cannot find rig specification file: {}'.format(self.rig_specification))
             rig_specification = {}
         
         # Load most recent rig_json

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1186,7 +1186,7 @@ class Window(QMainWindow):
         rig_settings = self.Settings.copy()
         rig_settings['rig_name'] = self.rig_name 
         rig_settings['box_number'] = self.box_number
-        df = pd.read_csv(self.SettingsBoxFile,index_col=None,header=None).to_dict(orient='series')
+        df = pd.read_csv(self.SettingsBoxFile,index_col=None,header=None)
         df = {row[0]:row[1] for index, row in df.iterrows()}
         print(df)
         rig_settings['box_settings'] = df

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1160,16 +1160,11 @@ class Window(QMainWindow):
                 logging.error('Error loading rig specification file: {}'.format(e))
         else:
             raise Exception('Cannot find rig specification file at: {}'.format(self.rig_specification))
-    
-        # Load most recent rig_json
-        old_rig_json_path = os.path.join(self.SettingFolder,'rig_metadata','rig_alex_laptop_2024-05-14_13_35_18.json')
-        with open(old_rig_json_path, 'r') as f:
-            old_rig_json = json.load(f)
-    
+        
         # Build, but don't save!
         self.Settings['rig_metadata_folder'] = os.path.join(self.SettingFolder, 'rig_metadata')
         self.Settings['rig_name'] = self.rig_name 
-        build_rig_json(old_rig_json_path,self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
+        build_rig_json({},self.Settings, self.WaterCalibrationResults, self.LaserCalibrationResults)        
 
         # Compare with most recent rig_json
         # if updated, save new version

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -107,29 +107,51 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                     firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
                     )
     else:
+        # TODO need to add correct details
         stage = d.MotorizedStage(
                     name="AIND lick spout stage",
                     manufacturer=d.Organization.AIND,
                     travel=15.0,
-                    )       
+                    )      
+    if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == 1:
+        # TODO, need to add correct details
+        lick_spouts=[
+            d.RewardSpout(
+                name="AIND_Lick_Detector Left",
+                side=d.SpoutSide.LEFT,
+                spout_diameter=1.2,
+                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
+                lick_sensor_type=d.LickSensorType("Capacitive")
+            ),
+            d.RewardSpout(
+                name="AIND_Lick_Detector Right",
+                side=d.SpoutSide.RIGHT,
+                spout_diameter=1.2,
+                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
+                lick_sensor_type=d.LickSensorType("Capacitive")
+            ),
+            ]   
+    else:
+        lick_spouts=[
+            d.RewardSpout(
+                name="Janelia_Lick_Detector Left",
+                side=d.SpoutSide.LEFT,
+                spout_diameter=1.2,
+                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
+                lick_sensor_type=d.LickSensorType("Capacitive")
+            ),
+            d.RewardSpout(
+                name="Janelia_Lick_Detector Right",
+                side=d.SpoutSide.RIGHT,
+                spout_diameter=1.2,
+                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
+                lick_sensor_type=d.LickSensorType("Capacitive")
+            ),
+            ]
+    # TODO, should add speaker
     components['stimulus_devices']=[
         d.RewardDelivery(
-            reward_spouts=[
-                d.RewardSpout(
-                    name="Janelia_Lick_Detector Left", # TODO
-                    side=d.SpoutSide.LEFT,
-                    spout_diameter=1.2,
-                    solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
-                    lick_sensor_type=d.LickSensorType("Capacitive")
-                ),
-                d.RewardSpout(
-                    name="Janelia_Lick_Detector Right", # TODO
-                    side=d.SpoutSide.RIGHT,
-                    spout_diameter=1.2,
-                    solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
-                    lick_sensor_type=d.LickSensorType("Capacitive")
-                ),
-            ],
+            reward_spouts=lick_spouts,
             stage_type = stage,
         ),
         ]

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -113,7 +113,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                     manufacturer=d.Organization.AIND,
                     travel=15.0,
                     )      
-    if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == 1:
+    if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == 1):
         # TODO, need to add correct details
         lick_spouts=[
             d.RewardSpout(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -367,7 +367,7 @@ def build_rig_json(old_rig, settings, water_calibration, laser_calibration):
         new_rig_json = json.load(f)
 
     # Load most recent rig_json
-    old_rig_json_path = os.path.join(self.SettingFolder,'rig_metadata','rig_alex_laptop_2024-05-14_13_35_18.json')
+    old_rig_json_path = os.path.join(settings,'rig_metadata','rig_alex_laptop_2024-05-14_13_35_18.json')
     with open(old_rig_json_path, 'r') as f:
         old_rig_json = json.load(f)
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -367,7 +367,7 @@ def build_rig_json(old_rig, settings, water_calibration, laser_calibration):
         new_rig_json = json.load(f)
 
     # Load most recent rig_json
-    old_rig_json_path = os.path.join(settings,'rig_metadata','rig_alex_laptop_2024-05-14_13_35_18.json')
+    old_rig_json_path = os.path.join(settings['rig_metadata_folder'],'rig_alex_laptop_2024-05-14_13_35_18.json')
     with open(old_rig_json_path, 'r') as f:
         old_rig_json = json.load(f)
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -483,14 +483,14 @@ def parse_water_calibration(water_calibration):
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Left',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
-        input = {'valve open time (s):':''},
+        input = {'valve open time (s):':', '.join(list(water_calibration[date]['Left'].keys()))},
         output = {'water volume (ul):':''}
         )
     right = d.Calibration(
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Left',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
-        input = {'valve open time (s):':''},
+        input = {'valve open time (s):':', '.join(list(water_calibration[date]['Right'].keys()))},
         output = {'water volume (ul):':''}
         )
     return left, right

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -11,14 +11,13 @@ from aind_data_schema_models.modalities import Modality
 def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration):    
     logging.info('building rig json')
 
-    # Determining if FIB rig
-    modalities = [Modality.BEHAVIOR]
+    # TODO, what other modalities do we need to include?
     FIB = settings['FIP_workflow_path'] != ''
+    OPTO = False
+
+    modalities = [Modality.BEHAVIOR]
     if FIB:
         modalities.append(Modality.FIB)
-    # TODO, what other modalities do we need to include?
-    OPTO = True
-
 
     cameras=[
         d.CameraAssembly(
@@ -85,7 +84,6 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
 
     #######################################################################################################
     ##FIB Specific
-
     if FIB:
         patch_cords=[
             d.Patch(
@@ -363,13 +361,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 
             ),
         ],
-
-        
-
-        
-        ##Optogenetics Specific
-        #######################################################################################################
-    
+  
         # TODO, need to merge in laser and water calibration things
         ##Calibrations
         calibrations=[

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -487,7 +487,7 @@ def parse_water_calibration(water_calibration):
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Left',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
-        input = {'valve open time (s):':', '.join(left_times)},
+        input = {'valve open time (s):':left_times},
         output = {'water volume (ul):':left_volumes}
         )
 
@@ -495,7 +495,7 @@ def parse_water_calibration(water_calibration):
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Right',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
-        input = {'valve open time (s):':', '.join(right_times)},
+        input = {'valve open time (s):':right_times},
         output = {'water volume (ul):':right_volumes}
         )
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -114,7 +114,6 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                     travel=15.0,
                     )      
     if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1"):
-        # TODO, need to add correct details
         lick_spouts=[
             d.RewardSpout(
                 name="AIND_Lick_Detector Left",
@@ -366,7 +365,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 harp_device_type=d.HarpDeviceType.BEHAVIOR,
                 core_version="2.1",
                 firmware_version="FTDI version:",
-                computer_name="behavior_computer", # TODO should this be hostname?
+                computer_name="behavior_computer", 
                 is_clock_generator=False,
                 channels=[
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
@@ -384,7 +383,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 harp_device_type=d.HarpDeviceType.BEHAVIOR,
                 core_version="2.1",
                 firmware_version="FTDI version:",
-                computer_name="behavior_computer", # TODO should this be hostname?
+                computer_name="behavior_computer", 
                 is_clock_generator=False,
                 channels=[
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
@@ -399,7 +398,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     ###########################################################################
     if OPTO:
         ##Optogenetics Specific   ##Xinxin to fill in
- 
+        # TODO
+         
         components['light_sources'].append(
             d.LightEmittingDiode(
                 name="LED for photostimulation",
@@ -425,7 +425,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     ###########################################################################
     # Assemble rig schema
     rig = r.Rig(
-        rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
+        rig_id="{}_{}".format(settings['rig_name'],datetime.now().strftime('%Y-%m-%d') 
         modification_date=date.today(),
         **components 
         )
@@ -445,10 +445,12 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
 
     # Remove the modification date, since that doesnt matter for comparison purposes
-    if ('values_changed' in differences) and ("root['modification_date']" in differences['values_changed']):
-        differences['values_changed'].pop("root['modification_date']")
-        if len(differences['values_changed']) == 0:
-            differences.pop('values_changed')
+    values_to_ignore = ['modification_date','rig_id']
+    for value in values_to_ignore:
+        if ('values_changed' in differences) and ("root['{}']".format(value) in differences['values_changed']):
+            differences['values_changed'].pop("root['{}']".format(value))
+            if len(differences['values_changed']) == 0:
+                differences.pop('values_changed')
 
     # Determine which to save
     ###########################################################################

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -371,18 +371,18 @@ def build_rig_json(old_rig, settings, water_calibration, laser_calibration):
     with open(old_rig_json_path, 'r') as f:
         old_rig_json = json.load(f)
 
-    logging.info('comparing with old rig json')
     differences = DeepDiff(new_rig_json, old_rig_json,ignore_order=True)
-    print(differences)
+    logging.info('comparing with old rig json: {}'.format(differences))
 
+    if len(differences) > 0:
+        # Write to file 
+        final_path = os.path.join(settings['rig_metadata_folder'],'rig_{}_{}.json'.format(settings['rig_name'], datetime.now().strftime('%Y-%m-%d_%H_%M_%S')))
+        os.rename(new_rig_json_path, final_path)
+        logging.info('Saving new rig json: rig{}'.format(final_path))
+    else:
+        os.remove(new_rig_json_path)
+        logging.info('Using existing rig json')
 
-
-    #if len(differences['values_changed']) > 0:
-    #    # Write to file 
-    #    suffix = '_{}_{}.json'.format(settings['rig_name'], datetime.now().strftime('%Y-%m-%d_%H_%M_%S'))
-    #    rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
-    #    logging.info('Saving new rig json: rig{}'.format(suffix))
-    #    logging.info('values changed: {}'.format(differences['values_changed'].keys()))
 
 
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -11,6 +11,9 @@ from aind_data_schema_models.modalities import Modality
 def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibration):    
     logging.info('building rig json')
 
+    # Build dictionaries of components
+    components = {}
+
     # TODO, what other modalities do we need to include?
     FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
     OPTO = False
@@ -18,6 +21,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     modalities = [Modality.BEHAVIOR]
     if FIB:
         modalities.append(Modality.FIB)
+    components['modalities'] = modalities
 
     cameras=[
         d.CameraAssembly(
@@ -322,7 +326,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     rig = r.Rig(
         rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
         modification_date=date.today(),
-        modalities= modalities,
+        **components,
         cameras=cameras,   
         patch_cords=patch_cords,
         light_sources=light_sources,

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -425,7 +425,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     ###########################################################################
     # Assemble rig schema
     rig = r.Rig(
-        rig_id="{}_{}".format(settings['rig_name'],datetime.now().strftime('%Y-%m-%d') 
+        rig_id="{}_{}".format(settings['rig_name'],datetime.now().strftime('%Y-%m-%d')), 
         modification_date=date.today(),
         **components 
         )

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -484,13 +484,13 @@ def parse_water_calibration(water_calibration):
         device_name = 'Lick spout Left',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
         input = {'valve open time (s):':''},
-        output = {'water volume (ul):':'')
+        output = {'water volume (ul):':''}
         )
     right = d.Calibration(
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Left',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
         input = {'valve open time (s):':''},
-        output = {'water volume (ul):':'')
+        output = {'water volume (ul):':''}
         )
     return left, right

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -12,7 +12,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
     logging.info('building rig json')
     rig = r.Rig(
         rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
-        modification_date=date(2000, 1, 1), # TODO
+        modification_date=date.today(),
         modalities=[Modality.FIB, Modality.BEHAVIOR], # TODO
         cameras=[
             d.CameraAssembly(
@@ -358,7 +358,6 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
     )
     logging.info('built rig json')
 
-
     # Write the new rig schema to a json file and load it back 
     # I do this to ignore serialization issues when comparing the rig.jsons 
     suffix = '_temp.json'
@@ -379,7 +378,6 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
         if len(differences['values_changed']) == 0:
             differences.pop('values_changed')
     logging.info('comparing with old rig json: {}'.format(differences))
-
 
     # If any differences remain, rename the temp file
     if len(differences) > 0:

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -32,6 +32,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
 
     # Cameras
     ###########################################################################
+    # TODO, ensure this toggles with rig
     components['cameras']=[
         d.CameraAssembly(
             name="BehaviorVideography_FaceSide",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -406,7 +406,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     ###########################################################################
     if OPTO:
         ##Optogenetics Specific   ## TODO Xinxin to fill in
-         
+        print('need to implement') 
         #components['light_sources'].append(
         #    d.LightEmittingDiode(
         #        name="LED for photostimulation",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -98,6 +98,23 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
 
     # Stimulus devices
     ###########################################################################
+    if settings['newscale_serial_num_box{}'.format(settings['box_number'])] != '':
+        stage = d.MotorizedStage(
+                    name="NewScaleMotor for LickSpouts",
+                    serial_number=settings['newscale_serial_num_box{}'.format(settings['box_number'])], 
+                    manufacturer=d.Organization.NEW_SCALE_TECHNOLOGIES,
+                    travel=15.0,  #unit is mm
+                    firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
+                    )
+    else:
+        # TODO
+        stage = d.MotorizedStage(
+                    name="AIND lick spout stage",
+                    serial_number="?", 
+                    manufacturer=d.Organization.NEW_SCALE_TECHNOLOGIES,
+                    travel=15.0,  #unit is mm
+                    firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
+                    )       
     components['stimulus_devices']=[
         d.RewardDelivery(
             reward_spouts=[
@@ -116,14 +133,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                     lick_sensor_type=d.LickSensorType("Capacitive")
                 ),
             ],
-            stage_type=d.MotorizedStage(
-                    name="NewScaleMotor for LickSpouts",
-                    serial_number="xxxx", #grabing from GUI/SettingFiles # TODO
-                    manufacturer=d.Organization.NEW_SCALE_TECHNOLOGIES,
-                    travel=15.0,  #unit is mm
-                    firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
-            ),
-            
+            stage_type = stage,
         ),
         ]
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -113,7 +113,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                     manufacturer=d.Organization.AIND,
                     travel=15.0,
                     )      
-    if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == 1):
+    if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1"):
         # TODO, need to add correct details
         lick_spouts=[
             d.RewardSpout(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -348,7 +348,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 computer_name="behavior_computer",
                 channels=[
                 ],
-            )]
+            )],
         
         #######################################################################################################
         ##Optogenetics Specific   ##Xinxin to fill in

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -18,6 +18,9 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
     # TODO, what other modalities do we need to include?
 
 
+
+
+
     cameras=[
         d.CameraAssembly(
             name="BehaviorVideography_FaceSide",
@@ -81,66 +84,10 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
         ),
     ]
 
-    # Assemble rig schema
-    rig = r.Rig(
-        rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
-        modification_date=date.today(),
-        modalities= modalities,
-        cameras=cameras,   
-        daqs=[
-            d.HarpDevice(
-                name="Harp Behavior",
-                harp_device_type=d.HarpDeviceType.BEHAVIOR,
-                core_version="2.1",
-                firmware_version="FTDI version:",
-                computer_name="behavior_computer", # TODO should this be hostname?
-                is_clock_generator=False,
-                channels=[
-                    d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
-                    d.DAQChannel(channel_name="DO1", device_name="Solenoid Right", channel_type="Digital Output"),
-                    d.DAQChannel(channel_name="DI0", device_name="Janelia_Lick_Detector Left", channel_type="Digital Input"), # TODO, need to check this
-                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input"), # TODO, need to check this
-                    d.DAQChannel(channel_name="DI3", device_name="Photometry Clock", channel_type="Digital Input"),
-                ],
-            )
-        ],
-        mouse_platform=d.Tube(name="mouse_tube_foraging", diameter=4.0),
-        stimulus_devices=[
-            d.RewardDelivery(
-                reward_spouts=[
-                    d.RewardSpout(
-                        name="Janelia_Lick_Detector Left",
-                        side=d.SpoutSide.LEFT,
-                        spout_diameter=1.2,
-                        solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
-                        lick_sensor_type=d.LickSensorType("Capacitive")
-                    ),
-                    d.RewardSpout(
-                        name="Janelia_Lick_Detector Right",
-                        side=d.SpoutSide.RIGHT,
-                        spout_diameter=1.2,
-                        solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
-                        lick_sensor_type=d.LickSensorType("Capacitive")
-                    ),
-                ],
-                stage_type=d.MotorizedStage(
-                        name="NewScaleMotor for LickSpouts",
-                        serial_number="xxxx", #grabing from GUI/SettingFiles # TODO
-                        manufacturer=d.Organization.NEW_SCALE_TECHNOLOGIES,
-                        travel=15.0,  #unit is mm
-                        firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
-                ),
-                
-            ),
-        ],
-        
-        
-        ## Common
-        #######################################################################################################
-        ##FIB Specific
-        
-        # TODO, need to toggle whether to include this       
- 
+    #######################################################################################################
+    ##FIB Specific
+
+    if settings['FIP_workflow_path'] != '':
         patch_cords=[
             d.Patch(
                 name="Bundle Branching Fiber-optic Patch Cord",
@@ -149,7 +96,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 core_diameter=200,
                 numerical_aperture=0.37,
             )
-        ],
+        ]
         light_sources=[
             d.LightEmittingDiode(
                 name="470nm LED",
@@ -169,7 +116,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 model="M565F3",
                 wavelength=565,
             ),
-        ],
+        ]
         detectors=[
             d.Detector(
                 name="Green CMOS",
@@ -207,7 +154,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 chroma="Monochrome",
                 bit_depth=16,
             ),
-        ],
+        ]
         objectives=[
             d.Objective(
                 name="Objective",
@@ -218,7 +165,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 magnification=10,
                 immersion="air",
             )
-        ],
+        ]
         filters=[
             d.Filter(
                 name="Green emission filter",
@@ -296,7 +243,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 width=35.6,
                 height=23.2,
             ),
-        ],
+        ]
         lenses=[
             d.Lens(
                 manufacturer=d.Organization.THORLABS,
@@ -305,11 +252,79 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 focal_length=80,
                 size=1,
             )
+        ]
+        
+        additional_devices=[d.Device(device_type="Photometry Clock", name="Photometry Clock")]
+    else:
+        patch_cords = []
+        light_sources = []
+        detectors = []
+        objectives = []
+        filters = []
+        lenses = []
+        additional_devices = []
+
+
+    # Assemble rig schema
+    rig = r.Rig(
+        rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
+        modification_date=date.today(),
+        modalities= modalities,
+        cameras=cameras,   
+        patch_cords=patch_cords,
+        light_sources=light_sources,
+        detectors=detectors,
+        objectives=objectives,
+        filters=filters,
+        lenses=lenses,
+        additional_devices=additional_devices,
+        daqs=[
+            d.HarpDevice(
+                name="Harp Behavior",
+                harp_device_type=d.HarpDeviceType.BEHAVIOR,
+                core_version="2.1",
+                firmware_version="FTDI version:",
+                computer_name="behavior_computer", # TODO should this be hostname?
+                is_clock_generator=False,
+                channels=[
+                    d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
+                    d.DAQChannel(channel_name="DO1", device_name="Solenoid Right", channel_type="Digital Output"),
+                    d.DAQChannel(channel_name="DI0", device_name="Janelia_Lick_Detector Left", channel_type="Digital Input"), # TODO, need to check this
+                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input"), # TODO, need to check this
+                    d.DAQChannel(channel_name="DI3", device_name="Photometry Clock", channel_type="Digital Input"),
+                ],
+            )
+        ],
+        mouse_platform=d.Tube(name="mouse_tube_foraging", diameter=4.0),
+        stimulus_devices=[
+            d.RewardDelivery(
+                reward_spouts=[
+                    d.RewardSpout(
+                        name="Janelia_Lick_Detector Left",
+                        side=d.SpoutSide.LEFT,
+                        spout_diameter=1.2,
+                        solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
+                        lick_sensor_type=d.LickSensorType("Capacitive")
+                    ),
+                    d.RewardSpout(
+                        name="Janelia_Lick_Detector Right",
+                        side=d.SpoutSide.RIGHT,
+                        spout_diameter=1.2,
+                        solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
+                        lick_sensor_type=d.LickSensorType("Capacitive")
+                    ),
+                ],
+                stage_type=d.MotorizedStage(
+                        name="NewScaleMotor for LickSpouts",
+                        serial_number="xxxx", #grabing from GUI/SettingFiles # TODO
+                        manufacturer=d.Organization.NEW_SCALE_TECHNOLOGIES,
+                        travel=15.0,  #unit is mm
+                        firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
+                ),
+                
+            ),
         ],
         
-        additional_devices=[d.Device(device_type="Photometry Clock", name="Photometry Clock")],
-        
-        ##FIB Specific
         #######################################################################################################
         ##Optogenetics Specific   ##Xinxin to fill in
         # TODO, need to toggle whether to include this, and fill it in       
@@ -377,7 +392,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
         new_rig_json = json.load(f)
 
     # Compare the two rig.jsons
-    differences = DeepDiff(new_rig_json, old_rig_json,ignore_order=True)
+    differences = DeepDiff(old_rig_json, new_rig_json,ignore_order=True)
 
     # Print differences
     logging.info('comparing with old rig json: {}'.format(differences))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -17,6 +17,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
     if FIB:
         modalities.append(Modality.FIB)
     # TODO, what other modalities do we need to include?
+    OPTO = False
 
     cameras=[
         d.CameraAssembly(
@@ -294,7 +295,29 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
             )
         ]
 
-
+    if OPTO:
+        ##Optogenetics Specific   ##Xinxin to fill in
+ 
+        light_sources.append(
+            d.LightEmittingDiode(
+                name="LED for photostimulation",
+                manufacturer=d.Organization.PRIZMATIX,
+                model="xxx",
+                wavelength=470,
+            )
+            )
+        
+        daqs.append(
+            d.DAQDevice(
+                name="NIDAQ for opto",
+                device_type="DAQ Device",
+                data_interface="USB2.0",
+                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
+                computer_name="behavior_computer",
+                channels=[
+                ],
+            )
+            )
 
     # Assemble rig schema
     rig = r.Rig(
@@ -339,41 +362,9 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 
             ),
         ],
-        daqs=[
-            d.DAQDevice(
-                name="NIDAQ for opto",
-                device_type="DAQ Device",
-                data_interface="USB2.0",
-                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-                computer_name="behavior_computer",
-                channels=[
-                ],
-            )],
+
         
-        #######################################################################################################
-        ##Optogenetics Specific   ##Xinxin to fill in
-        # TODO, need to toggle whether to include this, and fill it in       
- 
-        #light_sources=[
-        #    d.LightEmittingDiode(
-        #        name="LED for photostimulation",
-        #        manufacturer=d.Organization.PRIZMATIX,
-        #        model="xxx",
-        #        wavelength=470,
-        #    ),
-        #],
-        
-        #daqs=[
-        #    d.DAQDevice(
-        #        name="NIDAQ for opto",
-        #        device_type="DAQ Device",
-        #        data_interface="USB2.0",
-        #        manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-        #        computer_name="behavior_computer",
-        #        channels=[
-        #        ],
-        #    )
-        #],
+
         
         ##Optogenetics Specific
         #######################################################################################################

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -403,18 +403,15 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     # Compare the two rig.jsons
     differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
 
-    # Print differences
-    logging.info('comparing with old rig json: {}'.format(differences))
-
     # Remove the modification date, since that doesnt matter for comparison purposes
     if ('values_changed' in differences) and ("root['modification_date']" in differences['values_changed']):
         differences['values_changed'].pop("root['modification_date']")
         if len(differences['values_changed']) == 0:
             differences.pop('values_changed')
-    logging.info('comparing with old rig json: {}'.format(differences))
 
     # If any differences remain, rename the temp file
     if len(differences) > 0:
+        logging.info('differences with existing rig json: {}'.format(differences))
         # Write to file 
         time_str = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
         filename = 'rig_{}_{}.json'.format(settings['rig_name'],time_str )

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -110,6 +110,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
         stage = d.MotorizedStage(
                     name="AIND lick spout stage",
                     manufacturer=d.Organization.AIND
+                    travel=15.0,
                     )       
     components['stimulus_devices']=[
         d.RewardDelivery(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -10,73 +10,83 @@ from aind_data_schema_models.modalities import Modality
 
 def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration):    
     logging.info('building rig json')
+
+    # Determining if FIB rig
+    modalities = [Modality.BEHAVIOR]
+    if settings['FIP_workflow_path'] != '':
+        modalities.append(Modality.FIB)
+    # TODO, what other modalities do we need to include?
+
+
+    cameras=[
+        d.CameraAssembly(
+            name="BehaviorVideography_FaceSide",
+            #camera_assembly_name="BehaviorVideography_FaceBottom",
+            camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
+            camera=d.Camera(
+                name="Side face camera",
+                detector_type="Camera",
+                serial_number="TBD",
+                manufacturer=d.Organization.AILIPU,
+                model="ELP-USBFHD05MT-KL170IR",
+                notes="The light intensity sensor was removed; IR illumination is constantly on",
+                data_interface="USB",
+                computer_name="W10DTJK7N0M3",
+                max_frame_rate=120,
+                sensor_width=640,
+                sensor_height=480,
+                chroma="Color",
+                cooling="Air",
+                bin_mode="Additive",
+                recording_software=d.Software(name="Bonsai", version="2.5"),
+            ),
+            lens=d.Lens(
+                name="Xenocam 1",
+                model="XC0922LENS",
+                serial_number="unknown",
+                manufacturer=d.Organization.OTHER,
+                max_aperture="f/1.4",
+                notes='Focal Length 9-22mm 1/3" IR F1.4',
+            ),
+        ),
+        d.CameraAssembly(
+            name="BehaviorVideography_FaceBottom",
+            #camera_assembly_name="BehaviorVideography_FaceBottom",
+            camera_target=d.CameraTarget.FACE_BOTTOM,
+            camera=d.Camera(
+                name="Bottom face Camera",
+                detector_type="Camera",
+                serial_number="TBD",
+                manufacturer=d.Organization.AILIPU,
+                model="ELP-USBFHD05MT-KL170IR",
+                notes="The light intensity sensor was removed; IR illumination is constantly on",
+                data_interface="USB",
+                computer_name="W10DTJK7N0M3",
+                max_frame_rate=120,
+                sensor_width=640,
+                sensor_height=480,
+                chroma="Color",
+                cooling="Air",
+                bin_mode="Additive",
+                recording_software=d.Software(name="Bonsai", version="2.5"),
+            ),
+            lens=d.Lens(
+                name="Xenocam 2",
+                model="XC0922LENS",
+                serial_number="unknown",
+                manufacturer=d.Organization.OTHER,
+                max_aperture="f/1.4",
+                notes='Focal Length 9-22mm 1/3" IR F1.4',
+            ),
+        ),
+    ]
+
+    # Assemble rig schema
     rig = r.Rig(
         rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
         modification_date=date.today(),
-        modalities=[Modality.FIB, Modality.BEHAVIOR], # TODO
-        cameras=[
-            d.CameraAssembly(
-                name="BehaviorVideography_FaceSide",
-                #camera_assembly_name="BehaviorVideography_FaceBottom",
-                camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
-                camera=d.Camera(
-                    name="Side face camera",
-                    detector_type="Camera",
-                    serial_number="TBD",
-                    manufacturer=d.Organization.AILIPU,
-                    model="ELP-USBFHD05MT-KL170IR",
-                    notes="The light intensity sensor was removed; IR illumination is constantly on",
-                    data_interface="USB",
-                    computer_name="W10DTJK7N0M3",
-                    max_frame_rate=120,
-                    sensor_width=640,
-                    sensor_height=480,
-                    chroma="Color",
-                    cooling="Air",
-                    bin_mode="Additive",
-                    recording_software=d.Software(name="Bonsai", version="2.5"),
-                ),
-                lens=d.Lens(
-                    name="Xenocam 1",
-                    model="XC0922LENS",
-                    serial_number="unknown",
-                    manufacturer=d.Organization.OTHER,
-                    max_aperture="f/1.4",
-                    notes='Focal Length 9-22mm 1/3" IR F1.4',
-                ),
-            ),
-            d.CameraAssembly(
-                name="BehaviorVideography_FaceBottom",
-                #camera_assembly_name="BehaviorVideography_FaceBottom",
-                camera_target=d.CameraTarget.FACE_BOTTOM,
-                camera=d.Camera(
-                    name="Bottom face Camera",
-                    detector_type="Camera",
-                    serial_number="TBD",
-                    manufacturer=d.Organization.AILIPU,
-                    model="ELP-USBFHD05MT-KL170IR",
-                    notes="The light intensity sensor was removed; IR illumination is constantly on",
-                    data_interface="USB",
-                    computer_name="W10DTJK7N0M3",
-                    max_frame_rate=120,
-                    sensor_width=640,
-                    sensor_height=480,
-                    chroma="Color",
-                    cooling="Air",
-                    bin_mode="Additive",
-                    recording_software=d.Software(name="Bonsai", version="2.5"),
-                ),
-                lens=d.Lens(
-                    name="Xenocam 2",
-                    model="XC0922LENS",
-                    serial_number="unknown",
-                    manufacturer=d.Organization.OTHER,
-                    max_aperture="f/1.4",
-                    notes='Focal Length 9-22mm 1/3" IR F1.4',
-                ),
-            ),
-        ],
-        
+        modalities= modalities,
+        cameras=cameras,   
         daqs=[
             d.HarpDevice(
                 name="Harp Behavior",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -8,6 +8,8 @@ import aind_data_schema.core.rig as r
 import aind_data_schema.components.devices as d
 from aind_data_schema_models.modalities import Modality
 
+from foraging_gui.Visualization import GetWaterCalibration
+
 def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibration):    
 
     # Set up
@@ -476,13 +478,11 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
         logging.info('Using existing rig json')
 
 def parse_water_calibration(water_calibration):
-    sorted_dates = sorted(water_calibration.keys())
-    print(sorted_dates)
-    date = sorted_dates[-1]
-    left_times = list(water_calibration[date]['Left'].keys())
-    right_times = list(water_calibration[date]['Right'].keys())
-    left_volumes = [water_calibration[date]['Left'][x]['0.5']['200'][0] for x in left_times]
-    right_volumes = [water_calibration[date]['Right'][x]['0.5']['200'][0] for x in right_times]
+    
+    date = sorted(water_calibration.keys())[-1]
+    left_times, left_volumes = GetWaterCalibration(water_calibration, date, 'Left')
+    right_times, right_volumes = GetWaterCalibration(water_calibration, date, 'Right')
+
     left = d.Calibration(
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Left',
@@ -490,6 +490,7 @@ def parse_water_calibration(water_calibration):
         input = {'valve open time (s):':', '.join(left_times)},
         output = {'water volume (ul):':left_volumes}
         )
+
     right = d.Calibration(
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Right',
@@ -497,4 +498,7 @@ def parse_water_calibration(water_calibration):
         input = {'valve open time (s):':', '.join(right_times)},
         output = {'water volume (ul):':right_volumes}
         )
+
     return left, right
+
+

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -17,7 +17,8 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
     if FIB:
         modalities.append(Modality.FIB)
     # TODO, what other modalities do we need to include?
-    OPTO = False
+    OPTO = True
+
 
     cameras=[
         d.CameraAssembly(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -109,7 +109,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     else:
         stage = d.MotorizedStage(
                     name="AIND lick spout stage",
-                    manufacturer=d.Organization.AIND
+                    manufacturer=d.Organization.AIND,
                     travel=15.0,
                     )       
     components['stimulus_devices']=[

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -12,6 +12,47 @@ from foraging_gui.Visualization import GetWaterCalibration
 
 def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibration):    
 
+    # Build the new rig schema
+    rig = build_rig_json_core(settings, water_calibration, laser_calibration)
+
+    # Compare with existing rig schema
+    # Write the new rig schema to a json file and load it back 
+    # I do this to ignore serialization issues when comparing the rig.jsons 
+    suffix = '_temp.json'
+    rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
+    new_rig_json_path = os.path.join(settings['rig_metadata_folder'],'rig_temp.json')
+    with open(new_rig_json_path, 'r') as f:
+        new_rig_json = json.load(f)
+
+    # Compare the two rig.jsons
+    differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
+
+    # Remove the modification date, since that doesnt matter for comparison purposes
+    values_to_ignore = ['modification_date','rig_id']
+    for value in values_to_ignore:
+        if ('values_changed' in differences) and ("root['{}']".format(value) in differences['values_changed']):
+            differences['values_changed'].pop("root['{}']".format(value))
+            if len(differences['values_changed']) == 0:
+                differences.pop('values_changed')
+
+    # Determine which schema to use
+    if len(differences) > 0:
+        # If any differences remain, rename the temp file
+        logging.info('differences with existing rig json: {}'.format(differences))
+        # Write to file 
+        time_str = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
+        filename = 'rig_{}_{}.json'.format(settings['rig_name'],time_str )
+        final_path = os.path.join(settings['rig_metadata_folder'],filename)
+        os.rename(new_rig_json_path, final_path)
+        logging.info('Saving new rig json: {}'.format(filename))
+    else:
+        # Delete temp file
+        os.remove(new_rig_json_path)
+        logging.info('Using existing rig json')
+
+
+def build_rig_json_core(settings, water_calibration, laser_calibration):
+
     # Set up
     ###########################################################################
     logging.info('building rig json')
@@ -440,43 +481,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
         **components 
         )
     logging.info('finished building rig json')
-
-    # Compare with existing rig schema
-    ###########################################################################
-    # Write the new rig schema to a json file and load it back 
-    # I do this to ignore serialization issues when comparing the rig.jsons 
-    suffix = '_temp.json'
-    rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
-    new_rig_json_path = os.path.join(settings['rig_metadata_folder'],'rig_temp.json')
-    with open(new_rig_json_path, 'r') as f:
-        new_rig_json = json.load(f)
-
-    # Compare the two rig.jsons
-    differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
-
-    # Remove the modification date, since that doesnt matter for comparison purposes
-    values_to_ignore = ['modification_date','rig_id']
-    for value in values_to_ignore:
-        if ('values_changed' in differences) and ("root['{}']".format(value) in differences['values_changed']):
-            differences['values_changed'].pop("root['{}']".format(value))
-            if len(differences['values_changed']) == 0:
-                differences.pop('values_changed')
-
-    # Determine which schema to use
-    ###########################################################################
-    if len(differences) > 0:
-        # If any differences remain, rename the temp file
-        logging.info('differences with existing rig json: {}'.format(differences))
-        # Write to file 
-        time_str = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
-        filename = 'rig_{}_{}.json'.format(settings['rig_name'],time_str )
-        final_path = os.path.join(settings['rig_metadata_folder'],filename)
-        os.rename(new_rig_json_path, final_path)
-        logging.info('Saving new rig json: {}'.format(filename))
-    else:
-        # Delete temp file
-        os.remove(new_rig_json_path)
-        logging.info('Using existing rig json')
+    return rig
 
 def parse_water_calibration(water_calibration):
     

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -12,7 +12,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     logging.info('building rig json')
 
     # TODO, what other modalities do we need to include?
-    FIB = settings['FIP_workflow_path'] != ''
+    FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
     OPTO = False
 
     modalities = [Modality.BEHAVIOR]

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -255,29 +255,6 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
         ]
         
         additional_devices=[d.Device(device_type="Photometry Clock", name="Photometry Clock")]
-    else:
-        patch_cords = []
-        light_sources = []
-        detectors = []
-        objectives = []
-        filters = []
-        lenses = []
-        additional_devices = []
-
-
-    # Assemble rig schema
-    rig = r.Rig(
-        rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
-        modification_date=date.today(),
-        modalities= modalities,
-        cameras=cameras,   
-        patch_cords=patch_cords,
-        light_sources=light_sources,
-        detectors=detectors,
-        objectives=objectives,
-        filters=filters,
-        lenses=lenses,
-        additional_devices=additional_devices,
         daqs=[
             d.HarpDevice(
                 name="Harp Behavior",
@@ -294,7 +271,49 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                     d.DAQChannel(channel_name="DI3", device_name="Photometry Clock", channel_type="Digital Input"),
                 ],
             )
-        ],
+        ]
+    else:
+        patch_cords = []
+        light_sources = []
+        detectors = []
+        objectives = []
+        filters = []
+        lenses = []
+        additional_devices = []
+        daqs=[
+            d.HarpDevice(
+                name="Harp Behavior",
+                harp_device_type=d.HarpDeviceType.BEHAVIOR,
+                core_version="2.1",
+                firmware_version="FTDI version:",
+                computer_name="behavior_computer", # TODO should this be hostname?
+                is_clock_generator=False,
+                channels=[
+                    d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
+                    d.DAQChannel(channel_name="DO1", device_name="Solenoid Right", channel_type="Digital Output"),
+                    d.DAQChannel(channel_name="DI0", device_name="Janelia_Lick_Detector Left", channel_type="Digital Input"), # TODO, need to check this
+                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input"), # TODO, need to check this
+                    d.DAQChannel(channel_name="DI3", device_name="Photometry Clock", channel_type="Digital Input"),
+                ],
+            )
+        ]
+
+
+
+    # Assemble rig schema
+    rig = r.Rig(
+        rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
+        modification_date=date.today(),
+        modalities= modalities,
+        cameras=cameras,   
+        patch_cords=patch_cords,
+        light_sources=light_sources,
+        detectors=detectors,
+        objectives=objectives,
+        filters=filters,
+        lenses=lenses,
+        additional_devices=additional_devices,
+        daqs=daqs,
         mouse_platform=d.Tube(name="mouse_tube_foraging", diameter=4.0),
         stimulus_devices=[
             d.RewardDelivery(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -8,7 +8,7 @@ import aind_data_schema.core.rig as r
 import aind_data_schema.components.devices as d
 from aind_data_schema_models.modalities import Modality
 
-def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration):    
+def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibration):    
     logging.info('building rig json')
 
     # TODO, what other modalities do we need to include?
@@ -401,7 +401,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
         new_rig_json = json.load(f)
 
     # Compare the two rig.jsons
-    differences = DeepDiff(old_rig_json, new_rig_json,ignore_order=True)
+    differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
 
     # Print differences
     logging.info('comparing with old rig json: {}'.format(differences))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -372,7 +372,7 @@ def build_rig_json(old_rig, settings, water_calibration, laser_calibration):
         old_rig_json = json.load(f)
 
     logging.info('comparing with old rig json')
-    differences = DeepDiff(new_rig_json, old_rig_json)
+    differences = DeepDiff(new_rig_json, old_rig_json,ignore_order=True)
     print(differences)
 
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -479,18 +479,22 @@ def parse_water_calibration(water_calibration):
     sorted_dates = sorted(water_calibration.keys())
     print(sorted_dates)
     date = sorted_dates[-1]
+    left_times = list(water_calibration[date]['Left'].keys())
+    right_times = list(water_calibration[date]['Right'].keys())
+    left_volumes = [water_calibration[date]['Left'][x]['0.5']['200'][0] for x in left_times]
+    right_volumes = [water_calibration[date]['Right'][x]['0.5']['200'][0] for x in right_times]
     left = d.Calibration(
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
         device_name = 'Lick spout Left',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
-        input = {'valve open time (s):':', '.join(list(water_calibration[date]['Left'].keys()))},
-        output = {'water volume (ul):':''}
+        input = {'valve open time (s):':', '.join(left_times)},
+        output = {'water volume (ul):':left_volumes}
         )
     right = d.Calibration(
         calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
-        device_name = 'Lick spout Left',
+        device_name = 'Lick spout Right',
         description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
-        input = {'valve open time (s):':', '.join(list(water_calibration[date]['Right'].keys()))},
-        output = {'water volume (ul):':''}
+        input = {'valve open time (s):':', '.join(right_times)},
+        output = {'water volume (ul):':right_volumes}
         )
     return left, right

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -371,8 +371,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 channels=[
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
                     d.DAQChannel(channel_name="DO1", device_name="Solenoid Right", channel_type="Digital Output"),
-                    d.DAQChannel(channel_name="DI0", device_name="Janelia_Lick_Detector Left", channel_type="Digital Input"), # TODO, need to check this
-                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input"), # TODO, need to check this
+                    d.DAQChannel(channel_name="DI0", device_name=lick_spouts[0].name, channel_type="Digital Input"),
+                    d.DAQChannel(channel_name="DI1", device_name=lick_spouts[1].name, channel_type="Digital Input"),
                     d.DAQChannel(channel_name="DI3", device_name="Photometry Clock", channel_type="Digital Input"),
                 ],
             )
@@ -389,8 +389,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 channels=[
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
                     d.DAQChannel(channel_name="DO1", device_name="Solenoid Right", channel_type="Digital Output"),
-                    d.DAQChannel(channel_name="DI0", device_name="Janelia_Lick_Detector Left", channel_type="Digital Input"), # TODO, need to check this
-                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input") # TODO, need to check this
+                    d.DAQChannel(channel_name="DI0", device_name=lick_spouts[0].name, channel_type="Digital Input"),
+                    d.DAQChannel(channel_name="DI1", device_name=lick_spouts[1].name, channel_type="Digital Input") 
                 ],
             )
         ]

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -107,13 +107,9 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                     firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
                     )
     else:
-        # TODO
         stage = d.MotorizedStage(
                     name="AIND lick spout stage",
-                    serial_number="?", 
-                    manufacturer=d.Organization.NEW_SCALE_TECHNOLOGIES,
-                    travel=15.0,  #unit is mm
-                    firmware="https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497",
+                    manufacturer=d.Organization.AIND
                     )       
     components['stimulus_devices']=[
         d.RewardDelivery(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -292,8 +292,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
                     d.DAQChannel(channel_name="DO1", device_name="Solenoid Right", channel_type="Digital Output"),
                     d.DAQChannel(channel_name="DI0", device_name="Janelia_Lick_Detector Left", channel_type="Digital Input"), # TODO, need to check this
-                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input"), # TODO, need to check this
-                    d.DAQChannel(channel_name="DI3", device_name="Photometry Clock", channel_type="Digital Input"),
+                    d.DAQChannel(channel_name="DI1", device_name="Janelia_Lick_Detector Right", channel_type="Digital Input") # TODO, need to check this
                 ],
             )
         ]

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -308,17 +308,17 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
             )
             )
         
-        daqs.append(
-            d.DAQDevice(
-                name="NIDAQ for opto",
-                device_type="DAQ Device",
-                data_interface="USB2.0",
-                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-                computer_name="behavior_computer",
-                channels=[
-                ],
-            )
-            )
+        #daqs.append(
+        #    d.DAQDevice(
+        #        name="NIDAQ for opto",
+        #        device_type="DAQ Device",
+        #        data_interface="USB2.0",
+        #        manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
+        #        computer_name="behavior_computer",
+        #        channels=[
+        #        ],
+        #    )
+        #    )
 
     # Assemble rig schema
     rig = r.Rig(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -374,6 +374,14 @@ def build_rig_json(old_rig, settings, water_calibration, laser_calibration):
     differences = DeepDiff(new_rig_json, old_rig_json,ignore_order=True)
     logging.info('comparing with old rig json: {}'.format(differences))
 
+    if ('values_changed' in differences) and ("root['modification_date']" in differences['values_changed']):
+        differences['values_changed'].pop("root['modification_date']")
+        if len(differences['values_changed']) == 0:
+            differences.pop('values_changed')
+
+    logging.info('comparing with old rig json: {}'.format(differences))
+
+
     if len(differences) > 0:
         # Write to file 
         final_path = os.path.join(settings['rig_metadata_folder'],'rig_{}_{}.json'.format(settings['rig_name'], datetime.now().strftime('%Y-%m-%d_%H_%M_%S')))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -13,13 +13,10 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
 
     # Determining if FIB rig
     modalities = [Modality.BEHAVIOR]
-    if settings['FIP_workflow_path'] != '':
+    FIB = settings['FIP_workflow_path'] != ''
+    if FIB:
         modalities.append(Modality.FIB)
     # TODO, what other modalities do we need to include?
-
-
-
-
 
     cameras=[
         d.CameraAssembly(
@@ -87,7 +84,7 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
     #######################################################################################################
     ##FIB Specific
 
-    if settings['FIP_workflow_path'] != '':
+    if FIB:
         patch_cords=[
             d.Patch(
                 name="Bundle Branching Fiber-optic Patch Cord",
@@ -318,14 +315,14 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
             d.RewardDelivery(
                 reward_spouts=[
                     d.RewardSpout(
-                        name="Janelia_Lick_Detector Left",
+                        name="Janelia_Lick_Detector Left", # TODO
                         side=d.SpoutSide.LEFT,
                         spout_diameter=1.2,
                         solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
                         lick_sensor_type=d.LickSensorType("Capacitive")
                     ),
                     d.RewardSpout(
-                        name="Janelia_Lick_Detector Right",
+                        name="Janelia_Lick_Detector Right", # TODO
                         side=d.SpoutSide.RIGHT,
                         spout_diameter=1.2,
                         solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
@@ -342,6 +339,16 @@ def build_rig_json(old_rig_json, settings, water_calibration, laser_calibration)
                 
             ),
         ],
+        daqs=[
+            d.DAQDevice(
+                name="NIDAQ for opto",
+                device_type="DAQ Device",
+                data_interface="USB2.0",
+                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
+                computer_name="behavior_computer",
+                channels=[
+                ],
+            )]
         
         #######################################################################################################
         ##Optogenetics Specific   ##Xinxin to fill in

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -366,20 +366,23 @@ def build_rig_json(old_rig, settings, water_calibration, laser_calibration):
     with open(new_rig_json_path, 'r') as f:
         new_rig_json = json.load(f)
 
+    # Load most recent rig_json
+    old_rig_json_path = os.path.join(self.SettingFolder,'rig_metadata','rig_alex_laptop_2024-05-14_13_35_18.json')
+    with open(old_rig_json_path, 'r') as f:
+        old_rig_json = json.load(f)
 
     logging.info('comparing with old rig json')
-    differences = DeepDiff(new_rig_json, old_rig)
+    differences = DeepDiff(new_rig_json, old_rig_json)
     print(differences)
 
-    differences['values_changed'].pop("root['rig_id']")
-    differences['values_changed'].pop("root['modification_date']")
 
-    if len(differences['values_changed']) > 0:
-        # Write to file 
-        suffix = '_{}_{}.json'.format(settings['rig_name'], datetime.now().strftime('%Y-%m-%d_%H_%M_%S'))
-        rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
-        logging.info('Saving new rig json: rig{}'.format(suffix))
-        logging.info('values changed: {}'.format(differences['values_changed'].keys()))
+
+    #if len(differences['values_changed']) > 0:
+    #    # Write to file 
+    #    suffix = '_{}_{}.json'.format(settings['rig_name'], datetime.now().strftime('%Y-%m-%d_%H_%M_%S'))
+    #    rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
+    #    logging.info('Saving new rig json: rig{}'.format(suffix))
+    #    logging.info('values changed: {}'.format(differences['values_changed'].keys()))
 
 
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -18,12 +18,11 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
     OPTO = False
 
-    modalities = [Modality.BEHAVIOR]
+    components['modalities'] = [Modality.BEHAVIOR]
     if FIB:
-        modalities.append(Modality.FIB)
-    components['modalities'] = modalities
+        components['modalities'].append(Modality.FIB)
 
-    cameras=[
+    components['cameras']=[
         d.CameraAssembly(
             name="BehaviorVideography_FaceSide",
             #camera_assembly_name="BehaviorVideography_FaceBottom",
@@ -89,7 +88,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     #######################################################################################################
     ##FIB Specific
     if FIB:
-        patch_cords=[
+        components['patch_cords']=[
             d.Patch(
                 name="Bundle Branching Fiber-optic Patch Cord",
                 manufacturer=d.Organization.DORIC,
@@ -98,7 +97,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 numerical_aperture=0.37,
             )
         ]
-        light_sources=[
+
+        components['light_sources']=[
             d.LightEmittingDiode(
                 name="470nm LED",
                 manufacturer=d.Organization.THORLABS,
@@ -118,7 +118,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 wavelength=565,
             ),
         ]
-        detectors=[
+
+        components['detectors']=[
             d.Detector(
                 name="Green CMOS",
                 serial_number="21396991",
@@ -156,7 +157,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 bit_depth=16,
             ),
         ]
-        objectives=[
+
+        components['objectives']=[
             d.Objective(
                 name="Objective",
                 serial_number="128022336",
@@ -167,7 +169,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 immersion="air",
             )
         ]
-        filters=[
+
+        components['filters']=[
             d.Filter(
                 name="Green emission filter",
                 manufacturer=d.Organization.SEMROCK,
@@ -245,7 +248,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
                 height=23.2,
             ),
         ]
-        lenses=[
+        components['lenses']=[
             d.Lens(
                 manufacturer=d.Organization.THORLABS,
                 model="AC254-080-A-ML",
@@ -255,8 +258,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
             )
         ]
         
-        additional_devices=[d.Device(device_type="Photometry Clock", name="Photometry Clock")]
-        daqs=[
+        components['additional_devices']=[d.Device(device_type="Photometry Clock", name="Photometry Clock")]
+        components['daqs']=[
             d.HarpDevice(
                 name="Harp Behavior",
                 harp_device_type=d.HarpDeviceType.BEHAVIOR,
@@ -274,14 +277,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
             )
         ]
     else:
-        patch_cords = []
-        light_sources = []
-        detectors = []
-        objectives = []
-        filters = []
-        lenses = []
-        additional_devices = []
-        daqs=[
+        components['daqs']=[
             d.HarpDevice(
                 name="Harp Behavior",
                 harp_device_type=d.HarpDeviceType.BEHAVIOR,
@@ -301,7 +297,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     if OPTO:
         ##Optogenetics Specific   ##Xinxin to fill in
  
-        light_sources.append(
+        components['light_sources'].append(
             d.LightEmittingDiode(
                 name="LED for photostimulation",
                 manufacturer=d.Organization.PRIZMATIX,
@@ -327,15 +323,6 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
         rig_id="447_FIP/Behavior/Opt_FullModalityTemplate", ## TODO
         modification_date=date.today(),
         **components,
-        cameras=cameras,   
-        patch_cords=patch_cords,
-        light_sources=light_sources,
-        detectors=detectors,
-        objectives=objectives,
-        filters=filters,
-        lenses=lenses,
-        additional_devices=additional_devices,
-        daqs=daqs,
         mouse_platform=d.Tube(name="mouse_tube_foraging", diameter=4.0),
         stimulus_devices=[
             d.RewardDelivery(

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -204,7 +204,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
     nwbfile.add_trial_column(name='rewarded_historyR', description=f'The reward history of right lick port')
     nwbfile.add_trial_column(name='delay_start_time', description=f'The delay start time')
     nwbfile.add_trial_column(name='goCue_start_time', description=f'The go cue start time')
-    nwbfile.add_trial_column(name='reward_outcome_time', description=f'The reward outcome time (reward/no reward/no response)')
+    nwbfile.add_trial_column(name='reward_outcome_time', description=f'The reward outcome time (reward/no reward/no response). Note: This is in fact time when choice is registered.')
     ## training paramters ##
     # behavior structure
     nwbfile.add_trial_column(name='bait_left', description=f'Whether the current left lickport has a bait or not')
@@ -235,6 +235,8 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
     nwbfile.add_trial_column(name='response_duration', description=f'The maximum time that the animal must make a choce in order to get a reward')
     # reward consumption duration
     nwbfile.add_trial_column(name='reward_consumption_duration', description=f'The duration for the animal to consume the reward')
+    # reward delay
+    nwbfile.add_trial_column(name='reward_delay', description=f'The delay between choice and reward delivery')
     # auto water
     nwbfile.add_trial_column(name='auto_waterL', description=f'Autowater given at Left')
     nwbfile.add_trial_column(name='auto_waterR', description=f'Autowater given at Right')
@@ -368,6 +370,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
                         ITI_duration=obj.B_ITIHistory[i],
                         response_duration=float(obj.TP_ResponseTime[i]),
                         reward_consumption_duration=float(obj.TP_RewardConsumeTime[i]),
+                        reward_delay=float(obj.TP_RewardDelay[i]),
                         auto_waterL=obj.B_AutoWaterTrial[0][i] if type(obj.B_AutoWaterTrial[0]) is list else obj.B_AutoWaterTrial[i],   # Back-compatible with old autowater format
                         auto_waterR=obj.B_AutoWaterTrial[1][i] if type(obj.B_AutoWaterTrial[0]) is list else obj.B_AutoWaterTrial[i],
                         # optogenetics

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -406,26 +406,30 @@ class PlotWaterCalibration(FigureCanvas):
             self.ax1.plot(fit_x, fit_y,color=color,linestyle='--')
         return slope, intercept
     
-    def _GetWaterCalibration(self,WaterCalibrationResults,current_date,current_valve):
-        '''Get the water calibration results from a specific date and valve'''
-        X=[]
-        Y=[]
-        all_valve_opentime=WaterCalibrationResults[current_date][current_valve].keys()
-        for current_valve_opentime in all_valve_opentime:
-            average_water=[]
-            X.append(current_valve_opentime)
-            all_valve_openinterval=WaterCalibrationResults[current_date][current_valve][current_valve_opentime].keys()
-            for current_valve_openinterval in all_valve_openinterval:
-                all_cycle=WaterCalibrationResults[current_date][current_valve][current_valve_opentime][current_valve_openinterval].keys()
-                for current_cycle in all_cycle:
-                    total_water=np.nanmean(WaterCalibrationResults[current_date][current_valve][current_valve_opentime][current_valve_openinterval][current_cycle])
-                    if total_water != '':
-                        average_water.append(total_water/float(current_cycle))
-            Y.append(np.nanmean(average_water))
-        sorted_X=sorted(map(float, X))
-        sorted_indices = sorted(range(len(X)), key=lambda i: float(X[i]))
-        sorted_Y = [Y[i] for i in sorted_indices]
-        return sorted_X,sorted_Y
+    def _GetWaterCalibration(self,WaterCalibrationResult, current_date, current_valve):
+        x,y = GetWaterCalibration(WaterCalibrationResult, current_date, current_valve)   
+        return x, y
+ 
+def GetWaterCalibration(self,WaterCalibrationResults,current_date,current_valve):
+    '''Get the water calibration results from a specific date and valve'''
+    X=[]
+    Y=[]
+    all_valve_opentime=WaterCalibrationResults[current_date][current_valve].keys()
+    for current_valve_opentime in all_valve_opentime:
+        average_water=[]
+        X.append(current_valve_opentime)
+        all_valve_openinterval=WaterCalibrationResults[current_date][current_valve][current_valve_opentime].keys()
+        for current_valve_openinterval in all_valve_openinterval:
+            all_cycle=WaterCalibrationResults[current_date][current_valve][current_valve_opentime][current_valve_openinterval].keys()
+            for current_cycle in all_cycle:
+                total_water=np.nanmean(WaterCalibrationResults[current_date][current_valve][current_valve_opentime][current_valve_openinterval][current_cycle])
+                if total_water != '':
+                    average_water.append(total_water/float(current_cycle))
+        Y.append(np.nanmean(average_water))
+    sorted_X=sorted(map(float, X))
+    sorted_indices = sorted(range(len(X)), key=lambda i: float(X[i]))
+    sorted_Y = [Y[i] for i in sorted_indices]
+    return sorted_X,sorted_Y
 
 class PlotLickDistribution(FigureCanvas):
     def __init__(self,GeneratedTrials=None,dpi=100,width=5, height=4):

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -410,7 +410,7 @@ class PlotWaterCalibration(FigureCanvas):
         x,y = GetWaterCalibration(WaterCalibrationResult, current_date, current_valve)   
         return x, y
  
-def GetWaterCalibration(self,WaterCalibrationResults,current_date,current_valve):
+def GetWaterCalibration(WaterCalibrationResults,current_date,current_valve):
     '''Get the water calibration results from a specific date and valve'''
     X=[]
     Y=[]


### PR DESCRIPTION
The nwb file can be a bit misleading when the session has a '**reward delay**', which is a fixed delay between response and reward. 

In current version, '**reward_outome_time**' is the time when reward is determined. If a choice is made, it's time of first lick, if not, it's time of end of lick window. It makes sense in sessions where there's no reward delay. But when we introduce a reward delay, this time should be called '**response_time**' or 'decision_time' and additional '**reward_delay**' information (not saved in nwb yet) should be added to calculate time of outcome. 
 
Given how big impact this file may have downstream, minimum change is made here to enable analysis. One column called '**reward_delay**'  was added to NWB. 

Btw, one questions about our current behavior pipeline: if we update the generate nwb function, do previous sessions get re-processed? 