### PR TITLE
Add reward delivery to dev

### DIFF
--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -204,7 +204,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
     nwbfile.add_trial_column(name='rewarded_historyR', description=f'The reward history of right lick port')
     nwbfile.add_trial_column(name='delay_start_time', description=f'The delay start time')
     nwbfile.add_trial_column(name='goCue_start_time', description=f'The go cue start time')
-    nwbfile.add_trial_column(name='reward_outcome_time', description=f'The reward outcome time (reward/no reward/no response)')
+    nwbfile.add_trial_column(name='reward_outcome_time', description=f'The reward outcome time (reward/no reward/no response) Note: This is in fact time when choice is registered.')
     ## training paramters ##
     # behavior structure
     nwbfile.add_trial_column(name='bait_left', description=f'Whether the current left lickport has a bait or not')
@@ -235,6 +235,8 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
     nwbfile.add_trial_column(name='response_duration', description=f'The maximum time that the animal must make a choce in order to get a reward')
     # reward consumption duration
     nwbfile.add_trial_column(name='reward_consumption_duration', description=f'The duration for the animal to consume the reward')
+    # reward delay
+    nwbfile.add_trial_column(name='reward_delay', description=f'The delay between choice and reward delivery')
     # auto water
     nwbfile.add_trial_column(name='auto_waterL', description=f'Autowater given at Left')
     nwbfile.add_trial_column(name='auto_waterR', description=f'Autowater given at Right')
@@ -368,6 +370,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
                         ITI_duration=obj.B_ITIHistory[i],
                         response_duration=float(obj.TP_ResponseTime[i]),
                         reward_consumption_duration=float(obj.TP_RewardConsumeTime[i]),
+                        reward_delay=float(obj.TP_RewardDelay[i]),
                         auto_waterL=obj.B_AutoWaterTrial[0][i] if type(obj.B_AutoWaterTrial[0]) is list else obj.B_AutoWaterTrial[i],   # Back-compatible with old autowater format
                         auto_waterR=obj.B_AutoWaterTrial[1][i] if type(obj.B_AutoWaterTrial[0]) is list else obj.B_AutoWaterTrial[i],
                         # optogenetics

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -370,7 +370,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
                         ITI_duration=obj.B_ITIHistory[i],
                         response_duration=float(obj.TP_ResponseTime[i]),
                         reward_consumption_duration=float(obj.TP_RewardConsumeTime[i]),
-                        reward_delay=float(obj.TP_RewardDelay[i]),
+                        reward_delay=float(_get_field(obj, 'TP_RewardDelay', index=i, default=0)),
                         auto_waterL=obj.B_AutoWaterTrial[0][i] if type(obj.B_AutoWaterTrial[0]) is list else obj.B_AutoWaterTrial[i],   # Back-compatible with old autowater format
                         auto_waterR=obj.B_AutoWaterTrial[1][i] if type(obj.B_AutoWaterTrial[0]) is list else obj.B_AutoWaterTrial[i],
                         # optogenetics


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Added 'reward delay' field to nwb.trials. It is a delay between choice time and reward delivery.
2. Additional description about 'reward_outcome_time': It is time when choice is registered. 
### What issues or discussions does this update address?
This columns makes it possible to calculate actual reward delivery time when there's a reward delay in session.
### Describe the expected change in behavior from the perspective of the experimenter
There will be no change in behavior. 
### Describe any manual update steps for task computers
There will be no manual update,
### Was this update tested in 446/447?
No, it is tested locally on my laptop and desktop. 

Additional info:

In current version, 'reward_outome_time' is the time when reward is determined, not when it is delivered. If a choice is made, it's time of first lick, if not, it's time of end of lick window. It makes sense in sessions where there's no reward delay. But when we introduce a reward delay, this time should be called 'response_time' or 'decision_time' and additional 'reward_delay' information (not saved in nwb yet) should be added to calculate time of outcome.

Given how big impact this file may have downstream, minimum change is made here to enable analysis. One column called 'reward_delay' was added to NWB.





