### PR TITLE
Finishing implementation of rig.json generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "harp-python",
     "deepdiff",
     "aind-data-schema==0.36.0",
-    "aind-data-schema-models==0.1.1"
+    "aind-data-schema-models==0.1.5"
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests
 harp-python
 deepdiff
 aind-data-schema==0.36.0
-aind-data-schema-models==0.1.1
+aind-data-schema-models==0.1.5

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1199,7 +1199,7 @@ class Window(QMainWindow):
 
     def _get_bonsai_version(self,config_path):
         with open(config_path, "r") as f:
-            for line in fp:
+            for line in f:
                 if 'Package id="Bonsai"' in line:
                    return line.split('version="')[1].split('"')[0] 
         return '0.0.0'

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -73,7 +73,6 @@ class Window(QMainWindow):
         self.WaterCalibrationFiles=os.path.join(self.SettingFolder,'WaterCalibration_{}.json'.format(box_number))
         self.WaterCalibrationParFiles=os.path.join(self.SettingFolder,'WaterCalibrationPar_{}.json'.format(box_number))
         self.TrainingStageFiles=os.path.join(self.SettingFolder,'TrainingStagePar.json')
-        self.rig_specification = os.path.join(self.SettingFolder, 'rig_specification_{}.json'.format(box_number))
 
         # Load Laser and Water Calibration Files
         self._GetLaserCalibration()
@@ -1156,19 +1155,6 @@ class Window(QMainWindow):
             print('making directory: {}'.format(self.Settings['rig_metadata_folder']))
             os.makedirs(self.Settings['rig_metadata_folder'])
               
-        # Load rig_specification.json
-        if os.path.isfile(self.rig_specification):
-            logging.info('Loading rig specification file')
-            try:
-                with open(self.rig_specification, 'r') as f:
-                    rig_specification = json.load(f)
-            except Exception as e:
-                logging.error('Error loading rig specification file: {}'.format(e))
-                rig_specification = {}
-        else:
-            logging.info('Cannot find rig specification file: {}'.format(self.rig_specification))
-            rig_specification = {}
-        
         # Load most recent rig_json
         files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
         files = [f.__str__().split('\\')[-1] for f in files]
@@ -1189,7 +1175,6 @@ class Window(QMainWindow):
         rig_settings['box_number'] = self.box_number
         df = pd.read_csv(self.SettingsBoxFile,index_col=None,header=None)
         rig_settings['box_settings'] = {row[0]:row[1] for index, row in df.iterrows()}
-        rig_settings['rig_specification'] = rig_specification
         rig_settings['computer_name'] = socket.gethostname()
         rig_settings['bonsai_version'] = self._get_bonsai_version(rig_settings['bonsai_config_path'])
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -919,6 +919,7 @@ class Window(QMainWindow):
             'Teensy_COM_box4':'',
             'FIP_workflow_path':'',
             'bonsai_path':os.path.join(os.path.dirname(os.path.dirname(os.getcwd())),'bonsai','Bonsai.exe'),
+            'bonsai_config_path':os.path.join(os.path.dirname(os.path.dirname(os.getcwd())),'bonsai','Bonsai.config'),
             'bonsaiworkflow_path':os.path.join(os.path.dirname(os.getcwd()),'workflows','foraging.bonsai'),
             'newscale_serial_num_box1':'',
             'newscale_serial_num_box2':'',
@@ -1189,10 +1190,19 @@ class Window(QMainWindow):
         df = pd.read_csv(self.SettingsBoxFile,index_col=None,header=None)
         rig_settings['box_settings'] = {row[0]:row[1] for index, row in df.iterrows()}
         rig_settings['rig_specification'] = rig_specification
+        rig_settings['computer_name'] = socket.gethostname()
+        rig_settings['bonsai_version'] = self._get_bonsai_version(rig_settings['bonsai_config_path'])
  
         build_rig_json(existing_rig_json, rig_settings, 
             self.WaterCalibrationResults, 
             self.LaserCalibrationResults)        
+
+    def _get_bonsai_version(self,config_path):
+        with open(config_path, "r") as f:
+            for line in fp:
+                if 'Package id="Bonsai"' in line:
+                   return line.split('version="')[1].split('"')[0] 
+        return '0.0.0'
 
     def _OpenSettingFolder(self):
         '''Open the setting folder'''

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -79,20 +79,12 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
 
     # Cameras 
     ###########################################################################
-    lens=d.Lens( 
-        name="Behavior Video Lens Right Side",
-        manufacturer=d.Organization.FUJINON,
-        focal_length=16,
-        focal_length_unit=SizeUnit.MM,
-        model="CF16ZA-1S",
-        )
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
         if False:#RIGHT_CAMERA:
             components['cameras'].append(
                 d.CameraAssembly(
                     name="Right Camera assembly",
-                    computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                     lens=d.Lens( 
                         name="Behavior Video Lens Right Side",
@@ -106,6 +98,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         detector_type="Camera",
                         manufacturer=d.Organization.FLIR,
                         data_interface="USB",
+                        computer_name=settings['computer_name'],
                         chroma="Monochrome",
                         cooling="Air", 
                         sensor_format="1/2.9",
@@ -122,7 +115,6 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             components['cameras'].append(
                 d.CameraAssembly(
                     name="Bottom Camera assembly",
-                    computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
                     lens=d.Lens(
                         name="Behavior Video Lens Bottom of face", 
@@ -134,6 +126,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         ), 
                     camera=d.Camera(
                         name="bottom of face camera",
+                        computer_name=settings['computer_name'],
                         detector_type="Camera",
                         manufacturer=d.Organization.FLIR,
                         data_interface="USB",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -538,7 +538,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             d.Laser(
                 name="Optogenetics Laser 1",
                 manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer']),
-                wavelength=getattr(d.Organization,settings['box_settings']['OptoLaser1Wavelength']),
+                wavelength=settings['box_settings']['OptoLaser1Wavelength'],
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser1Model"],
                 serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
@@ -546,7 +546,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             d.Laser(
                 name="Optogenetics Laser 2",
                 manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer']),
-                wavelength=getattr(d.Organization,settings['box_settings']['OptoLaser2Wavelength']),
+                wavelength=settings['box_settings']['OptoLaser2Wavelength'],
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser2Model"],
                 serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -349,7 +349,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             ),
             d.Detector(
                 name="Red CMOS",
-                serial_number=settings["box_settings"]["FipRedCMOSSerialNumber"],,
+                serial_number=settings["box_settings"]["FipRedCMOSSerialNumber"],
                 manufacturer=d.Organization.FLIR,
                 model="BFS-U3-20S40M",
                 detector_type="Camera",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -617,7 +617,7 @@ def parse_laser_calibration(laser_calibration):
                         voltage, power = zip(*sorted(zip(voltage, power), key=lambda x: x[0]))
                         
                         datestr = datetime.strptime(latest_calibration_date,'%Y-%m-%d').date()
-                        description= f'Optogenetic calibration for {laser}, Laser_{laser_name}, protocol: {protocol}, frequency: {freq}.'
+                        description= f'Optogenetic calibration for {laser} {laser_name}, protocol: {protocol}, frequency: {freq}.'
                         calibrations.append(
                             d.Calibration(
                                 calibration_date = datestr,
@@ -635,7 +635,7 @@ def parse_laser_calibration(laser_calibration):
                     voltage, power = zip(*sorted(zip(voltage, power), key=lambda x: x[0]))
                     
                     datestr = datetime.strptime(latest_calibration_date,'%Y-%m-%d').date()
-                    description= f'Optogenetic calibration for {laser}, Laser_{laser_name}, protocol: {protocol}'
+                    description= f'Optogenetic calibration for {laser} {laser_name}, protocol: {protocol}'
                     calibrations.append(
                         d.Calibration(
                             calibration_date = datestr,

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -66,8 +66,6 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     HIGH_SPEED_CAMERA = ('HighSpeedCamera' in settings['box_settings']) and (settings['box_settings']['HighSpeedCamera'] == "1")
     RIGHT_CAMERA = ('HasSideCameraRight' in settings['box_settings']) and (settings['box_settings']['HasSideCameraRight'] == "1")
     BOTTOM_CAMERA = ('HasBottomCamera' in settings['box_settings']) and (settings['box_settings']['HasBottomCamera'] == "1")
-    AIND_LICK_DETECTOR = ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1")
-
 
     # Modalities
     ###########################################################################
@@ -324,7 +322,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ]
 
 
-    # Calibrations
+    # Water Calibration
     ###########################################################################
 
     components['calibrations']=[]
@@ -340,6 +338,9 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ###########################################################################
     if FIB:
         # TODO FIB calibration needs to be recorded and incorporated here
+        # This is waiting for the FIB calibration to be tracked after upcoming
+        # hardware/firmware changes
+
         components['patch_cords']=[
             d.Patch(
                 name="Bundle Branching Fiber-optic Patch Cord",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -530,6 +530,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 data_interface=d.DataInterface.USB,
                 manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
                 model="USB-6002",
+                computer_name=settings['computer_name'],
             )
         )
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -102,7 +102,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         model="CF16ZA-1S",
                         ),
                     camera=d.Camera(
-                        name = "Right size of face camera"
+                        name = "Right size of face camera",
                         detector_type="Camera",
                         manufacturer=d.Organization.FLIR,
                         data_interface="USB",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -60,9 +60,15 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     # Build dictionary of components
     components = {}
 
-    # Determine what extra components are present
+    # Determine what extra components are present using settings files
     FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
     OPTO = ('HasOpto' in settings['box_settings']) and (settings['box_settings']['HasOpto'] == "1")
+    HIGH_SPEED_CAMERA = ('HighSpeedCamera' in settings['box_settings']) and (settings['box_settings']['HighSpeedCamera'] == "1")
+    LEFT_CAMERA = ('HasSideCameraLeft' in settings['box_settings']) and (settings['HasSideCameraLeft'] == "1")
+    RIGHT_CAMERA = ('HasSideCameraRight' in settings['box_settings']) and (settings['HasSideCameraRight'] == "1")
+    BODY_CAMERA = ('HasBodyCamera' in settings['box_settings']) and (settings['HasBodyCamera'] == "1")
+    BOTTOM_CAMERA = ('HasBottomCamera' in settings['box_settings']) and (settings['HasBottomCamera'] == "1")
+    AIND_LICK_DETECTOR = ('AINDLickDetector' in settings['box_settings']) and (settings['AINDLickDetector'] == "1")
 
     # Modalities
     ###########################################################################
@@ -71,10 +77,8 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     if FIB:
         components['modalities'].append(Modality.FIB)
 
-
     # Cameras
     ###########################################################################
-    # TODO, ensure this toggles with rig
     components['cameras']=[
         d.CameraAssembly(
             name="BehaviorVideography_FaceSide",
@@ -88,14 +92,14 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 model="ELP-USBFHD05MT-KL170IR",
                 notes="The light intensity sensor was removed; IR illumination is constantly on",
                 data_interface="USB",
-                computer_name="W10DTJK7N0M3",
+                computer_name=settings['computer_name'],
                 max_frame_rate=120,
                 sensor_width=640,
                 sensor_height=480,
                 chroma="Color",
                 cooling="Air",
                 bin_mode="Additive",
-                recording_software=d.Software(name="Bonsai", version="2.5"),
+                recording_software=d.Software(name="Bonsai", version=settings['bonsai_version']),
             ),
             lens=d.Lens(
                 name="Xenocam 1",
@@ -118,14 +122,14 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 model="ELP-USBFHD05MT-KL170IR",
                 notes="The light intensity sensor was removed; IR illumination is constantly on",
                 data_interface="USB",
-                computer_name="W10DTJK7N0M3",
+                computer_name=settings['computer_name'],
                 max_frame_rate=120,
                 sensor_width=640,
                 sensor_height=480,
                 chroma="Color",
                 cooling="Air",
                 bin_mode="Additive",
-                recording_software=d.Software(name="Bonsai", version="2.5"),
+                recording_software=d.Software(name="Bonsai", version=settings['bonsai_version']),
             ),
             lens=d.Lens(
                 name="Xenocam 2",
@@ -418,7 +422,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 harp_device_type=d.HarpDeviceType.BEHAVIOR,
                 core_version="2.1",
                 firmware_version="FTDI version:",
-                computer_name="behavior_computer", 
+                computer_name=settings['computer_name'], 
                 is_clock_generator=False,
                 channels=[
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
@@ -436,7 +440,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 harp_device_type=d.HarpDeviceType.BEHAVIOR,
                 core_version="2.1",
                 firmware_version="FTDI version:",
-                computer_name="behavior_computer", 
+                computer_name=settings['computer_name'], 
                 is_clock_generator=False,
                 channels=[
                     d.DAQChannel(channel_name="DO0", device_name="Solenoid Left", channel_type="Digital Output"),
@@ -467,7 +471,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         #        device_type="DAQ Device",
         #        data_interface="USB2.0",
         #        manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-        #        computer_name="behavior_computer",
+        #        computer_name=settings['computer_name'],
         #        channels=[
         #        ],
         #    )
@@ -483,6 +487,18 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         )
     logging.info('finished building rig json')
     return rig
+
+    # TODO
+    # Cameras
+    # Platforms
+    # FIP
+    # OPTO
+    # Speaker
+    # Reward/lick spouts
+    # Lick spout stages
+    # Lick detector
+    # Harp boards
+    # Parse laser calibration
 
 def parse_water_calibration(water_calibration):
     

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -124,7 +124,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
                     lens=d.Lens( 
-                        manufacturer=d.Organization.KOWA,
+                        manufacturer=d.Organization.Other(name="Kowa"),
                         focal_length=25,
                         focal_length_unit=SizeUnit.MM,
                         model="LM25HC",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -520,12 +520,10 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ###########################################################################
     if OPTO:
         # TODO Xinxin to fill in
-        # Lasers/LEDS?
-        # Filters?
-        # Cables?
-        # Laser calibration
+        # Cables/Fibers/patch_cords?
+        # Laser Assembly?
  
-        daqs.append(
+        components['daqs'].append(
             d.DAQDevice(
                 name="optogenetics nidaq",
                 device_type="DAQ_Device",
@@ -535,68 +533,30 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         )
 
-        # Copied from other repo
-        #Oxxius_Lasers_473_1={
-        #    "name":"Oxxius Laser 473-1",
-        #    "device_type":"Laser",
-        #    "manufacturer":Organization.OXXIUS,
-        #    "wavelength":473,
-        #    "wavelength_unit":SizeUnit.NM,
-        #    "model": "L6CC-CSB-2422",
-        #    "serial_number": "LNC-00771",
-        #}
+        components['stimulus_devices'].append(
+            d.Laser(
+                name="Optogenetics Laser 1",
+                manufacturer=getattr(Organization,settings['box_settings']['OptoLaser1Manufacturer']),
+                wavelength=getattr(Organization,settings['box_settings']['OptoLaser1Wavelength']),
+                wavelength_unit=SizeUnit.NM,
+                model=settings["box_settings"]["OptoLaser1Model"],
+                serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
+            )
+            d.Laser(
+                name="Optogenetics Laser 2",
+                manufacturer=getattr(Organization,settings['box_settings']['OptoLaser2Manufacturer']),
+                wavelength=getattr(Organization,settings['box_settings']['OptoLaser2Wavelength']),
+                wavelength_unit=SizeUnit.NM,
+                model=settings["box_settings"]["OptoLaser2Model"],
+                serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
+            )
+        )
 
+        # TODO Laser calibration
 
-        #Oxxius_Lasers_473_2={
-        #    "name":"Oxxius Laser 473-2",
-        #    "device_type":"Laser",
-        #    "manufacturer":Organization.OXXIUS,
-        #    "wavelength":473,
-        #    "wavelength_unit":SizeUnit.NM,
-        #    "model": "L6CC-CSB-2422",
-        #    "serial_number": "LNC-00771",
-        #}
-
-        #Oxxius_Lasers_561_1={
-        #    "name":"Oxxius Laser 561-1",
-        #    "device_type":"Laser",
-        #    "manufacturer":Organization.OXXIUS,
-        #    "wavelength":473,
-        #    "wavelength_unit":SizeUnit.NM,
-        #    "model": "L6CC-CSB-2422",
-        #    "serial_number": "LNC-00771",
-        #}
-
-        #Oxxius_Lasers_561_2={
-        #    "name":"Oxxius Laser 561-2",
-        #    "device_type":"Laser",
-        #    "manufacturer":Organization.OXXIUS,
-        #    "wavelength":473,
-        #    "wavelength_unit":SizeUnit.NM,
-        #    "model": "L6CC-CSB-2422",
-        #    "serial_number": "LNC-00771",
-        #}
-
-        #Oxxius_Lasers_638_1={
-        #    "name":"Oxxius Laser 638-1",
-        #    "device_type":"Laser",
-        #    "manufacturer":Organization.OXXIUS,
-        #    "wavelength":473,
-        #    "wavelength_unit":SizeUnit.NM,
-        #    "model": "L6CC-CSB-2422",
-        #    "serial_number": "LNC-00771",
-        #}
-
-        #Oxxius_Lasers_638_2={
-        #    "name":"Oxxius Laser 638-2",
-        #    "device_type":"Laser",
-        #    "manufacturer":Organization.OXXIUS,
-        #    "wavelength":473,
-        #    "wavelength_unit":SizeUnit.NM,
-        #    "model": "L6CC-CSB-2422",
-        #    "serial_number": "LNC-00771",
-        #}
-
+    # laser calibration
+    if laser_calibration != {}:
+        components['calibrations'].extend(parse_laser_calibration(laser_calibration))
 
     # Generate Rig Schema
     ###########################################################################
@@ -634,4 +594,24 @@ def parse_water_calibration(water_calibration):
 
     return left, right
 
+def parse_laser_calibration(laser_calibration):
+    calibrations = []
+
+    laser1 = d.Calibration(
+        calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
+        device_name = 'Laser 1 Calibration',
+        description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
+        input = {'valve open time (s):':left_times},
+        output = {'water volume (ul):':left_volumes}
+        )
+
+    laser2 = d.Calibration(
+        calibration_date=datetime.strptime(date, "%Y-%m-%d").date(),
+        device_name = 'Laser 2 Calibration',
+        description = 'Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters.',
+        input = {'valve open time (s):':right_times},
+        output = {'water volume (ul):':right_volumes}
+        )
+
+    return calibrations
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -331,7 +331,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         components['detectors']=[
             d.Detector(
                 name="Green CMOS",
-                serial_number="21396991",
+                serial_number=settings["box_settings"]["FipGreenCMOSSerialNumber"],
                 manufacturer=d.Organization.FLIR,
                 model="BFS-U3-20S40M",
                 detector_type="Camera",
@@ -349,7 +349,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             ),
             d.Detector(
                 name="Red CMOS",
-                serial_number="21396991",
+                serial_number=settings["box_settings"]["FipRedCMOSSerialNumber"],,
                 manufacturer=d.Organization.FLIR,
                 model="BFS-U3-20S40M",
                 detector_type="Camera",
@@ -370,7 +370,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         components['objectives']=[
             d.Objective(
                 name="Objective",
-                serial_number="128022336",
+                serial_number=settings['box_settings']['FipObjectiveSerialNumber'],
                 manufacturer=d.Organization.NIKON,
                 model="CFI Plan Apochromat Lambda D 10x",
                 numerical_aperture=0.45,

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -89,7 +89,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                     lens=d.Lens( 
                         manufacturer=d.Organization.FUJINON,
-                        focal_length=16
+                        focal_length=16,
                         focal_length_unit=SizeUnit.MM,
                         model="CF16ZA-1S",
                         ),

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -213,7 +213,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         d.HarpDevice(
             name="Harp Behavior",
             harp_device_type=d.HarpDeviceType.BEHAVIOR,
-            manufacturer:d.Organization.CHAMPALIMAUD,
+            manufacturer=d.Organization.CHAMPALIMAUD,
             core_version="2.1",
             firmware_version="FTDI version:",
             computer_name=settings['computer_name'], 
@@ -224,31 +224,31 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 d.DAQChannel(channel_name="DI0", device_name=lick_spouts[0].name, channel_type="Digital Input"),
                 d.DAQChannel(channel_name="DI1", device_name=lick_spouts[1].name, channel_type="Digital Input") 
             ],
-        )
+        ),
         d.HarpDevice(
             name="Harp Sound",
             harp_device_type=d.HarpDeviceType.SOUND_CARD,
-            manufacturer:d.Organization.CHAMPALIMAUD,
+            manufacturer=d.Organization.CHAMPALIMAUD,
             core_version="2.1",
             firmware_version="FTDI version:",
             computer_name=settings['computer_name'], 
             is_clock_generator=False,
             data_interface=d.DataInterface.USB
-        )
+        ),
         d.HarpDevice(
             name="Harp clock synchronization board",
             harp_device_type=d.HarpDeviceType.CLOCK_SYNCHRONIZER,
-            manufacturer:d.Organization.CHAMPALIMAUD,
+            manufacturer=d.Organization.CHAMPALIMAUD,
             core_version="2.1",
             firmware_version="FTDI version:",
             computer_name=settings['computer_name'], 
             is_clock_generator=True,
             data_interface=d.DataInterface.USB
-        )       
+        ),       
         d.HarpDevice(
             name="Harp sound amplifier",
             harp_device_type=d.HarpDeviceType.INPUT_EXPANDER,
-            manufacturer:d.Organization.CHAMPALIMAUD,
+            manufacturer=d.Organization.CHAMPALIMAUD,
             core_version="2.1",
             firmware_version="FTDI version:",
             computer_name=settings['computer_name'], 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -79,7 +79,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         components['modalities'].append(Modality.FIB)
 
 
-    # Cameras # TODO
+    # Cameras 
     ###########################################################################
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
@@ -236,7 +236,8 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         stage = d.MotorizedStage(
                     name="AIND lick spout stage",
                     manufacturer=d.Organization.AIND,
-                    travel=0, #TODO, need to fill in this value
+                    travel=30, 
+                    travel_unit=SizeUnit.MM
                     )      
 
     if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1"):

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -535,24 +535,24 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         #    )
         #)
 
-        components['stimulus_devices'].extend([
-            d.Laser(
-                name="Optogenetics Laser 1",
-                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
-                wavelength=settings['box_settings']['OptoLaser1Wavelength'],
-                wavelength_unit=SizeUnit.NM,
-                model=settings["box_settings"]["OptoLaser1Model"],
-                serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-            ),
-            d.Laser(
-                name="Optogenetics Laser 2",
-                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),
-                wavelength=settings['box_settings']['OptoLaser2Wavelength'],
-                wavelength_unit=SizeUnit.NM,
-                model=settings["box_settings"]["OptoLaser2Model"],
-                serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
-            )
-        ])
+        #components['stimulus_devices'].append(
+        #    d.Laser(
+        #        name="Optogenetics Laser 1",
+        #        manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
+        #        wavelength=settings['box_settings']['OptoLaser1Wavelength'],
+        #        wavelength_unit=SizeUnit.NM,
+        #        model=settings["box_settings"]["OptoLaser1Model"],
+        #        serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
+        #    ))
+        #components['stimulus_devices'].append(
+        #    d.Laser(
+        #        name="Optogenetics Laser 2",
+        #        manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),
+        #        wavelength=settings['box_settings']['OptoLaser2Wavelength'],
+        #        wavelength_unit=SizeUnit.NM,
+        #        model=settings["box_settings"]["OptoLaser2Model"],
+        #        serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
+        #    ))
 
         # laser calibration
         components['calibrations'].extend(parse_laser_calibration(laser_calibration))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -64,9 +64,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
     OPTO = ('HasOpto' in settings['box_settings']) and (settings['box_settings']['HasOpto'] == "1")
     HIGH_SPEED_CAMERA = ('HighSpeedCamera' in settings['box_settings']) and (settings['box_settings']['HighSpeedCamera'] == "1")
-    LEFT_CAMERA = ('HasSideCameraLeft' in settings['box_settings']) and (settings['box_settings']['HasSideCameraLeft'] == "1")
     RIGHT_CAMERA = ('HasSideCameraRight' in settings['box_settings']) and (settings['box_settings']['HasSideCameraRight'] == "1")
-    BODY_CAMERA = ('HasBodyCamera' in settings['box_settings']) and (settings['box_settings']['HasBodyCamera'] == "1")
     BOTTOM_CAMERA = ('HasBottomCamera' in settings['box_settings']) and (settings['box_settings']['HasBottomCamera'] == "1")
     AIND_LICK_DETECTOR = ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1")
 
@@ -83,12 +81,12 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ###########################################################################
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
-        if LEFT_CAMERA:
+        if RIGHT_CAMERA:
             components['cameras'].append(
                 d.CameraAssembly(
-                    name="Left Camera",
+                    name="Right Camera",
                     computer_name=settings['computer_name'],
-                    camera_target=d.CameraTarget.FACE_SIDE_LEFT,
+                    camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                     lens=d.Lens( 
                         manufacturer=d.Organization.FUJINON,
                         focal_length=16
@@ -107,15 +105,8 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         sensor_height=540,
                         max_frame_rate=522,
                         model="Blackfly S BFS-U3-04S2M",
-                        serial_number=settings['box_settings']['SideCameraLeft'],
+                        serial_number=settings['box_settings']['SideCameraRight'],
                     )
-                )
-            )
-        if RIGHT_CAMERA:
-            components['cameras'].append(
-                d.CameraAssembly(
-                    name="Right Camera",
-                    camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                 )
             )
         if BOTTOM_CAMERA:
@@ -144,13 +135,6 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         model="Blackfly S BFS-U3-04S2M",
                         serial_number=settings['box_settings']['BottomCamera'],
                     )
-                )
-            )
-        if BODY_CAMERA:
-            components['cameras'].append(
-                d.CameraAssembly(
-                    name="Body Camera",
-                    camera_target=d.CameraTarget.BODY,
                 )
             )
     else:

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -325,6 +325,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     # FIB specific information
     ###########################################################################
     if FIB:
+        # TODO FIB calibration needs to be recorded and incorporated here
         components['patch_cords']=[
             d.Patch(
                 name="Bundle Branching Fiber-optic Patch Cord",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -534,7 +534,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         )
 
-        components['laser_assemblies'].append(
+        components['laser_assemblies'] = [
             d.LaserAssembly(
                 lasers = [
                     d.Laser(
@@ -555,7 +555,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         )],
                 name = 'Optogenetic laser assembly',
                 )
-            )
+            ]
 
         # laser calibration
         components['calibrations'].extend(parse_laser_calibration(laser_calibration))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -544,7 +544,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         wavelength_unit=SizeUnit.NM,
                         model=settings["box_settings"]["OptoLaser1Model"],
                         serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-                        ))
+                        )
                     d.Laser(
                         name="Optogenetics Laser 2",
                         manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -88,7 +88,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         )
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
-        if RIGHT_CAMERA:
+        if False:#RIGHT_CAMERA:
             components['cameras'].append(
                 d.CameraAssembly(
                     name="Right Camera",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -117,7 +117,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     camera_target=d.CameraTarget.FACE_BOTTOM,
                     lens=d.Lens( 
                         manufacturer=d.Organization.KOWA,
-                        focal_length=25
+                        focal_length=25,
                         focal_length_unit=SizeUnit.MM,
                         model="LM25HC",
                         ), 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -62,7 +62,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
 
     # Determine what extra components are present
     FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
-    OPTO = ('HasOpto' in settings['box_settings']) and (settings['box_settings']['HasOpto'] == "1"):
+    OPTO = ('HasOpto' in settings['box_settings']) and (settings['box_settings']['HasOpto'] == "1")
 
     # Modalities
     ###########################################################################

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -535,15 +535,16 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         )
 
-        components['stimulus_devices'].append(
-            d.Laser(
-                name="Optogenetics Laser 1",
-                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
-                wavelength=settings['box_settings']['OptoLaser1Wavelength'],
-                wavelength_unit=SizeUnit.NM,
-                model=settings["box_settings"]["OptoLaser1Model"],
-                serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-            ))
+        #components['stimulus_devices'].append(
+        d.Laser(
+            name="Optogenetics Laser 1",
+            manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
+            wavelength=settings['box_settings']['OptoLaser1Wavelength'],
+            wavelength_unit=SizeUnit.NM,
+            model=settings["box_settings"]["OptoLaser1Model"],
+            serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
+        )
+        #    ))
         #components['stimulus_devices'].append(
         #    d.Laser(
         #        name="Optogenetics Laser 2",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -124,10 +124,11 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
                     lens=d.Lens( 
-                        manufacturer=d.Organization.OTHER(name="Kowa"),
+                        manufacturer=d.Organization.OTHER,
                         focal_length=25,
                         focal_length_unit=SizeUnit.MM,
                         model="LM25HC",
+                        notes='Manufacturer is Kowa'
                         ), 
                     camera=d.Camera(
                         detector_type="Camera",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -88,6 +88,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                     lens=d.Lens( 
+                        name="Behavior Video Lens Right Side"
                         manufacturer=d.Organization.FUJINON,
                         focal_length=16,
                         focal_length_unit=SizeUnit.MM,

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -81,7 +81,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ###########################################################################
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
-        if False:#RIGHT_CAMERA:
+        if RIGHT_CAMERA:
             components['cameras'].append(
                 d.CameraAssembly(
                     name="Right Camera assembly",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -206,7 +206,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 manufacturer=d.Organization.THORLABS,
                 model="M810L5",
                 wavelength=810,
-                bandwith=30,
+                bandwidth=30,
             )
         ]
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -148,7 +148,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ###########################################################################
     components['mouse_platform']=d.Tube(
         name="mouse_tube_foraging", 
-        diameter=3.0
+        diameter=3.0,
         diameter_unit=SizeUnit.CM
         )
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -537,7 +537,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         components['stimulus_devices'].append(
             d.Laser(
                 name="Optogenetics Laser 1",
-                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer']),
+                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
                 wavelength=settings['box_settings']['OptoLaser1Wavelength'],
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser1Model"],
@@ -545,7 +545,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             ),
             d.Laser(
                 name="Optogenetics Laser 2",
-                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer']),
+                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),
                 wavelength=settings['box_settings']['OptoLaser2Wavelength'],
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser2Model"],

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -554,7 +554,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
                         )],
                 name = 'Optogenetic laser assembly',
-                manipulator = d.Manipulator(manufacturer=d.Organization.OTHER)
+                manipulator = d.Manipulator(manufacturer=d.Organization.OTHER,name='optogenetic laser manipulator')
                 )
             ]
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -527,7 +527,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             d.DAQDevice(
                 name="optogenetics nidaq",
                 device_type="DAQ_Device",
-                data_interface=DataInterface.USB,
+                data_interface=d.DataInterface.USB,
                 manufacturer=Organization.NATIONAL_INSTRUMENTS,
                 model="USB-6002",
             )

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -83,6 +83,50 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     ###########################################################################
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
+        if LEFT_CAMERA:
+            components['cameras'].append(
+                d.CameraAssembly(
+                    name="Left Camera",
+                    computer_name=settings['computer_name'],
+                    camera_target=d.CameraTarget.FACE_SIDE_LEFT,
+                    #lens=,
+                    #filter=,
+                    camera=d.Camera(
+                        detector_type="Camera",
+                        manufacturer=d.Organization.FLIR,
+                        data_interface="USB",
+                        chroma="Monochrome",
+                        cooling="Air", 
+                        sensor_format="1/2.9",
+                        sensor_format_unit=SizeUnit.IN,
+                        sensor_width=720,
+                        sensor_height=540,
+                        max_frame_rate=522,
+                        model="Blackfly S BFS-U3-04S2M",
+                    )
+                )
+            )
+        if RIGHT_CAMERA:
+            components['cameras'].append(
+                d.CameraAssembly(
+                    name="Right Camera",
+                    camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
+                )
+            )
+        if BOTTOM_CAMERA:
+            components['cameras'].append(
+                d.CameraAssembly(
+                    name="Bottom Camera",
+                    camera_target=d.CameraTarget.FACE_BOTTOM,
+                )
+            )
+        if BODY_CAMERA:
+            components['cameras'].append(
+                d.CameraAssembly(
+                    name="Body Camera",
+                    camera_target=d.CameraTarget.BODY,
+                )
+            )
     else:
         components['cameras']=[
             d.CameraAssembly(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -526,7 +526,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         components['daqs'].append(
             d.DAQDevice(
                 name="optogenetics nidaq",
-                device_type="DAQ_Device",
+                device_type="DAQ Device",
                 data_interface=d.DataInterface.USB,
                 manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
                 model="USB-6002",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -524,16 +524,16 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         # Cables/Fibers/patch_cords?
         # Laser Assembly?
  
-        components['daqs'].append(
-            d.DAQDevice(
-                name="optogenetics nidaq",
-                device_type="DAQ Device",
-                data_interface=d.DataInterface.USB,
-                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-                model="USB-6002",
-                computer_name=settings['computer_name'],
-            )
-        )
+        #components['daqs'].append(
+        #    d.DAQDevice(
+        #        name="optogenetics nidaq",
+        #        device_type="DAQ Device",
+        #        data_interface=d.DataInterface.USB,
+        #        manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
+        #        model="USB-6002",
+        #        computer_name=settings['computer_name'],
+        #    )
+        #)
 
         components['stimulus_devices'].extend([
             d.Laser(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -554,6 +554,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
                         )],
                 name = 'Optogenetic laser assembly',
+                manipulator = d.Manipulator(manufacturer=d.Organization.OTHER)
                 )
             ]
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -93,6 +93,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         focal_length=16,
                         focal_length_unit=SizeUnit.MM,
                         model="CF16ZA-1S",
+                        type="lens",
                         ),
                     camera=d.Camera(
                         detector_type="Camera",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -624,24 +624,24 @@ def parse_laser_calibration(laser_calibration):
                                 input = {'input voltage (v)':voltage},
                                 output = {'laser power (mw)':power},
                             ))
-                elif protocol in ['Constant', 'Pulse']:
-                    for laser_name in this_calibration[protocol].keys():
-                        voltage = [x[0] for x in 
-                            this_calibration[protocol][laser_name]['LaserPowerVoltage']]
-                        power = [x[1] for x in 
-                            this_calibration[protocol][laser_name]['LaserPowerVoltage']]
-                        voltage, power = zip(*sorted(zip(voltage, power), key=lambda x: x[0]))
-                        
-                        datestr = datetime.strptime(latest_calibration_date,'%Y-%m-%d').date()
-                        description= f'Optogenetic calibration for {laser}, Laser_{laser_name}, protocol: {protocol}'
-                        calibrations.append(
-                            d.Calibration(
-                                calibration_date = datestr,
-                                device_name = laser_name, 
-                                description = description, 
-                                input = {'input voltage (v)':voltage},
-                                output = {'laser power (mw)':power},
-                            ))
+            elif protocol in ['Constant', 'Pulse']:
+                for laser_name in this_calibration[protocol].keys():
+                    voltage = [x[0] for x in 
+                        this_calibration[protocol][laser_name]['LaserPowerVoltage']]
+                    power = [x[1] for x in 
+                        this_calibration[protocol][laser_name]['LaserPowerVoltage']]
+                    voltage, power = zip(*sorted(zip(voltage, power), key=lambda x: x[0]))
+                    
+                    datestr = datetime.strptime(latest_calibration_date,'%Y-%m-%d').date()
+                    description= f'Optogenetic calibration for {laser}, Laser_{laser_name}, protocol: {protocol}'
+                    calibrations.append(
+                        d.Calibration(
+                            calibration_date = datestr,
+                            device_name = laser_name, 
+                            description = description, 
+                            input = {'input voltage (v)':voltage},
+                            output = {'laser power (mw)':power},
+                        ))
 
     return calibrations
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -88,7 +88,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                     lens=d.Lens( 
-                        name="Behavior Video Lens Right Side"
+                        name="Behavior Video Lens Right Side",
                         manufacturer=d.Organization.FUJINON,
                         focal_length=16,
                         focal_length_unit=SizeUnit.MM,

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -520,8 +520,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     # Optogenetics specific
     ###########################################################################
     if OPTO:
-        # TODO Xinxin to fill in
-        # Cables/Fibers/patch_cords?
+        # TODO need to fill in details on cables, fibers, patch cords, manipulator 
  
         components['daqs'].append(
             d.DAQDevice(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import numpy as np
 from deepdiff import DeepDiff
 from datetime import date, datetime, timezone
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -124,7 +124,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
                     lens=d.Lens( 
-                        manufacturer=d.Organization.Other(name="Kowa"),
+                        manufacturer=d.Organization.OTHER(name="Kowa"),
                         focal_length=25,
                         focal_length_unit=SizeUnit.MM,
                         model="LM25HC",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -200,6 +200,16 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             ),
         ]
 
+    components['light_sources'] = [
+             d.LightEmittingDiode(
+                name="IR LED",
+                manufacturer=d.Organization.THORLABS,
+                model="M810L5",
+                wavelength=810,
+                bandwith=30,
+            )
+        ]
+
 
     # Mouse Platform
     ###########################################################################
@@ -341,26 +351,27 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         ]
 
-        components['light_sources']=[
+        components['light_sources'].append(
             d.LightEmittingDiode(
                 name="470nm LED",
                 manufacturer=d.Organization.THORLABS,
                 model="M470F3",
                 wavelength=470,
-            ),
+            ))
+        components['light_sources'].append(
             d.LightEmittingDiode(
                 name="415nm LED",
                 manufacturer=d.Organization.THORLABS,
                 model="M415F3",
                 wavelength=415,
-            ),
+            ))
+        components['light_sources'].append(
             d.LightEmittingDiode(
                 name="565nm LED",
                 manufacturer=d.Organization.THORLABS,
                 model="M565F3",
                 wavelength=565,
-            ),
-        ]
+            ))
 
         components['detectors']=[
             d.Detector(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -123,7 +123,8 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     name="Bottom Camera",
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
-                    lens=d.Lens( 
+                    lens=d.Lens(
+                        name="Behavior Video Lens Bottom of face", 
                         manufacturer=d.Organization.OTHER,
                         focal_length=25,
                         focal_length_unit=SizeUnit.MM,

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -534,7 +534,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         )
 
-        components['stimulus_devices'].append(
+        components['stimulus_devices'].extend([
             d.Laser(
                 name="Optogenetics Laser 1",
                 manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
@@ -551,7 +551,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 model=settings["box_settings"]["OptoLaser2Model"],
                 serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
             )
-        )
+        ])
 
         # laser calibration
         components['calibrations'].extend(parse_laser_calibration(laser_calibration))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -53,10 +53,6 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
 
 
 def build_rig_json_core(settings, water_calibration, laser_calibration):
-
-    # TODO
-    # Cameras
-
     # Set up
     ###########################################################################
     logging.info('building rig json')
@@ -74,6 +70,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     BOTTOM_CAMERA = ('HasBottomCamera' in settings['box_settings']) and (settings['box_settings']['HasBottomCamera'] == "1")
     AIND_LICK_DETECTOR = ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1")
 
+
     # Modalities
     ###########################################################################
     # Opto is not a modality, its a stimulus
@@ -81,68 +78,69 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     if FIB:
         components['modalities'].append(Modality.FIB)
 
-    # Cameras
+
+    # Cameras # TODO
     ###########################################################################
-    components['cameras']=[
-        d.CameraAssembly(
-            name="BehaviorVideography_FaceSide",
-            camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
-            camera=d.Camera(
-                name="Side face camera",
-                detector_type="Camera",
-                serial_number="TBD",
-                manufacturer=d.Organization.AILIPU,
-                model="ELP-USBFHD05MT-KL170IR",
-                notes="The light intensity sensor was removed; IR illumination is constantly on",
-                data_interface="USB",
-                computer_name=settings['computer_name'],
-                max_frame_rate=120,
-                sensor_width=640,
-                sensor_height=480,
-                chroma="Color",
-                cooling="Air",
-                bin_mode="Additive",
-                recording_software=d.Software(name="Bonsai", version=settings['bonsai_version']),
+    if HIGH_SPEED_CAMERA:
+        components['cameras']=[]
+    else:
+        components['cameras']=[
+            d.CameraAssembly(
+                name="BehaviorVideography_FaceSide",
+                camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
+                camera=d.Camera(
+                    name="Side face camera",
+                    detector_type="Camera",
+                    manufacturer=d.Organization.AILIPU,
+                    model="ELP-USBFHD05MT-KL170IR",
+                    notes="The light intensity sensor was removed; IR illumination is constantly on",
+                    data_interface="USB",
+                    computer_name=settings['computer_name'],
+                    max_frame_rate=120,
+                    sensor_width=640,
+                    sensor_height=480,
+                    chroma="Color",
+                    cooling="Air",
+                    bin_mode="Additive",
+                    recording_software=d.Software(name="Bonsai", version=settings['bonsai_version']),
+                ),
+                lens=d.Lens(
+                    name="Xenocam 1",
+                    model="XC0922LENS",
+                    manufacturer=d.Organization.OTHER,
+                    max_aperture="f/1.4",
+                    notes='Focal Length 9-22mm 1/3" IR F1.4',
+                ),
             ),
-            lens=d.Lens(
-                name="Xenocam 1",
-                model="XC0922LENS",
-                serial_number="unknown",
-                manufacturer=d.Organization.OTHER,
-                max_aperture="f/1.4",
-                notes='Focal Length 9-22mm 1/3" IR F1.4',
+            d.CameraAssembly(
+                name="BehaviorVideography_FaceBottom",
+                camera_target=d.CameraTarget.FACE_BOTTOM,
+                camera=d.Camera(
+                    name="Bottom face Camera",
+                    detector_type="Camera",
+                    manufacturer=d.Organization.AILIPU,
+                    model="ELP-USBFHD05MT-KL170IR",
+                    notes="The light intensity sensor was removed; IR illumination is constantly on",
+                    data_interface="USB",
+                    computer_name=settings['computer_name'],
+                    max_frame_rate=120,
+                    sensor_width=640,
+                    sensor_height=480,
+                    chroma="Color",
+                    cooling="Air",
+                    bin_mode="Additive",
+                    recording_software=d.Software(name="Bonsai", version=settings['bonsai_version']),
+                ),
+                lens=d.Lens(
+                    name="Xenocam 2",
+                    model="XC0922LENS",
+                    manufacturer=d.Organization.OTHER,
+                    max_aperture="f/1.4",
+                    notes='Focal Length 9-22mm 1/3" IR F1.4',
+                ),
             ),
-        ),
-        d.CameraAssembly(
-            name="BehaviorVideography_FaceBottom",
-            camera_target=d.CameraTarget.FACE_BOTTOM,
-            camera=d.Camera(
-                name="Bottom face Camera",
-                detector_type="Camera",
-                serial_number="TBD",
-                manufacturer=d.Organization.AILIPU,
-                model="ELP-USBFHD05MT-KL170IR",
-                notes="The light intensity sensor was removed; IR illumination is constantly on",
-                data_interface="USB",
-                computer_name=settings['computer_name'],
-                max_frame_rate=120,
-                sensor_width=640,
-                sensor_height=480,
-                chroma="Color",
-                cooling="Air",
-                bin_mode="Additive",
-                recording_software=d.Software(name="Bonsai", version=settings['bonsai_version']),
-            ),
-            lens=d.Lens(
-                name="Xenocam 2",
-                model="XC0922LENS",
-                serial_number="unknown",
-                manufacturer=d.Organization.OTHER,
-                max_aperture="f/1.4",
-                notes='Focal Length 9-22mm 1/3" IR F1.4',
-            ),
-        ),
-    ]
+        ]
+
 
     # Mouse Platform
     ###########################################################################
@@ -151,6 +149,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         diameter=3.0,
         diameter_unit=SizeUnit.CM
         )
+
 
     # Stimulus devices
     ###########################################################################
@@ -169,42 +168,29 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     manufacturer=d.Organization.AIND,
                     travel=0, #TODO, need to fill in this value
                     )      
+
     if ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1"):
-        lick_spouts=[
-            d.RewardSpout(
-                name="AIND_Lick_Detector Left",
-                side=d.SpoutSide.LEFT,
-                spout_diameter=1.2,
-                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
-                lick_sensor_type=d.LickSensorType("Capacitive")
-            ),
-            d.RewardSpout(
-                name="AIND_Lick_Detector Right",
-                side=d.SpoutSide.RIGHT,
-                spout_diameter=1.2,
-                spout_diameter_unit=SizeUnit.MM,
-                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
-                lick_sensor_type=d.LickSensorType("Capacitive")
-            ),
-            ]   
+        lick_spout_name = 'AIND_Lick_Detector'
     else:
-        lick_spouts=[
-            d.RewardSpout(
-                name="Janelia_Lick_Detector Left",
-                side=d.SpoutSide.LEFT,
-                spout_diameter=1.2,
-                spout_diameter_unit=SizeUnit.MM,
-                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
-                lick_sensor_type=d.LickSensorType("Capacitive")
-            ),
-            d.RewardSpout(
-                name="Janelia_Lick_Detector Right",
-                side=d.SpoutSide.RIGHT,
-                spout_diameter=1.2,
-                solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
-                lick_sensor_type=d.LickSensorType("Capacitive")
-            ),
-            ]
+        lick_spout_name = 'Janelia_Lick_Detector'
+    lick_spouts=[
+        d.RewardSpout(
+            name="{} Left".format(lick_spout_name),
+            side=d.SpoutSide.LEFT,
+            spout_diameter=1.2,
+            solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Left"),
+            lick_sensor_type=d.LickSensorType("Capacitive")
+        ),
+        d.RewardSpout(
+            name="{} Right".format(lick_spout_name),
+            side=d.SpoutSide.RIGHT,
+            spout_diameter=1.2,
+            spout_diameter_unit=SizeUnit.MM,
+            solenoid_valve=d.Device(device_type="Solenoid", name="Solenoid Right"),
+            lick_sensor_type=d.LickSensorType("Capacitive")
+        ),
+        ]   
+
     components['stimulus_devices']=[
         d.RewardDelivery(
             reward_spouts=lick_spouts,
@@ -268,6 +254,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         )
     ]
 
+
     # Calibrations
     ###########################################################################
 
@@ -278,6 +265,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         left, right = parse_water_calibration(water_calibration)
         components['calibrations'].append(left)
         components['calibrations'].append(right)
+
 
     # FIB specific information
     ###########################################################################

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -64,11 +64,11 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     FIB = settings['Teensy_COM_box{}'.format(settings['box_number'])] != ''
     OPTO = ('HasOpto' in settings['box_settings']) and (settings['box_settings']['HasOpto'] == "1")
     HIGH_SPEED_CAMERA = ('HighSpeedCamera' in settings['box_settings']) and (settings['box_settings']['HighSpeedCamera'] == "1")
-    LEFT_CAMERA = ('HasSideCameraLeft' in settings['box_settings']) and (settings['HasSideCameraLeft'] == "1")
-    RIGHT_CAMERA = ('HasSideCameraRight' in settings['box_settings']) and (settings['HasSideCameraRight'] == "1")
-    BODY_CAMERA = ('HasBodyCamera' in settings['box_settings']) and (settings['HasBodyCamera'] == "1")
-    BOTTOM_CAMERA = ('HasBottomCamera' in settings['box_settings']) and (settings['HasBottomCamera'] == "1")
-    AIND_LICK_DETECTOR = ('AINDLickDetector' in settings['box_settings']) and (settings['AINDLickDetector'] == "1")
+    LEFT_CAMERA = ('HasSideCameraLeft' in settings['box_settings']) and (settings['box_settings']['HasSideCameraLeft'] == "1")
+    RIGHT_CAMERA = ('HasSideCameraRight' in settings['box_settings']) and (settings['box_settings']['HasSideCameraRight'] == "1")
+    BODY_CAMERA = ('HasBodyCamera' in settings['box_settings']) and (settings['box_settings']['HasBodyCamera'] == "1")
+    BOTTOM_CAMERA = ('HasBottomCamera' in settings['box_settings']) and (settings['box_settings']['HasBottomCamera'] == "1")
+    AIND_LICK_DETECTOR = ('AINDLickDetector' in settings['box_settings']) and (settings['box_settings']['AINDLickDetector'] == "1")
 
     # Modalities
     ###########################################################################

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -473,28 +473,22 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     # Optogenetics specific
     ###########################################################################
     if OPTO:
-        ##Optogenetics Specific   ## TODO Xinxin to fill in
         print('need to implement') 
-        #components['light_sources'].append(
-        #    d.LightEmittingDiode(
-        #        name="LED for photostimulation",
-        #        manufacturer=d.Organization.PRIZMATIX,
-        #        model="xxx",
-        #        wavelength=470,
-        #    )
-        #    )
+        # TODO Xinxin to fill in
+        # Lasers/LEDS?
+        # Filters?
+        # Cables?
         
-        #daqs.append(
-        #    d.DAQDevice(
-        #        name="NIDAQ for opto",
-        #        device_type="DAQ Device",
-        #        data_interface="USB2.0",
-        #        manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-        #        computer_name=settings['computer_name'],
-        #        channels=[
-        #        ],
-        #    )
-        #    )
+        daqs.append(
+            d.DAQDevice(
+                name="optogenetics nidaq",
+                device_type="DAQ_Device",
+                data_interface=DataInterface.USB,
+                manufacturer=Organization.NATIONAL_INSTRUMENTS,
+                model="USB-6002",
+            )
+        )
+
 
     # Generate Rig Schema
     ###########################################################################
@@ -510,17 +504,16 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     # TODO
     # Cameras
     # Platforms
-    # FIP
-    # OPTO
     # Reward/lick spouts
     # Lick detector
-    # Harp boards
     # Parse laser calibration
     #
     # TODO, later
     # Lick spout stages - Need to add details for AIND stages
     # Speaker - needs manufactor, any details
     # What if water calibration is null?
+    # OPTO
+
 
 def parse_water_calibration(water_calibration):
     

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -91,7 +91,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         if False:#RIGHT_CAMERA:
             components['cameras'].append(
                 d.CameraAssembly(
-                    name="Right Camera",
+                    name="Right Camera assembly",
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_SIDE_RIGHT,
                     lens=d.Lens( 
@@ -102,6 +102,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         model="CF16ZA-1S",
                         ),
                     camera=d.Camera(
+                        name = "Right size of face camera"
                         detector_type="Camera",
                         manufacturer=d.Organization.FLIR,
                         data_interface="USB",
@@ -120,7 +121,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         if BOTTOM_CAMERA:
             components['cameras'].append(
                 d.CameraAssembly(
-                    name="Bottom Camera",
+                    name="Bottom Camera assembly",
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
                     lens=d.Lens(
@@ -132,6 +133,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         notes='Manufacturer is Kowa'
                         ), 
                     camera=d.Camera(
+                        name="bottom of face camera",
                         detector_type="Camera",
                         manufacturer=d.Organization.FLIR,
                         data_interface="USB",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -535,15 +535,15 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         )
 
-        #components['stimulus_devices'].append(
-        #    d.Laser(
-        #        name="Optogenetics Laser 1",
-        #        manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
-        #        wavelength=settings['box_settings']['OptoLaser1Wavelength'],
-        #        wavelength_unit=SizeUnit.NM,
-        #        model=settings["box_settings"]["OptoLaser1Model"],
-        #        serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-        #    ))
+        components['stimulus_devices'].append(
+            d.Laser(
+                name="Optogenetics Laser 1",
+                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
+                wavelength=settings['box_settings']['OptoLaser1Wavelength'],
+                wavelength_unit=SizeUnit.NM,
+                model=settings["box_settings"]["OptoLaser1Model"],
+                serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
+            ))
         #components['stimulus_devices'].append(
         #    d.Laser(
         #        name="Optogenetics Laser 2",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -541,7 +541,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser1Model"],
                 serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-            )
+            ),
             d.Laser(
                 name="Optogenetics Laser 2",
                 manufacturer=getattr(Organization,settings['box_settings']['OptoLaser2Manufacturer']),

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -79,6 +79,13 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
 
     # Cameras 
     ###########################################################################
+    lens=d.Lens( 
+        name="Behavior Video Lens Right Side",
+        manufacturer=d.Organization.FUJINON,
+        focal_length=16,
+        focal_length_unit=SizeUnit.MM,
+        model="CF16ZA-1S",
+        )
     if HIGH_SPEED_CAMERA:
         components['cameras']=[]
         if RIGHT_CAMERA:
@@ -93,7 +100,6 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         focal_length=16,
                         focal_length_unit=SizeUnit.MM,
                         model="CF16ZA-1S",
-                        type="lens",
                         ),
                     camera=d.Camera(
                         detector_type="Camera",

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -524,16 +524,16 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         # Cables/Fibers/patch_cords?
         # Laser Assembly?
  
-        #components['daqs'].append(
-        #    d.DAQDevice(
-        #        name="optogenetics nidaq",
-        #        device_type="DAQ Device",
-        #        data_interface=d.DataInterface.USB,
-        #        manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
-        #        model="USB-6002",
-        #        computer_name=settings['computer_name'],
-        #    )
-        #)
+        components['daqs'].append(
+            d.DAQDevice(
+                name="optogenetics nidaq",
+                device_type="DAQ Device",
+                data_interface=d.DataInterface.USB,
+                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
+                model="USB-6002",
+                computer_name=settings['computer_name'],
+            )
+        )
 
         #components['stimulus_devices'].append(
         #    d.Laser(

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -206,7 +206,6 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 manufacturer=d.Organization.THORLABS,
                 model="M810L5",
                 wavelength=810,
-                bandwidth=30,
             )
         ]
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -544,7 +544,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         wavelength_unit=SizeUnit.NM,
                         model=settings["box_settings"]["OptoLaser1Model"],
                         serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-                        )
+                        ),
                     d.Laser(
                         name="Optogenetics Laser 2",
                         manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -528,7 +528,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                 name="optogenetics nidaq",
                 device_type="DAQ_Device",
                 data_interface=d.DataInterface.USB,
-                manufacturer=Organization.NATIONAL_INSTRUMENTS,
+                manufacturer=d.Organization.NATIONAL_INSTRUMENTS,
                 model="USB-6002",
             )
         )
@@ -536,16 +536,16 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
         components['stimulus_devices'].append(
             d.Laser(
                 name="Optogenetics Laser 1",
-                manufacturer=getattr(Organization,settings['box_settings']['OptoLaser1Manufacturer']),
-                wavelength=getattr(Organization,settings['box_settings']['OptoLaser1Wavelength']),
+                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer']),
+                wavelength=getattr(d.Organization,settings['box_settings']['OptoLaser1Wavelength']),
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser1Model"],
                 serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
             ),
             d.Laser(
                 name="Optogenetics Laser 2",
-                manufacturer=getattr(Organization,settings['box_settings']['OptoLaser2Manufacturer']),
-                wavelength=getattr(Organization,settings['box_settings']['OptoLaser2Wavelength']),
+                manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer']),
+                wavelength=getattr(d.Organization,settings['box_settings']['OptoLaser2Wavelength']),
                 wavelength_unit=SizeUnit.NM,
                 model=settings["box_settings"]["OptoLaser2Model"],
                 serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -598,7 +598,7 @@ def parse_laser_calibration(laser_calibration):
     laser_colors = get_laser_names(laser_calibration) 
     for laser in laser_colors:
         # find the last calibration for this laser color        
-        latest_calibration_date = FindLatestCalibrationDate(laser, laser_calibration):
+        latest_calibration_date = FindLatestCalibrationDate(laser, laser_calibration)
         if latest_calibration_date == 'NA':
             continue
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -89,8 +89,12 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                     name="Left Camera",
                     computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_SIDE_LEFT,
-                    #lens=,
-                    #filter=,
+                    lens=d.Lens( 
+                        manufacturer=d.Organization.FUJINON,
+                        focal_length=16
+                        focal_length_unit=SizeUnit.MM,
+                        model="CF16ZA-1S",
+                        ),
                     camera=d.Camera(
                         detector_type="Camera",
                         manufacturer=d.Organization.FLIR,
@@ -103,6 +107,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         sensor_height=540,
                         max_frame_rate=522,
                         model="Blackfly S BFS-U3-04S2M",
+                        serial_number=settings['box_settings']['SideCameraLeft'],
                     )
                 )
             )
@@ -117,7 +122,28 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             components['cameras'].append(
                 d.CameraAssembly(
                     name="Bottom Camera",
+                    computer_name=settings['computer_name'],
                     camera_target=d.CameraTarget.FACE_BOTTOM,
+                    lens=d.Lens( 
+                        manufacturer=d.Organization.KOWA,
+                        focal_length=25
+                        focal_length_unit=SizeUnit.MM,
+                        model="LM25HC",
+                        ), 
+                    camera=d.Camera(
+                        detector_type="Camera",
+                        manufacturer=d.Organization.FLIR,
+                        data_interface="USB",
+                        chroma="Monochrome",
+                        cooling="Air", 
+                        sensor_format="1/2.9",
+                        sensor_format_unit=SizeUnit.IN,
+                        sensor_width=720,
+                        sensor_height=540,
+                        max_frame_rate=522,
+                        model="Blackfly S BFS-U3-04S2M",
+                        serial_number=settings['box_settings']['BottomCamera'],
+                    )
                 )
             )
         if BODY_CAMERA:

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -555,6 +555,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
                         )],
                 name = 'Optogenetic laser assembly',
                 )
+            )
 
         # laser calibration
         components['calibrations'].extend(parse_laser_calibration(laser_calibration))

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -522,7 +522,6 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
     if OPTO:
         # TODO Xinxin to fill in
         # Cables/Fibers/patch_cords?
-        # Laser Assembly?
  
         components['daqs'].append(
             d.DAQDevice(
@@ -535,25 +534,27 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
             )
         )
 
-        #components['stimulus_devices'].append(
-        d.Laser(
-            name="Optogenetics Laser 1",
-            manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
-            wavelength=settings['box_settings']['OptoLaser1Wavelength'],
-            wavelength_unit=SizeUnit.NM,
-            model=settings["box_settings"]["OptoLaser1Model"],
-            serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
-        )
-        #    ))
-        #components['stimulus_devices'].append(
-        #    d.Laser(
-        #        name="Optogenetics Laser 2",
-        #        manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),
-        #        wavelength=settings['box_settings']['OptoLaser2Wavelength'],
-        #        wavelength_unit=SizeUnit.NM,
-        #        model=settings["box_settings"]["OptoLaser2Model"],
-        #        serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
-        #    ))
+        components['laser_assemblies'].append(
+            d.LaserAssembly(
+                lasers = [
+                    d.Laser(
+                        name="Optogenetics Laser 1",
+                        manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser1Manufacturer'].upper()),
+                        wavelength=settings['box_settings']['OptoLaser1Wavelength'],
+                        wavelength_unit=SizeUnit.NM,
+                        model=settings["box_settings"]["OptoLaser1Model"],
+                        serial_number=settings["box_settings"]["OptoLaser1SerialNumber"],
+                        ))
+                    d.Laser(
+                        name="Optogenetics Laser 2",
+                        manufacturer=getattr(d.Organization,settings['box_settings']['OptoLaser2Manufacturer'].upper()),
+                        wavelength=settings['box_settings']['OptoLaser2Wavelength'],
+                        wavelength_unit=SizeUnit.NM,
+                        model=settings["box_settings"]["OptoLaser2Model"],
+                        serial_number=settings["box_settings"]["OptoLaser2SerialNumber"],
+                        )],
+                name = 'Optogenetic laser assembly',
+                )
 
         # laser calibration
         components['calibrations'].extend(parse_laser_calibration(laser_calibration))

--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -17,4 +17,7 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+FipRedCMOSSerialNumber,0
+FipGreenCMOSSerialNumber,0
+FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -17,6 +17,14 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+OptoLaser1Manufacturer,0
+OptoLaser1Wavelength,0
+OptoLaser1Model,0
+OptoLaser1SerialNumber,0
+OptoLaser2Manufacturer,0
+OptoLaser2Wavelength,0
+OptoLaser2Model,0
+OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0

--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -16,4 +16,5 @@ HasSideCameraLeft,0
 HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
+HasOpto,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -17,4 +17,7 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+FipRedCMOSSerialNumber,0
+FipGreenCMOSSerialNumber,0
+FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -17,6 +17,14 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+OptoLaser1Manufacturer,0
+OptoLaser1Wavelength,0
+OptoLaser1Model,0
+OptoLaser1SerialNumber,0
+OptoLaser2Manufacturer,0
+OptoLaser2Wavelength,0
+OptoLaser2Model,0
+OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -16,4 +16,5 @@ HasSideCameraLeft,0
 HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
+HasOpto,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -17,4 +17,7 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+FipRedCMOSSerialNumber,0
+FipGreenCMOSSerialNumber,0
+FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -17,6 +17,14 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+OptoLaser1Manufacturer,0
+OptoLaser1Wavelength,0
+OptoLaser1Model,0
+OptoLaser1SerialNumber,0
+OptoLaser2Manufacturer,0
+OptoLaser2Wavelength,0
+OptoLaser2Model,0
+OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -16,4 +16,5 @@ HasSideCameraLeft,0
 HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
+HasOpto,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -17,4 +17,7 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+FipRedCMOSSerialNumber,0
+FipGreenCMOSSerialNumber,0
+FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -17,6 +17,14 @@ HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
 HasOpto,0
+OptoLaser1Manufacturer,0
+OptoLaser1Wavelength,0
+OptoLaser1Model,0
+OptoLaser1SerialNumber,0
+OptoLaser2Manufacturer,0
+OptoLaser2Wavelength,0
+OptoLaser2Model,0
+OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -16,4 +16,5 @@ HasSideCameraLeft,0
 HasBottomCamera,0
 HasSideCameraRight,0
 HasBodyCamera,0
+HasOpto,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- [x] Need to pin version of aind-data-schema  
- [x] Remove `rig_specification.json`, uses `Settings_box1.csv` instead
- [x] Document fields that need to be added `HasOpto`, `FipCMOSSerialNumber`
    - `HasOpto`, 0 is no opto, 1 is opto
    - `FipRedCMOSSerialNumber`, must be present for FIP sessions
    - `FipGreenCMOSSerialNumber`, must be present for FIP sessions
    - `FipObjectiveSerialNumber`, must be present for FIP sessions
- [x] Check Camera information, specifically filter, lens. which cameras are in 446/428?
    - Remove body camera, and side right?
    - is left and right mouse-centric?
- [x] Need `travel` field for lick spout motor stage
- [x] Need FIP calibration information
- [x] Need Opto information

### What issues or discussions does this update address?
- finishes resolving https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/345






