### PR TITLE
Testing Updates

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -173,6 +173,7 @@ class Window(QMainWindow):
             return
         json_files = [f for f in os.listdir(self.rig_metadata_folder) if f.endswith('.json')]
         dates=[]
+        print('rig'+self.current_box)
         for file in json_files:
             #Assume the file name has the structure 'rig' + rig name+'_'+date+'.json'
             print(file)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2386,7 +2386,7 @@ class Window(QMainWindow):
             generate_metadata(Obj=Obj)
         except Exception as e:
             self._manage_warning_labels(self.MetadataWarning,warning_text='Meta data is not saved succuessfully!')
-            logging.error(str(e))
+            logging.error('Error generating session metadata: '+str(e))
 
         # save Json or mat
         if self.SaveFile.endswith('.mat'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1001,7 +1001,7 @@ class Window(QMainWindow):
             'lick_spout_distance_box2':5000,
             'lick_spout_distance_box3':5000,
             'lick_spout_distance_box4':5000,
-            'name_mapper_file':os.path.join(self.SettingFolder,"name_mapper.json")
+            'name_mapper_file':os.path.join(self.SettingFolder,"name_mapper.json"),
             'create_rig_metadata':True,
         }
         

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -160,35 +160,44 @@ class Window(QMainWindow):
     
     def _load_rig_metadata(self):
         '''Load the latest rig metadata'''
-        if not os.path.exists(self.rig_metadata_folder):
-            try:
-                os.makedirs(self.rig_metadata_folder)
-                logging.error(str(e))
-                self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata folder found!')
-                logging.warning('No rig metadata folder found!')
-            except Exception as e:
-                logging.error(str(e))
-                self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata folder found! Failed to create new folder!')
-                logging.warning('No rig metadata folder found! Failed to create new folder!')
-            return
-        json_files = [f for f in os.listdir(self.rig_metadata_folder) if f.endswith('.json')]
-        dates=[]
-        for file in json_files:
-            #Assume the file name has the structure 'rig_' + rig name+'_'+date+'.json'
-            if file.startswith('rig_'+self.current_box):
-                date_str = file.split('_')[-1].split('.')[0]
-                dates.append(date_str)
-        if len(dates)==0:
-            logging.error('No rig metadata file found')
-            self.latest_rig_metadata_file=''
-            self.latest_rig_metadata={}
-            self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata found!')
-            return
-        dates_string = [datetime.strptime(date_str, '%Y-%m-%d') for date_str in dates]
-        max_datetime = max(dates_string)
-        max_datetime_index = dates_string.index(max_datetime)
-        selected_json_file = 'rig_'+self.current_box+'_'+dates[max_datetime_index]+'.json'
-        self.latest_rig_metadata_file = os.path.join(self.rig_metadata_folder, selected_json_file)
+
+        ## check if folder exists
+        #if not os.path.exists(self.rig_metadata_folder):
+        #    try:
+        #        os.makedirs(self.rig_metadata_folder)
+        #        logging.error(str(e))
+        #        self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata folder found!')
+        #        logging.warning('No rig metadata folder found!')
+        #    except Exception as e:
+        #        logging.error(str(e))
+        #        self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata folder found! Failed to create new folder!')
+        #        logging.warning('No rig metadata folder found! Failed to create new folder!')
+        #    return
+
+        ## Get the most recent
+        #files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
+        #files = [f.__str__().split('\\')[-1] for f in files]
+        #json_files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
+
+        #dates=[]
+        #for file in json_files:
+        #    #Assume the file name has the structure 'rig_' + rig name+'_'+date+'.json'
+        #    if file.startswith('rig_'+self.current_box):
+        #        date_str = file.split('_')[-1].split('.')[0]
+        #        dates.append(date_str)
+        #if len(dates)==0:
+        #    logging.error('No rig metadata file found')
+        #    self.latest_rig_metadata_file=''
+        #    self.latest_rig_metadata={}
+        #    self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata found!')
+        #    return
+        #dates_string = [datetime.strptime(date_str, '%Y-%m-%d') for date_str in dates]
+        #max_datetime = max(dates_string)
+        #max_datetime_index = dates_string.index(max_datetime)
+        #selected_json_file = 'rig_'+self.current_box+'_'+dates[max_datetime_index]+'.json'
+
+        rig_json, rig_json_file= self._load_most_recent_rig_json()
+        self.latest_rig_metadata_file = rig_json_file 
         self.Metadata_dialog._SelectRigMetadata(self.latest_rig_metadata_file)
 
     def _LoadUI(self):
@@ -1253,7 +1262,35 @@ class Window(QMainWindow):
             subprocess.Popen(['explorer', self.rig_metadata_folder])
         except Exception as e:
             logging.error(str(e))
-            
+
+    def _load_most_recent_rig_json(self,error_if_none=True):
+        # See if rig metadata folder exists 
+        if not os.path.exists(self.Settings['rig_metadata_folder']):
+            print('making directory: {}'.format(self.Settings['rig_metadata_folder']))
+            os.makedirs(self.Settings['rig_metadata_folder'])
+
+        # Load most recent rig_json
+        files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
+        files = [f.__str__().split('\\')[-1] for f in files]
+        files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
+
+        if len(files) ==0:
+            # No rig.jsons found, this will trigger saving the new one
+            rig_json = {}
+            rig_json_path = ''
+            if error_if_none:
+                logging.error('Did not find any existing rig.json files')      
+                self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata found!')
+            else:
+                logging.info('Did not find any existing rig.json files')
+        else:
+            rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],files[-1])
+            logging.info('Found existing rig.json: {}'.format(files[-1]))
+            with open(rig_json_path, 'r') as f:
+                rig_json = json.load(f)      
+
+        return rig_json, rig_json_path
+ 
     def _LoadRigJson(self):    
     
         # User can skip this step if they make rig metadata themselves
@@ -1261,24 +1298,7 @@ class Window(QMainWindow):
             logging.info('Skipping rig metadata creation because create_rig_metadata=False')
             return
 
-        # See if rig metadata folder exists 
-        if not os.path.exists(self.Settings['rig_metadata_folder']):
-            print('making directory: {}'.format(self.Settings['rig_metadata_folder']))
-            os.makedirs(self.Settings['rig_metadata_folder'])
-              
-        # Load most recent rig_json
-        files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
-        files = [f.__str__().split('\\')[-1] for f in files]
-        files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
-        if len(files) ==0:
-            # No rig.jsons found, this will trigger saving the new one
-            existing_rig_json = {}
-            logging.info('Did not find any existing rig.json files')
-        else:
-            existing_rig_json_path = os.path.join(self.Settings['rig_metadata_folder'],files[-1])
-            logging.info('Found existing rig.json: {}'.format(files[-1]))
-            with open(existing_rig_json_path, 'r') as f:
-                existing_rig_json = json.load(f)      
+        existing_rig_json = self._load_most_recent_rig_json(self,error_if_none=False) 
 
         # Builds a new rig.json, and saves if there are changes with the most recent
         rig_settings = self.Settings.copy()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2382,11 +2382,12 @@ class Window(QMainWindow):
         Obj['meta_data_dialog'] = self.Metadata_dialog.meta_data
 
         # generate the metadata file
-        try:
-            generate_metadata(Obj=Obj)
-        except Exception as e:
-            self._manage_warning_labels(self.MetadataWarning,warning_text='Meta data is not saved succuessfully!')
-            logging.error('Error generating session metadata: '+str(e))
+        #DEBUGGING
+        #try:
+        generate_metadata(Obj=Obj)
+        #except Exception as e:
+        #    self._manage_warning_labels(self.MetadataWarning,warning_text='Meta data is not saved succuessfully!')
+        #    logging.error('Error generating session metadata: '+str(e))
 
         # save Json or mat
         if self.SaveFile.endswith('.mat'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -175,6 +175,7 @@ class Window(QMainWindow):
         dates=[]
         for file in json_files:
             #Assume the file name has the structure 'rig' + rig name+'_'+date+'.json'
+            print(file)
             if file.startswith('rig'+self.current_box):
                 date_str = file.split('_')[-1].split('.')[0]
                 dates.append(date_str)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1298,7 +1298,7 @@ class Window(QMainWindow):
             logging.info('Skipping rig metadata creation because create_rig_metadata=False')
             return
 
-        existing_rig_json = self._load_most_recent_rig_json(error_if_none=False) 
+        existing_rig_json, rig_json_path = self._load_most_recent_rig_json(error_if_none=False) 
 
         # Builds a new rig.json, and saves if there are changes with the most recent
         rig_settings = self.Settings.copy()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -160,42 +160,7 @@ class Window(QMainWindow):
     
     def _load_rig_metadata(self):
         '''Load the latest rig metadata'''
-
-        ## check if folder exists
-        #if not os.path.exists(self.rig_metadata_folder):
-        #    try:
-        #        os.makedirs(self.rig_metadata_folder)
-        #        logging.error(str(e))
-        #        self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata folder found!')
-        #        logging.warning('No rig metadata folder found!')
-        #    except Exception as e:
-        #        logging.error(str(e))
-        #        self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata folder found! Failed to create new folder!')
-        #        logging.warning('No rig metadata folder found! Failed to create new folder!')
-        #    return
-
-        ## Get the most recent
-        #files = sorted(Path(self.Settings['rig_metadata_folder']).iterdir(), key=os.path.getmtime)
-        #files = [f.__str__().split('\\')[-1] for f in files]
-        #json_files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
-
-        #dates=[]
-        #for file in json_files:
-        #    #Assume the file name has the structure 'rig_' + rig name+'_'+date+'.json'
-        #    if file.startswith('rig_'+self.current_box):
-        #        date_str = file.split('_')[-1].split('.')[0]
-        #        dates.append(date_str)
-        #if len(dates)==0:
-        #    logging.error('No rig metadata file found')
-        #    self.latest_rig_metadata_file=''
-        #    self.latest_rig_metadata={}
-        #    self._manage_warning_labels(self.MetadataWarning,warning_text='No rig metadata found!')
-        #    return
-        #dates_string = [datetime.strptime(date_str, '%Y-%m-%d') for date_str in dates]
-        #max_datetime = max(dates_string)
-        #max_datetime_index = dates_string.index(max_datetime)
-        #selected_json_file = 'rig_'+self.current_box+'_'+dates[max_datetime_index]+'.json'
-
+ 
         rig_json, rig_json_file= self._load_most_recent_rig_json()
         self.latest_rig_metadata_file = rig_json_file 
         self.Metadata_dialog._SelectRigMetadata(self.latest_rig_metadata_file)
@@ -1275,7 +1240,7 @@ class Window(QMainWindow):
         files = [f for f in files if (f.startswith('rig_'+self.rig_name) and f.endswith('.json'))]
 
         if len(files) ==0:
-            # No rig.jsons found, this will trigger saving the new one
+            # No rig.jsons found
             rig_json = {}
             rig_json_path = ''
             if error_if_none:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1298,7 +1298,7 @@ class Window(QMainWindow):
             logging.info('Skipping rig metadata creation because create_rig_metadata=False')
             return
 
-        existing_rig_json = self._load_most_recent_rig_json(self,error_if_none=False) 
+        existing_rig_json = self._load_most_recent_rig_json(error_if_none=False) 
 
         # Builds a new rig.json, and saves if there are changes with the most recent
         rig_settings = self.Settings.copy()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -173,11 +173,9 @@ class Window(QMainWindow):
             return
         json_files = [f for f in os.listdir(self.rig_metadata_folder) if f.endswith('.json')]
         dates=[]
-        print('rig'+self.current_box)
         for file in json_files:
-            #Assume the file name has the structure 'rig' + rig name+'_'+date+'.json'
-            print(file)
-            if file.startswith('rig'+self.current_box):
+            #Assume the file name has the structure 'rig_' + rig name+'_'+date+'.json'
+            if file.startswith('rig_'+self.current_box):
                 date_str = file.split('_')[-1].split('.')[0]
                 dates.append(date_str)
         if len(dates)==0:
@@ -189,7 +187,7 @@ class Window(QMainWindow):
         dates_string = [datetime.strptime(date_str, '%Y-%m-%d') for date_str in dates]
         max_datetime = max(dates_string)
         max_datetime_index = dates_string.index(max_datetime)
-        selected_json_file = 'rig'+self.current_box+'_'+dates[max_datetime_index]+'.json'
+        selected_json_file = 'rig_'+self.current_box+'_'+dates[max_datetime_index]+'.json'
         self.latest_rig_metadata_file = os.path.join(self.rig_metadata_folder, selected_json_file)
         self.Metadata_dialog._SelectRigMetadata(self.latest_rig_metadata_file)
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -287,8 +287,10 @@ class generate_metadata:
         # Possible reason: 1) the NewScale stage is not connected to the behavior GUI. 2) the session is not started.
         if ('B_NewscalePositions' not in self.Obj) or (self.Obj['meta_data_dialog']['session_metadata']['LickSpoutReferenceArea']=='') or (self.Obj['meta_data_dialog']['session_metadata']['LickSpoutReferenceX']=='') or (self.Obj['meta_data_dialog']['session_metadata']['LickSpoutReferenceY']=='') or (self.Obj['meta_data_dialog']['session_metadata']['LickSpoutReferenceZ']==''):
             self.has_reward_delivery = False
+            logging.info('Cannot log reward delivery in session metadata - missing fields')
         elif self.Obj['B_NewscalePositions']==[]:
             self.has_reward_delivery = False
+            logging.info('Cannot log reward delivery in session metadata - missing newscale positions')
         else:
             self.has_reward_delivery = True
 
@@ -392,23 +394,14 @@ class generate_metadata:
         # session_start_time and session_end_time are required fields
         if self.Obj['meta_data_dialog']['rig_metadata']=={}:
             return
-        print('debug a') 
         self._get_reward_delivery()
-        print('debug b') 
         self._get_water_calibration()
-        print('debug c') 
         self._get_opto_calibration()
-        print('debug d') 
         self.calibration=self.water_calibration+self.opto_calibration
-        print('debug e') 
         self._get_behavior_stream()
-        print('debug f') 
         self._get_ephys_stream()
-        print('debug g') 
         self._get_ophys_stream()
-        print('debug h') 
         self._get_high_speed_camera_stream()
-        print('debug i') 
         self._get_session_time()
         if self.session_start_time == '' or self.session_end_time == '':
             return

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -65,13 +65,13 @@ class generate_metadata:
         if json_file is None and Obj is None and dialog_metadata is None:
             logging.info("json file or Obj is not provided")
             return
-        
+        print('debug 1')  
         if json_file is not None:
             with open(json_file) as f:
                 self.Obj = json.load(f)
         else:
             self.Obj = Obj
-
+        print('debug 2') 
         if dialog_metadata_file is not None:
             with open(dialog_metadata_file) as f:
                 self.Obj['meta_data_dialog'] = json.load(f)
@@ -80,13 +80,18 @@ class generate_metadata:
         
         if output_folder is not None:
             self.Obj['MetadataFolder'] = output_folder
-        
+        print('debug 3') 
         self._handle_edge_cases()
+        print('debug 4') 
         self._save_rig_metadata()
+        print('debug 5') 
         self.Obj['session_metadata']= {}
         self._mapper()
+        print('debug 6') 
         self._get_box_type()
+        print('debug 7') 
         self._session()
+        print('debug 8') 
         if self.has_data_description:
             self._session_description()
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -280,6 +280,7 @@ class generate_metadata:
         # Possible reason: 1) the behavior data is not started in the session. 
         if 'B_AnimalResponseHistory' not in self.Obj:
             self.has_behavior_data = False
+            logging.info('No animal response history to log in session metadata')
         else:
             self.has_behavior_data = True
         
@@ -298,36 +299,43 @@ class generate_metadata:
         # Possible reason: 1) the water calibration file is not included in the ForagingSettings folder. 2) the water calibration is not saved in the json file.
         if 'WaterCalibrationResults' not in self.Obj:
             self.Obj['WaterCalibrationResults'] = {} 
+            logging.info('No water calibration file for session metadata')
 
         # Missing field LaserCalibrationResults in the json file.
         # Possible reason: 1) the optogenetic calibration file is not included in the ForagingSettings folder. 2) the optogenetic calibration is not saved in the json file. 3) no optogenetics calibration for this rig.
         if 'LaserCalibrationResults' not in self.Obj:
             self.Obj['LaserCalibrationResults'] = {}
+            logging.info('No laser calibration file for session metadata')
 
         # Missing field open_ephys in the json file.
         # Possible reason: 1) The ephys data is recorded but the open ephys is not controlled by the behavior GUI in the old version.
         if 'open_ephys' not in self.Obj:
             self.Obj['open_ephys'] = []
+            logging.info('no open ephys data for session metadata')
         
         # Missing field Camera_dialog in the json file.
         # Possible reason: 1) Old version of the software.
         if 'Camera_dialog' not in self.Obj:
             self.Obj['Camera_dialog'] = {}
+            logging.info('no camera data for session metadata')
 
         # Missing field 'settings_box' in the json file.
         # Possible reason: 1) Old version of the software.
         if 'settings_box' not in self.Obj:
             self.Obj['settings_box'] = {}
+            logging.info('Missing settings_box.csv file for session metadata')
 
         # Missing field 'meta_data_dialog' in the json file.
         # Possible reason: 1) Old version of the software.
         if 'meta_data_dialog' not in self.Obj:
             self.Obj['meta_data_dialog'] = {}
+            logging.info('Missing metadata dialog for session metadata')
 
         # Missing field 'rig_metadata' in the json file.
         # Possible reason: 1) Old version of the software. 2) the rig metadata is not provided.
         if 'rig_metadata' not in self.Obj['meta_data_dialog']:
             self.Obj['meta_data_dialog']['rig_metadata'] = {}
+            logging.info('Missing rig metadata for session metadata')
 
         # Missing field 'rig_metadata_file' and 'MetadataFolder' in the json file.
         # Possible reason: 1) Old version of the software. 2) the rig metadata is not provided.
@@ -366,6 +374,7 @@ class generate_metadata:
 
         if self.Obj['meta_data_dialog']['session_metadata']['ProjectName']=='':
             self.has_data_description = False
+            logging.info('No data description for session metadata')
         else:
             self.has_data_description = True
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -62,16 +62,17 @@ class generate_metadata:
 
     '''
     def __init__(self, json_file=None, Obj=None, dialog_metadata_file=None,dialog_metadata=None, output_folder=None):
+        
         if json_file is None and Obj is None and dialog_metadata is None:
             logging.info("json file or Obj is not provided")
             return
-        print('debug 1')  
+
         if json_file is not None:
             with open(json_file) as f:
                 self.Obj = json.load(f)
         else:
             self.Obj = Obj
-        print('debug 2') 
+
         if dialog_metadata_file is not None:
             with open(dialog_metadata_file) as f:
                 self.Obj['meta_data_dialog'] = json.load(f)
@@ -80,18 +81,13 @@ class generate_metadata:
         
         if output_folder is not None:
             self.Obj['MetadataFolder'] = output_folder
-        print('debug 3') 
+
         self._handle_edge_cases()
-        print('debug 4') 
         self._save_rig_metadata()
-        print('debug 5') 
         self.Obj['session_metadata']= {}
         self._mapper()
-        print('debug 6') 
         self._get_box_type()
-        print('debug 7') 
         self._session()
-        print('debug 8') 
         if self.has_data_description:
             self._session_description()
 
@@ -396,16 +392,23 @@ class generate_metadata:
         # session_start_time and session_end_time are required fields
         if self.Obj['meta_data_dialog']['rig_metadata']=={}:
             return
-        
+        print('debug a') 
         self._get_reward_delivery()
+        print('debug b') 
         self._get_water_calibration()
+        print('debug c') 
         self._get_opto_calibration()
+        print('debug d') 
         self.calibration=self.water_calibration+self.opto_calibration
-
+        print('debug e') 
         self._get_behavior_stream()
+        print('debug f') 
         self._get_ephys_stream()
+        print('debug g') 
         self._get_ophys_stream()
+        print('debug h') 
         self._get_high_speed_camera_stream()
+        print('debug i') 
         self._get_session_time()
         if self.session_start_time == '' or self.session_end_time == '':
             return


### PR DESCRIPTION
- missing comma when I merged `develop` into `generate_session_metadata`
- changed the format of rig.json names to `rig_<current_box>`
- Merged two redundant functions (parts of `_LoadRigJson` and `_load_rig_metadata`) into `_load_most_recent_rig_json`
- Adding more verbose error message when generating session metadata
- Adds logging info when handling special cases