### PR TITLE
Backup data

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2302,16 +2302,14 @@ class Window(QMainWindow):
                     else:
                         Value=getattr(self.GeneratedTrials, attr_name)
                         try:
-                            if math.isnan(Value):
-                                Obj[attr_name]='nan'
+                            if isinstance(Value, float) or isinstance(Value, int):                                
+                                if math.isnan(Value):
+                                    Obj[attr_name]='nan'    
+                                else:
+                                    Obj[attr_name]=Value   
                             else:
-                                Obj[attr_name]=Value
+                                Obj[attr_name]=Value        
                         except Exception as e:
-                            # Lots of B_xxx data are not real scalars and thus math.isnan(Value) will fail
-                            # e.g. B_AnimalResponseHistory. We just save them as they are. 
-                            # This is expected and no need to log an error.
-                            # I don't know the necessity of turning nan values into 'nan', 
-                            # but for backward compatibility, I keep it above.
                             logging.info(f'{attr_name} is not a real scalar, save it as it is.')
                             Obj[attr_name]=Value
         # save other events, e.g. session start time

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -94,7 +94,7 @@ class Window(QMainWindow):
         self.ToInitializeVisual = 1 # Should we visualize performance
         self.FigureUpdateTooSlow = 0# if the FigureUpdateTooSlow is true, using different process to update figures
         self.ANewTrial = 1          # permission to start a new trial
-        self.to_save = 1            # permission to save backup data
+        self.save_backup_allowed = 1   # permission to save backup data; 0, the previous saving has not finished, and it will not trigger the next saving; 1, it is allowed to save backup data
         self.UpdateParameters = 1   # permission to update parameters
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
@@ -3302,7 +3302,7 @@ class Window(QMainWindow):
     
     def _thread_complete6(self):
         '''complete of save data'''
-        self.to_save=1
+        self.save_backup_allowed=1
 
     def _thread_complete_timer(self):
         '''complete of _Timer'''
@@ -3692,8 +3692,8 @@ class Window(QMainWindow):
                 if self.actionLicks_sta.isChecked():
                     self.PlotLick._Update(GeneratedTrials=GeneratedTrials)
                 # save the data everytrial
-                if GeneratedTrials.B_CurrentTrialN>0 and self.to_save==1 and self.save_each_trial:
-                    self.to_save=0
+                if GeneratedTrials.B_CurrentTrialN>0 and self.save_backup_allowed==1 and self.save_each_trial:
+                    self.save_backup_allowed=0
                     self.threadpool6.start(worker_save)
 
                 if GeneratedTrials.CurrentSimulation==True:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2189,6 +2189,11 @@ class Window(QMainWindow):
             ForceSave=1
             SaveAs=0
             SaveContinue=1
+            saving_type_label = 'backup saving'
+        elif ForceSave==1:
+            saving_type_label = 'force saving'
+        else:
+            saving_type_label = 'normal saving'
 
         logging.info('Saving current session, ForceSave={}'.format(ForceSave))
         if ForceSave==0:
@@ -2398,6 +2403,9 @@ class Window(QMainWindow):
         # save the metadata collected in the metadata dialogue
         self.Metadata_dialog._save_metadata_dialog_parameters()
         Obj['meta_data_dialog'] = self.Metadata_dialog.meta_data
+
+        # save the saving type (normal saving, backup saving or force saving)
+        Obj['saving_type_label'] = saving_type_label
 
         # generate the metadata file
         try:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3300,7 +3300,7 @@ class Window(QMainWindow):
         '''complete of generating a trial'''
         self.ToGenerateATrial=1
     
-    def _thread_complete5(self):
+    def _thread_complete6(self):
         '''complete of save data'''
         self.to_save=1
 
@@ -3573,7 +3573,7 @@ class Window(QMainWindow):
             workerStartTrialLoop = Worker(self._StartTrialLoop,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial)
             workerStartTrialLoop1 = Worker(self._StartTrialLoop1,GeneratedTrials)
             worker_save = Worker(self._Save,BackupSave=1)
-            worker_save.signals.finished.connect(self._thread_complete5)
+            worker_save.signals.finished.connect(self._thread_complete6)
             self.worker1=worker1
             self.workerLick=workerLick
             self.workerPlot=workerPlot

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2415,19 +2415,19 @@ class Window(QMainWindow):
                 json.dump(Obj, outfile, indent=4, cls=NumpyEncoder)
 
         # Toggle unsaved data to False
-        self.unsaved_data=False
-        self.Save.setStyleSheet("background-color : None;")
-        self.Save.setStyleSheet("color: black;")
-
-        short_file = self.SaveFile.split('\\')[-1]
-        self.WarningLabel.setText('Saved: {}'.format(short_file))
-        self.WarningLabel.setStyleSheet(self.default_warning_color)
-        
-        self.SessionlistSpin.setEnabled(True)
-        self.Sessionlist.setEnabled(True)
-
-        # Drop `finished` file with date/time
         if BackupSave==0:
+            self.unsaved_data=False
+            self.Save.setStyleSheet("background-color : None;")
+            self.Save.setStyleSheet("color: black;")
+
+            short_file = self.SaveFile.split('\\')[-1]
+            self.WarningLabel.setText('Saved: {}'.format(short_file))
+            self.WarningLabel.setStyleSheet(self.default_warning_color)
+            
+            self.SessionlistSpin.setEnabled(True)
+            self.Sessionlist.setEnabled(True)
+
+            # Drop `finished` file with date/time
             filepath = os.path.join(self.SessionFolder, 'finished') 
             contents = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             with open(filepath, 'w') as finished_file:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2378,12 +2378,12 @@ class Window(QMainWindow):
 
         if BackupSave==0:
             self._check_drop_frames(save_tag=1)
-
-        # save drop frames information
-        Obj['drop_frames_tag']=self.drop_frames_tag
-        Obj['trigger_length']=self.trigger_length
-        Obj['drop_frames_warning_text']=self.drop_frames_warning_text
-        Obj['frame_num']=self.frame_num
+            
+            # save drop frames information
+            Obj['drop_frames_tag']=self.drop_frames_tag
+            Obj['trigger_length']=self.trigger_length
+            Obj['drop_frames_warning_text']=self.drop_frames_warning_text
+            Obj['frame_num']=self.frame_num
 
         # save manual water 
         Obj['ManualWaterVolume']=self.ManualWaterVolume

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3571,15 +3571,15 @@ class Window(QMainWindow):
             workerGenerateAtrial.signals.finished.connect(self._thread_complete4)
             workerStartTrialLoop = Worker(self._StartTrialLoop,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial)
             workerStartTrialLoop1 = Worker(self._StartTrialLoop1,GeneratedTrials)
-            workderSave = Worker(self._Save,BackupSave=1)
-            workderSave.signals.finished.connect(self._thread_complete5)
+            worker_save = Worker(self._Save,BackupSave=1)
+            worker_save.signals.finished.connect(self._thread_complete5)
             self.worker1=worker1
             self.workerLick=workerLick
             self.workerPlot=workerPlot
             self.workerGenerateAtrial=workerGenerateAtrial
             self.workerStartTrialLoop=workerStartTrialLoop
             self.workerStartTrialLoop1=workerStartTrialLoop1
-            self.workderSave=workderSave
+            self.worker_save=worker_save
         else:
             PlotM=self.PlotM
             worker1=self.worker1
@@ -3588,7 +3588,7 @@ class Window(QMainWindow):
             workerGenerateAtrial=self.workerGenerateAtrial
             workerStartTrialLoop=self.workerStartTrialLoop
             workerStartTrialLoop1=self.workerStartTrialLoop1
-            workderSave=self.workderSave
+            worker_save=self.worker_save
 
   
         # collecting the base signal for photometry. Only run once
@@ -3612,7 +3612,7 @@ class Window(QMainWindow):
             self.WarningLabelStop.setText('Running photometry baseline')
             self.WarningLabelStop.setStyleSheet(self.default_warning_color)
         
-        self._StartTrialLoop(GeneratedTrials,worker1,workderSave)
+        self._StartTrialLoop(GeneratedTrials,worker1,worker_save)
 
         if self.actionDrawing_after_stopping.isChecked()==True:
             try:
@@ -3620,7 +3620,7 @@ class Window(QMainWindow):
             except Exception as e:
                 logging.error(str(e))
 
-    def _StartTrialLoop(self,GeneratedTrials,worker1,workderSave):
+    def _StartTrialLoop(self,GeneratedTrials,worker1,worker_save):
         if self.Start.isChecked():
             logging.info('starting trial loop')
         else:
@@ -3693,7 +3693,7 @@ class Window(QMainWindow):
                 # save the data everytrial
                 if GeneratedTrials.B_CurrentTrialN>0 and self.to_save==1:
                     self.to_save=0
-                    self.threadpool6.start(workderSave)
+                    self.threadpool6.start(worker_save)
 
                 if GeneratedTrials.CurrentSimulation==True:
                     GeneratedTrials._GetAnimalResponse(self.Channel,self.Channel3,self.Channel4)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3297,6 +3297,10 @@ class Window(QMainWindow):
         '''complete of generating a trial'''
         self.ToGenerateATrial=1
     
+    def _thread_complete5(self):
+        '''complete of save data'''
+        self.to_save=1
+
     def _thread_complete_timer(self):
         '''complete of _Timer'''
         if not self.ignore_timer:
@@ -3565,12 +3569,15 @@ class Window(QMainWindow):
             workerGenerateAtrial.signals.finished.connect(self._thread_complete4)
             workerStartTrialLoop = Worker(self._StartTrialLoop,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial)
             workerStartTrialLoop1 = Worker(self._StartTrialLoop1,GeneratedTrials)
+            workderSave = Worker(self._Save,BackupSave=1)
+            workderSave.signals.finished.connect(self._thread_complete5)
             self.worker1=worker1
             self.workerLick=workerLick
             self.workerPlot=workerPlot
             self.workerGenerateAtrial=workerGenerateAtrial
             self.workerStartTrialLoop=workerStartTrialLoop
             self.workerStartTrialLoop1=workerStartTrialLoop1
+            self.workderSave=workderSave
         else:
             PlotM=self.PlotM
             worker1=self.worker1
@@ -3579,6 +3586,7 @@ class Window(QMainWindow):
             workerGenerateAtrial=self.workerGenerateAtrial
             workerStartTrialLoop=self.workerStartTrialLoop
             workerStartTrialLoop1=self.workerStartTrialLoop1
+            workderSave=self.workderSave
 
   
         # collecting the base signal for photometry. Only run once

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -94,7 +94,7 @@ class Window(QMainWindow):
         self.ToInitializeVisual = 1 # Should we visualize performance
         self.FigureUpdateTooSlow = 0# if the FigureUpdateTooSlow is true, using different process to update figures
         self.ANewTrial = 1          # permission to start a new trial
-        self.save_backup_allowed = 1   # permission to save backup data; 0, the previous saving has not finished, and it will not trigger the next saving; 1, it is allowed to save backup data
+        self.previous_backup_completed = 1   # permission to save backup data; 0, the previous saving has not finished, and it will not trigger the next saving; 1, it is allowed to save backup data
         self.UpdateParameters = 1   # permission to update parameters
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
@@ -3302,7 +3302,7 @@ class Window(QMainWindow):
     
     def _thread_complete6(self):
         '''complete of save data'''
-        self.save_backup_allowed=1
+        self.previous_backup_completed=1
 
     def _thread_complete_timer(self):
         '''complete of _Timer'''
@@ -3692,8 +3692,8 @@ class Window(QMainWindow):
                 if self.actionLicks_sta.isChecked():
                     self.PlotLick._Update(GeneratedTrials=GeneratedTrials)
                 # save the data everytrial
-                if GeneratedTrials.B_CurrentTrialN>0 and self.save_backup_allowed==1 and self.save_each_trial:
-                    self.save_backup_allowed=0
+                if GeneratedTrials.B_CurrentTrialN>0 and self.previous_backup_completed==1 and self.save_each_trial:
+                    self.previous_backup_completed=0
                     self.threadpool6.start(worker_save)
 
                 if GeneratedTrials.CurrentSimulation==True:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -979,6 +979,7 @@ class Window(QMainWindow):
             'lick_spout_distance_box4':5000,
             'name_mapper_file':os.path.join(self.SettingFolder,"name_mapper.json"),
             'create_rig_metadata':True,
+            'save_each_trial':True,
         }
         
         # Try to load Settings_box#.csv
@@ -1046,6 +1047,8 @@ class Window(QMainWindow):
         self.lick_spout_distance_box3 = self.Settings['lick_spout_distance_box3']
         self.lick_spout_distance_box4 = self.Settings['lick_spout_distance_box4']
         self.name_mapper_file = self.Settings['name_mapper_file']
+        self.save_each_trial = self.Settings['save_each_trial']
+
         if not is_absolute_path(self.project_info_file):
             self.project_info_file = os.path.join(self.SettingFolder,self.project_info_file)
         # Also stream log info to the console if enabled
@@ -3691,7 +3694,7 @@ class Window(QMainWindow):
                 if self.actionLicks_sta.isChecked():
                     self.PlotLick._Update(GeneratedTrials=GeneratedTrials)
                 # save the data everytrial
-                if GeneratedTrials.B_CurrentTrialN>0 and self.to_save==1:
+                if GeneratedTrials.B_CurrentTrialN>0 and self.to_save==1 and self.save_each_trial:
                     self.to_save=0
                     self.threadpool6.start(worker_save)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -94,6 +94,7 @@ class Window(QMainWindow):
         self.ToInitializeVisual = 1 # Should we visualize performance
         self.FigureUpdateTooSlow = 0# if the FigureUpdateTooSlow is true, using different process to update figures
         self.ANewTrial = 1          # permission to start a new trial
+        self.to_save = 1            # permission to save backup data
         self.UpdateParameters = 1   # permission to update parameters
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
@@ -108,6 +109,7 @@ class Window(QMainWindow):
         self.threadpool3=QThreadPool() # visualization
         self.threadpool4=QThreadPool() # for generating a new trial
         self.threadpool5=QThreadPool() # for starting the trial loop
+        self.threadpool6=QThreadPool() # for saving data
         self.threadpool_workertimer=QThreadPool() # for timing
 
         # Set up more parameters
@@ -3610,7 +3612,7 @@ class Window(QMainWindow):
             self.WarningLabelStop.setText('Running photometry baseline')
             self.WarningLabelStop.setStyleSheet(self.default_warning_color)
         
-        self._StartTrialLoop(GeneratedTrials,worker1)
+        self._StartTrialLoop(GeneratedTrials,worker1,workderSave)
 
         if self.actionDrawing_after_stopping.isChecked()==True:
             try:
@@ -3618,7 +3620,7 @@ class Window(QMainWindow):
             except Exception as e:
                 logging.error(str(e))
 
-    def _StartTrialLoop(self,GeneratedTrials,worker1):
+    def _StartTrialLoop(self,GeneratedTrials,worker1,workderSave):
         if self.Start.isChecked():
             logging.info('starting trial loop')
         else:
@@ -3689,8 +3691,9 @@ class Window(QMainWindow):
                 if self.actionLicks_sta.isChecked():
                     self.PlotLick._Update(GeneratedTrials=GeneratedTrials)
                 # save the data everytrial
-                if GeneratedTrials.B_CurrentTrialN>1:
-                    self._Save(BackupSave=1)
+                if GeneratedTrials.B_CurrentTrialN>0 and self.to_save==1:
+                    self.to_save=0
+                    self.threadpool6.start(workderSave)
 
                 if GeneratedTrials.CurrentSimulation==True:
                     GeneratedTrials._GetAnimalResponse(self.Channel,self.Channel3,self.Channel4)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Back up the data each trial. 
2. The code for saving backup data runs in a different thread and does not affect the operation of behavior propagation in the main thread. 
3. The data format is the same as normal saving process. 

### What issues or discussions does this update address?
Back up the data in case the software crashes

### Describe the expected change in behavior from the perspective of the experimenter
No

The backup is turned on by default. If you want to turn it off, set `save_each_trial` in the `ForagingSettings.json` to `False`.

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
- [x] Tested on my own computer
- [x] Tested in 447
- [x] Tested in 323_EPHYS3




