### PR TITLE
Handle IO errors when checking existing rig.json

### DIFF
--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -18,28 +18,8 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     # Build the new rig schema
     rig = build_rig_json_core(settings, water_calibration, laser_calibration)
 
-    # Compare with existing rig schema 
+    # Serialize, and then deserialize to compare with existing rig schema 
     new_rig_json = json.loads(rig.model_dump_json())
-
-    #suffix = '_temp.json'
-    #rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
-    #new_rig_json_path = os.path.join(settings['rig_metadata_folder'],'rig_temp.json')
-    #with open(new_rig_json_path, 'r') as f:
-    #    new_rig_json = json.load(f)
-
-    ### DEBUG
-    ## Compare the two rig.jsons
-    #print('loading json and deserialized comparison')
-    #differences = DeepDiff(serialized, new_rig_json,ignore_order=True)
-
-    ## Remove the modification date, since that doesnt matter for comparison purposes
-    #values_to_ignore = ['modification_date','rig_id']
-    #for value in values_to_ignore:
-    #    if ('values_changed' in differences) and ("root['{}']".format(value) in differences['values_changed']):
-    #        differences['values_changed'].pop("root['{}']".format(value))
-    #        if len(differences['values_changed']) == 0:
-    #            differences.pop('values_changed')
-    ### DEBUG
 
     # Compare the two rig.jsons
     differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
@@ -54,22 +34,18 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
 
     # Determine which schema to use
     if len(differences) > 0:
-        # If any differences remain, rename the temp file
+        # If any differences remain save a new rig.json
         logging.info('differences with existing rig json: {}'.format(differences))
         # Write to file 
         time_str = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
         filename = '_{}_{}.json'.format(settings['rig_name'],time_str )
         rig.write_standard_file(
-            suffix='_{}_{}.json'.format(settings['rig_name'],time_str ), 
+            suffix=filename, 
             output_directory=settings['rig_metadata_folder']
             )
-        #final_path = os.path.join(settings['rig_metadata_folder'],filename)
-        #os.rename(new_rig_json_path, final_path)
         filename = 'rig'+filename
         logging.info('Saving new rig json: {}'.format(filename))
     else:
-        # Delete temp file
-        #os.remove(new_rig_json_path)
         logging.info('Using existing rig json')
 
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -69,7 +69,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
         logging.info('Saving new rig json: {}'.format(filename))
     else:
         # Delete temp file
-        os.remove(new_rig_json_path)
+        #os.remove(new_rig_json_path)
         logging.info('Using existing rig json')
 
 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -24,7 +24,6 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
    
     ## DEBUG 
     serialized = rig.model_dump_json()
-    deserialized = r.model_validate_json(serialized)
 
     suffix = '_temp.json'
     rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
@@ -35,7 +34,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     ## DEBUG
     # Compare the two rig.jsons
     print('loading json and deserialized comparison')
-    differences = DeepDiff(deserialized, new_rig_json,ignore_order=True)
+    differences = DeepDiff(serialized, new_rig_json,ignore_order=True)
 
     # Remove the modification date, since that doesnt matter for comparison purposes
     values_to_ignore = ['modification_date','rig_id']

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -19,7 +19,7 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     rig = build_rig_json_core(settings, water_calibration, laser_calibration)
 
     # Compare with existing rig schema 
-    new_rig_json = rig.model_dump_json()
+    new_rig_json = json.loads(rig.model_dump_json())
 
     #suffix = '_temp.json'
     #rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 

--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -18,33 +18,28 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
     # Build the new rig schema
     rig = build_rig_json_core(settings, water_calibration, laser_calibration)
 
-    # Compare with existing rig schema
-    # Write the new rig schema to a json file and load it back 
-    # I do this to ignore serialization issues when comparing the rig.jsons 
-   
-    ## DEBUG 
-    serialized = rig.model_dump_json()
+    # Compare with existing rig schema 
+    new_rig_json = rig.model_dump_json()
 
-    suffix = '_temp.json'
-    rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
-    new_rig_json_path = os.path.join(settings['rig_metadata_folder'],'rig_temp.json')
-    with open(new_rig_json_path, 'r') as f:
-        new_rig_json = json.load(f)
+    #suffix = '_temp.json'
+    #rig.write_standard_file(suffix=suffix, output_directory=settings['rig_metadata_folder']) 
+    #new_rig_json_path = os.path.join(settings['rig_metadata_folder'],'rig_temp.json')
+    #with open(new_rig_json_path, 'r') as f:
+    #    new_rig_json = json.load(f)
 
-    ## DEBUG
-    # Compare the two rig.jsons
-    print('loading json and deserialized comparison')
-    differences = DeepDiff(serialized, new_rig_json,ignore_order=True)
+    ### DEBUG
+    ## Compare the two rig.jsons
+    #print('loading json and deserialized comparison')
+    #differences = DeepDiff(serialized, new_rig_json,ignore_order=True)
 
-    # Remove the modification date, since that doesnt matter for comparison purposes
-    values_to_ignore = ['modification_date','rig_id']
-    for value in values_to_ignore:
-        if ('values_changed' in differences) and ("root['{}']".format(value) in differences['values_changed']):
-            differences['values_changed'].pop("root['{}']".format(value))
-            if len(differences['values_changed']) == 0:
-                differences.pop('values_changed')
-    ## DEBUG
-
+    ## Remove the modification date, since that doesnt matter for comparison purposes
+    #values_to_ignore = ['modification_date','rig_id']
+    #for value in values_to_ignore:
+    #    if ('values_changed' in differences) and ("root['{}']".format(value) in differences['values_changed']):
+    #        differences['values_changed'].pop("root['{}']".format(value))
+    #        if len(differences['values_changed']) == 0:
+    #            differences.pop('values_changed')
+    ### DEBUG
 
     # Compare the two rig.jsons
     differences = DeepDiff(existing_rig_json, new_rig_json,ignore_order=True)
@@ -63,9 +58,14 @@ def build_rig_json(existing_rig_json, settings, water_calibration, laser_calibra
         logging.info('differences with existing rig json: {}'.format(differences))
         # Write to file 
         time_str = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
-        filename = 'rig_{}_{}.json'.format(settings['rig_name'],time_str )
-        final_path = os.path.join(settings['rig_metadata_folder'],filename)
-        os.rename(new_rig_json_path, final_path)
+        filename = '_{}_{}.json'.format(settings['rig_name'],time_str )
+        rig.write_standard_file(
+            suffix='_{}_{}.json'.format(settings['rig_name'],time_str ), 
+            output_directory=settings['rig_metadata_folder']
+            )
+        #final_path = os.path.join(settings['rig_metadata_folder'],filename)
+        #os.rename(new_rig_json_path, final_path)
+        filename = 'rig'+filename
         logging.info('Saving new rig json: {}'.format(filename))
     else:
         # Delete temp file


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Previously, when creating a rig metadata, we wrote the new metadata to file, then loaded it back. We then compared this with the existing rig metadata which was loaded to file. We did this to ensure serialization/deserialization happened consistently with the old and new. This created I/O errors when the new file didn't finish writing by the time it was loaded back. So now I just serialize/deserialize in python without writing to disk. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/406
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/488

### Describe the expected change in behavior from the perspective of the experimenter
Should limit uncaught errors about JSON decoding

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested on my laptop
- [ ] tested in 447




