### PR TITLE
Stall timer resets with any Harp message

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3752,8 +3752,8 @@ class Window(QMainWindow):
                     # User continues, wait another stall_duration and prompt again
                     logging.error('trial stalled {} minutes, user continued trials'.format(elapsed_time))
                     stall_iteration +=1
-                else:
-                    print(self.Channel.last_message_time)
+            else:
+                print(self.Channel.last_message_time)
 
 
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -98,7 +98,6 @@ class Window(QMainWindow):
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
         self.to_check_drop_frames = 1 # 1, to check drop frames during saving data; 0, not to check drop frames 
-        self.session_stalled=False
 
         # Connect to Bonsai
         self._InitializeBonsai()
@@ -3229,7 +3228,6 @@ class Window(QMainWindow):
         self.StartANewSession=1
         self.CreateNewFolder=1
         self.PhotometryRun=0
-        self.session_stalled=False
 
         self.unsaved_data=False
         self.ManualWaterVolume=[0,0]     
@@ -3286,7 +3284,6 @@ class Window(QMainWindow):
                         self.ANewTrial=1
                         self.WarningLabel.setText('')
                         self.WarningLabel.setStyleSheet(self.default_warning_color)
-                        self.session_stalled=True
                         break
                     else:
                         stall_iteration+=1
@@ -3371,13 +3368,6 @@ class Window(QMainWindow):
         if self.Start.isChecked():
             logging.info('Start button pressed: starting trial loop')
             self.keyPressEvent()
-    
-            if self.session_stalled:
-                reply = QMessageBox.critical(self,
-                    'Box {}, Start'.format(self.box_letter),    
-                    'Cannot continue session after trials stalled. Please start new session',
-                    QMessageBox.Ok)
-                return 
 
             if self.StartANewSession == 0 :
                 reply = QMessageBox.question(self, 
@@ -3759,7 +3749,6 @@ class Window(QMainWindow):
                     # Give warning to user
                     self.WarningLabel.setText('Trials stalled, recheck bonsai connection.')
                     self.WarningLabel.setStyleSheet(self.default_warning_color)
-                    self.session_stalled=True
                     break
                 else:
                     # User continues, wait another stall_duration and prompt again

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3637,7 +3637,7 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 10#5*60 
+        stall_duration = 5*60 
 
         while self.Start.isChecked():
             QApplication.processEvents()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3714,8 +3714,10 @@ class Window(QMainWindow):
                 if self.NewTrialRewardOrder==1:
                     GeneratedTrials._GenerateATrial(self.Channel4)   
 
-            elif ((time.time() - last_trial_start) >stall_duration*stall_iteration) and ((time.time() - self.Channel.last_message_time) > stall_duration*stall_iteration):
+            elif ((time.time() - last_trial_start) >stall_duration*stall_iteration) and \
+                ((time.time() - self.Channel.last_message_time) > stall_duration*stall_iteration):
                 # Elapsed time since last trial is more than tolerance
+                # and elapsed time since last harp message is more than tolerance
 
                 # Check if we are in the photometry baseline period.
                 if (self.finish_Timer==0) & ((time.time() - last_trial_start) < (float(self.baselinetime.text())*60+10)):
@@ -3752,8 +3754,6 @@ class Window(QMainWindow):
                     # User continues, wait another stall_duration and prompt again
                     logging.error('trial stalled {} minutes, user continued trials'.format(elapsed_time))
                     stall_iteration +=1
-            else:
-                print(self.Channel.last_message_time)
 
 
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3637,7 +3637,7 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 5*60 
+        stall_duration = 10#5*60 
 
         while self.Start.isChecked():
             QApplication.processEvents()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -98,6 +98,7 @@ class Window(QMainWindow):
         self.loggingstarted = -1    # Have we started trial logging
         self.unsaved_data = False   # Setting unsaved data to False 
         self.to_check_drop_frames = 1 # 1, to check drop frames during saving data; 0, not to check drop frames 
+        self.session_stalled=False
 
         # Connect to Bonsai
         self._InitializeBonsai()
@@ -3228,6 +3229,7 @@ class Window(QMainWindow):
         self.StartANewSession=1
         self.CreateNewFolder=1
         self.PhotometryRun=0
+        self.session_stalled=False
 
         self.unsaved_data=False
         self.ManualWaterVolume=[0,0]     
@@ -3284,6 +3286,7 @@ class Window(QMainWindow):
                         self.ANewTrial=1
                         self.WarningLabel.setText('')
                         self.WarningLabel.setStyleSheet(self.default_warning_color)
+                        self.session_stalled=True
                         break
                     else:
                         stall_iteration+=1
@@ -3368,6 +3371,13 @@ class Window(QMainWindow):
         if self.Start.isChecked():
             logging.info('Start button pressed: starting trial loop')
             self.keyPressEvent()
+    
+            if self.session_stalled:
+                reply = QMessageBox.critical(self,
+                    'Box {}, Start'.format(self.box_letter),    
+                    'Cannot continue session after trials stalled. Please start new session',
+                    QMessageBox.Ok)
+                return 
 
             if self.StartANewSession == 0 :
                 reply = QMessageBox.question(self, 
@@ -3637,7 +3647,7 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 20#5*60 
+        stall_duration = 5*60 
 
         while self.Start.isChecked():
             QApplication.processEvents()
@@ -3749,6 +3759,7 @@ class Window(QMainWindow):
                     # Give warning to user
                     self.WarningLabel.setText('Trials stalled, recheck bonsai connection.')
                     self.WarningLabel.setStyleSheet(self.default_warning_color)
+                    self.session_stalled=True
                     break
                 else:
                     # User continues, wait another stall_duration and prompt again

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3637,7 +3637,7 @@ class Window(QMainWindow):
         # Track elapsed time in case Bonsai Stalls
         last_trial_start = time.time()
         stall_iteration = 1
-        stall_duration = 5*60 
+        stall_duration = 20#5*60 
 
         while self.Start.isChecked():
             QApplication.processEvents()
@@ -3714,7 +3714,7 @@ class Window(QMainWindow):
                 if self.NewTrialRewardOrder==1:
                     GeneratedTrials._GenerateATrial(self.Channel4)   
 
-            elif (time.time() - last_trial_start) >stall_duration*stall_iteration:
+            elif ((time.time() - last_trial_start) >stall_duration*stall_iteration) and ((time.time() - self.Channel.last_message_time) > stall_duration*stall_iteration):
                 # Elapsed time since last trial is more than tolerance
 
                 # Check if we are in the photometry baseline period.
@@ -3752,6 +3752,8 @@ class Window(QMainWindow):
                     # User continues, wait another stall_duration and prompt again
                     logging.error('trial stalled {} minutes, user continued trials'.format(elapsed_time))
                     stall_iteration +=1
+                else:
+                    print(self.Channel.last_message_time)
 
 
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):

--- a/src/foraging_gui/rigcontrol.py
+++ b/src/foraging_gui/rigcontrol.py
@@ -41,7 +41,6 @@ class RigClient:
         self.msgs.put([msg,args])
         msg_str = str(CurrentMessage)
         self.last_message_time = time.time()       
-        print(self.last_message_time)
  
         # Selectively log photometry messages 
         if (('PhotometryRising' in msg_str) or ('PhotometryFalling' in msg_str)):

--- a/src/foraging_gui/rigcontrol.py
+++ b/src/foraging_gui/rigcontrol.py
@@ -10,7 +10,8 @@ class RigClient:
         self.client = client
         self.client.addMsgHandler("default", self.msg_handler)
         self.msgs = queue.Queue(maxsize=0)
-    
+        self.last_message_time = time.time()   
+ 
         # Keep track photometry message history
         self.photometry_messages = {}
         self.photometry_message_tolerance = 2
@@ -39,7 +40,9 @@ class RigClient:
         CurrentMessage=[msg.address,args[1][0],msg.values()[2],msg.values()[3]]
         self.msgs.put([msg,args])
         msg_str = str(CurrentMessage)
-        
+        self.last_message_time = time.time()       
+        print(self.last_message_time)
+ 
         # Selectively log photometry messages 
         if (('PhotometryRising' in msg_str) or ('PhotometryFalling' in msg_str)):
             # Only selectively log these two messages


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Since we changed the punishment for early licking, trial durations have sometimes gotten long enough to trigger the stall timer. The stall timer was checking the elapsed time since the last trial start as a way of checking if bonsai had crashed. Now I reset the stall timer based on any harp message from bonsai. Therefore early licking cannot trigger the stall timer, since the licks will show up as harp messages. 

### What issues or discussions does this update address?
- resolves #483 

### Describe the expected change in behavior from the perspective of the experimenter
- Should see the stall timer only if bonsai crashes

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested in 447




