### PR TITLE
Automatically set IACUC protocol and Project Name from schedule

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -959,7 +959,7 @@ class Window(QMainWindow):
     
     def _LoadSchedule(self):
         if os.path.exists(self.Settings['schedule_path']):
-            schedule = pd.read_csv(self.Settings['schedule_path']
+            schedule = pd.read_csv(self.Settings['schedule_path'])
             
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -960,7 +960,12 @@ class Window(QMainWindow):
     def _LoadSchedule(self):
         if os.path.exists(self.Settings['schedule_path']):
             schedule = pd.read_csv(self.Settings['schedule_path'])
-            
+            box_list = []
+            for tower, box in itertools.product([1,2,3,6,7,8,9],['A','B','C','D']):
+                box_list.append(str(tower)+box)
+
+            self.schedule = schedule.query('Box in @box_list').copy() 
+            print(self.schedule)
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2636,6 +2636,7 @@ class Window(QMainWindow):
         self.BaseWeight.setText('')
         self.WeightAfter.setText('')
         self.TargetRatio.setText('0.85')
+        self.keyPressEvent(allow_reset=True) 
 
         # Set IACUC protocol in metadata based on schedule
         protocol = self._GetInfoFromSchedule(mouse_id,'Protocol')
@@ -2669,6 +2670,15 @@ class Window(QMainWindow):
                 self.Metadata_dialog.ProjectName.setCurrentIndex(index)
                 self.Metadata_dialog._show_project_info()
                 logging.info('Setting Project name: {}'.format('Behavior Platform'))
+            else:
+                project_info = {
+                        'Funding Institution':['Allen Institution'],
+                        'Grant Number':['nan'],
+                        'Investigators':['Jeremiah Cohen'],
+                        'Fundee':['nan'],
+                    }
+                self.Metadata_dialog.project_info(project_info)
+                self.ProjectName.addItems(['Behavior Platform'])
 
         self.keyPressEvent(allow_reset=True) 
         return 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2678,7 +2678,7 @@ class Window(QMainWindow):
                         'Fundee':['nan'],
                     }
                 self.Metadata_dialog.project_info = project_info
-                self.ProjectName.addItems(['Behavior Platform'])
+                self.Metadata_dialog.ProjectName.addItems(['Behavior Platform'])
 
         self.keyPressEvent(allow_reset=True) 
         return 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -994,7 +994,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
-            'schedule_path':os.path.join('/','allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
+            'schedule_path':os.path.join('\\','allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2647,16 +2647,30 @@ class Window(QMainWindow):
                 update_rig_metadata=False, 
                 update_session_metadata=True
                 )
+            logging.info('Setting IACUC Protocol: {}'.format(protocol))
 
         # Set Project Name in metadata based on schedule
         project_name = self._GetInfoFromSchedule(mouse_id, 'Project Name')
+        add_default = True
         if project_name is not None:
             projects = [self.Metadata_dialog.ProjectName.itemText(i) for i in range(self.Metadata_dialog.ProjectName.count())]
             print(projects)
-            #index = ?
-
-            #self.Metadata_dialog.ProjectName.setCurrentIndex(index)
-            #self.Metadata_dialog._show_project_info()
+            print(project_name)
+            index = np.where(np.array(projects) == project_name)[0]
+            if len(index) > 0:
+                index = index[0]
+                self.Metadata_dialog.ProjectName.setCurrentIndex(index)
+                self.Metadata_dialog._show_project_info()
+                logging.info('Setting Project name: {}'.format(project_name))
+                add_default = False
+        if add_default:
+            projects = [self.Metadata_dialog.ProjectName.itemText(i) for i in range(self.Metadata_dialog.ProjectName.count())]
+            index = np.where(np.array(projects) == 'Behavior Platform')[0]
+            if len(index) > 0:
+                index = index[0]
+                self.Metadata_dialog.ProjectName.setCurrentIndex(index)
+                self.Metadata_dialog._show_project_info()
+                logging.info('Setting Project name: {}'.format(project_name))
 
         self.keyPressEvent(allow_reset=True) 
         return 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2636,14 +2636,27 @@ class Window(QMainWindow):
         self.BaseWeight.setText('')
         self.WeightAfter.setText('')
         self.TargetRatio.setText('0.85')
-        
+
+        # Set IACUC protocol in metadata based on schedule
         protocol = self._GetInfoFromSchedule(mouse_id,'Protocol')
         print(protocol) ## DEBUGGING
         if protocol is not None:
-            # Set metadata protocol 
+
             self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol']=str(int(protocol))
-            self.Metadata_dialog._update_metadata(update_rig_metadata=False, update_session_metadata=True)
-            #self.Metadata_dialog.IACUCProtocol.setText(str(protocol)) 
+            self.Metadata_dialog._update_metadata(
+                update_rig_metadata=False, 
+                update_session_metadata=True
+                )
+
+        # Set Project Name in metadata based on schedule
+        project_name = self._GetInfoFromSchedule(mouse_id, 'Project Name')
+        if project_name is not None:
+            projects = [self.Metadata_dialog.ProjectName.itemText(i) for i in range(self.Metadata_dialog.ProjectName.count())]
+            print(projects)
+            #index = ?
+
+            #self.Metadata_dialog.ProjectName.setCurrentIndex(index)
+            #self.Metadata_dialog._show_project_info()
 
         self.keyPressEvent(allow_reset=True) 
         return 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -994,7 +994,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
-            'schedule_path':os.path.join('Z:/','allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
+            'schedule_path':os.path.join('Z:\\','dynamic_foraging','DynamicForagingSchedule.csv'),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -966,7 +966,7 @@ class Window(QMainWindow):
                 box_list.append(str(tower)+box)
 
             self.schedule = schedule.query('Box in @box_list').copy() 
-            #print(self.schedule)
+            print(self.schedule) ## DEBUGGING
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return
@@ -977,7 +977,7 @@ class Window(QMainWindow):
             return None
         if mouse_id not in self.schedule['Mouse ID'].values:
             return None
-        return schedule.query('`Mouse ID` == @mouse_id').iloc[0][column]
+        return self.schedule.query('`Mouse ID` == @mouse_id').iloc[0][column]
 
     def _GetSettings(self):
         '''
@@ -2638,6 +2638,7 @@ class Window(QMainWindow):
         self.TargetRatio.setText('0.85')
         
         protocol = self._GetInfoFromSchedule(mouse_id,'Protocol')
+        print(protocol) ## DEBUGGING
         if protocol is not None:
             # Set metadata protocol 
             self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol']=str(int(protocol))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -69,6 +69,7 @@ class Window(QMainWindow):
         self.SettingFile=os.path.join(self.SettingFolder,'ForagingSettings.json')
         self.SettingsBoxFile=os.path.join(self.SettingFolder,'Settings_box'+str(self.box_number)+'.csv')
         self._GetSettings()
+        self._LoadSchedule()
 
         # Load Settings that are specific to this box 
         self.LaserCalibrationFiles=os.path.join(self.SettingFolder,'LaserCalibration_{}.json'.format(box_number))
@@ -955,6 +956,14 @@ class Window(QMainWindow):
                 return True
             else:
                 return False
+    
+    def _LoadSchedule(self):
+        if os.path.exists(self.Settings['schedule_path']):
+            schedule = pd.read_csv(self.Settings['schedule_path']
+            
+        else:
+            logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
+            return
 
     def _GetSettings(self):
         '''
@@ -985,6 +994,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
+            'schedule_path':os.path.join('allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -966,6 +966,7 @@ class Window(QMainWindow):
                 box_list.append(str(tower)+box)
 
             self.schedule = schedule.query('Box in @box_list').copy() 
+            logging.info('Loaded behavior schedule')
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2677,7 +2677,7 @@ class Window(QMainWindow):
                         'Investigators':['Jeremiah Cohen'],
                         'Fundee':['nan'],
                     }
-                self.Metadata_dialog.project_info(project_info)
+                self.Metadata_dialog.project_info = project_info
                 self.ProjectName.addItems(['Behavior Platform'])
 
         self.keyPressEvent(allow_reset=True) 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -994,7 +994,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
-            'schedule_path':os.path.join('\\','allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
+            'schedule_path':os.path.join('Z:/','allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -971,13 +971,13 @@ class Window(QMainWindow):
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return
 
-    def _GetIACUC(self, mouse_id):
+    def _GetInfoFromSchedule(self, mouse_id, column):
         mouse_id = str(mouse_id)
         if not hasattr(self, 'schedule'):
             return None
         if mouse_id not in self.schedule['Mouse ID'].values:
             return None
-        return int(schedule.query('`Mouse ID` == @mouse_id').iloc[0].Protocol)
+        return schedule.query('`Mouse ID` == @mouse_id').iloc[0][column]
 
     def _GetSettings(self):
         '''
@@ -2637,10 +2637,10 @@ class Window(QMainWindow):
         self.WeightAfter.setText('')
         self.TargetRatio.setText('0.85')
         
-        protocol = self._GetIACUC(mouse_id)
+        protocol = self._GetInfoFromSchedule(mouse_id,'Protocol')
         if protocol is not None:
             # Set metadata protocol 
-            self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol']=str(protocol)
+            self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol']=str(int(protocol))
             self.Metadata_dialog._update_metadata(update_rig_metadata=False, update_session_metadata=True)
             #self.Metadata_dialog.IACUCProtocol.setText(str(protocol)) 
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -966,7 +966,6 @@ class Window(QMainWindow):
                 box_list.append(str(tower)+box)
 
             self.schedule = schedule.query('Box in @box_list').copy() 
-            print(self.schedule) ## DEBUGGING
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return
@@ -2639,9 +2638,7 @@ class Window(QMainWindow):
 
         # Set IACUC protocol in metadata based on schedule
         protocol = self._GetInfoFromSchedule(mouse_id,'Protocol')
-        print(protocol) ## DEBUGGING
         if protocol is not None:
-
             self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol']=str(int(protocol))
             self.Metadata_dialog._update_metadata(
                 update_rig_metadata=False, 
@@ -2653,9 +2650,8 @@ class Window(QMainWindow):
         project_name = self._GetInfoFromSchedule(mouse_id, 'Project Name')
         add_default = True
         if project_name is not None:
-            projects = [self.Metadata_dialog.ProjectName.itemText(i) for i in range(self.Metadata_dialog.ProjectName.count())]
-            print(projects)
-            print(project_name)
+            projects = [self.Metadata_dialog.ProjectName.itemText(i) 
+                for i in range(self.Metadata_dialog.ProjectName.count())]
             index = np.where(np.array(projects) == project_name)[0]
             if len(index) > 0:
                 index = index[0]
@@ -2664,13 +2660,14 @@ class Window(QMainWindow):
                 logging.info('Setting Project name: {}'.format(project_name))
                 add_default = False
         if add_default:
-            projects = [self.Metadata_dialog.ProjectName.itemText(i) for i in range(self.Metadata_dialog.ProjectName.count())]
+            projects = [self.Metadata_dialog.ProjectName.itemText(i) 
+                for i in range(self.Metadata_dialog.ProjectName.count())]
             index = np.where(np.array(projects) == 'Behavior Platform')[0]
             if len(index) > 0:
                 index = index[0]
                 self.Metadata_dialog.ProjectName.setCurrentIndex(index)
                 self.Metadata_dialog._show_project_info()
-                logging.info('Setting Project name: {}'.format(project_name))
+                logging.info('Setting Project name: {}'.format('Behavior Platform'))
 
         self.keyPressEvent(allow_reset=True) 
         return 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -994,7 +994,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
-            'schedule_path':os.path.join('allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
+            'schedule_path':os.path.join('/','allen','aind','scratch','dynamic_foraging','DynamicForagingSchedule.csv'),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -971,6 +971,13 @@ class Window(QMainWindow):
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return
 
+    def _GetIACUC(self, mouse_id):
+        if not hasattr(self, 'schedule'):
+            return None
+        if str(mouse_id) not in self.schedule['Mouse ID'].values:
+            return None
+        return int(schedule.query('`Mouse ID` == @mouse_id').iloc[0].Protocol)
+
     def _GetSettings(self):
         '''
             Load the settings that are specific to this computer

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2679,9 +2679,9 @@ class Window(QMainWindow):
                     }
                 self.Metadata_dialog.project_info = project_info
                 self.Metadata_dialog.ProjectName.addItems(['Behavior Platform'])
+                logging.info('Setting Project name: {}'.format('Behavior Platform'))
 
         self.keyPressEvent(allow_reset=True) 
-        return 
     
     def _Open_getListOfMice(self):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -10,6 +10,7 @@ import socket
 import harp
 import pandas as pd
 import threading
+import itertools
 from pathlib import Path
 from datetime import date, datetime
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -966,15 +966,16 @@ class Window(QMainWindow):
                 box_list.append(str(tower)+box)
 
             self.schedule = schedule.query('Box in @box_list').copy() 
-            print(self.schedule)
+            #print(self.schedule)
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))
             return
 
     def _GetIACUC(self, mouse_id):
+        mouse_id = str(mouse_id)
         if not hasattr(self, 'schedule'):
             return None
-        if str(mouse_id) not in self.schedule['Mouse ID'].values:
+        if mouse_id not in self.schedule['Mouse ID'].values:
             return None
         return int(schedule.query('`Mouse ID` == @mouse_id').iloc[0].Protocol)
 
@@ -2635,6 +2636,14 @@ class Window(QMainWindow):
         self.BaseWeight.setText('')
         self.WeightAfter.setText('')
         self.TargetRatio.setText('0.85')
+        
+        protocol = self._GetIACUC(mouse_id)
+        if protocol is not None:
+            # Set metadata protocol 
+            self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol']=str(protocol)
+            self.Metadata_dialog._update_metadata(update_rig_metadata=False, update_session_metadata=True)
+            #self.Metadata_dialog.IACUCProtocol.setText(str(protocol)) 
+
         self.keyPressEvent(allow_reset=True) 
         return 
     

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -961,11 +961,7 @@ class Window(QMainWindow):
     def _LoadSchedule(self):
         if os.path.exists(self.Settings['schedule_path']):
             schedule = pd.read_csv(self.Settings['schedule_path'])
-            box_list = []
-            for tower, box in itertools.product([1,2,3,6,7,8,9],['A','B','C','D']):
-                box_list.append(str(tower)+box)
-
-            self.schedule = schedule.query('Box in @box_list').copy() 
+            schedule = schedule.dropna(subset=['Mouse ID','Box']).copy()
             logging.info('Loaded behavior schedule')
         else:
             logging.error('Could not find schedule at {}'.format(self.Settings['schedule_path']))


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Uses a cached copy of the training schedule to set the IACUC protocol and Project Name when starting a new mouse
- The cached copy is refreshed every 2 minutes (process running on my computer), and saved at `/allen/aind/scratch/dynamic_foraging/DynamicForagingSchedule.csv`
- If the mouse is not on the schedule, no IACUC protocol is set, and the Project Name defaults to "Behavior Platform"
- If the project description file is not present, then the Project Name defaults to "Behavior Platform"
- Since the ephys rigs and 428 are not on the schedule, they will not have these fields set. But if the mouse went through training in 446/447, then it will already be set by the time the mouse goes to ephys/428

### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested in 447




