### PR TITLE
Update random method

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -238,7 +238,8 @@ class Window(QMainWindow):
         self.TargetRatio.textChanged.connect(self._UpdateSuggestedWater)
         self.WeightAfter.textChanged.connect(self._PostWeightChange)
         self.BaseWeight.textChanged.connect(self._UpdateSuggestedWater)
-        self.Randomness.currentIndexChanged.connect(self._Randomness)
+        self.RandomnessBlock.currentIndexChanged.connect(self._RandomnessBlock)
+        self.RandomnessOther.currentIndexChanged.connect(self._RandomnessOther)
         self.actionTemporary_Logging.triggered.connect(self._startTemporaryLogging)
         self.actionFormal_logging.triggered.connect(self._startFormalLogging)
         self.actionOpen_logging_folder.triggered.connect(self._OpenLoggingFolder)
@@ -1570,28 +1571,29 @@ class Window(QMainWindow):
                 pass
                 #widget.clear()
 
-    def _Randomness(self):
-        '''enable/disable some fields in the Block/Delay Period/ITI'''
-        if self.Randomness.currentText()=='Exponential':
+    def _RandomnessBlock(self):
+        '''enable/disable some fields in the Block'''
+        if self.RandomnessBlock.currentText()=='Exponential':
             self.label_14.setEnabled(True)
-            self.label_18.setEnabled(True)
-            self.label_39.setEnabled(True)
             self.BlockBeta.setEnabled(True)
-            self.DelayBeta.setEnabled(True)
-            self.ITIBeta.setEnabled(True)
-            # if self.Task.currentText()!='RewardN':
-            #     self.BlockBeta.setStyleSheet("color: black;border: 1px solid gray;background-color: white;")
+
         elif self.Randomness.currentText()=='Even':
             self.label_14.setEnabled(False)
+            self.BlockBeta.setEnabled(False)
+
+    def _RandomnessOther(self):
+        '''enable/disable some fields in the Delay Period/ITI'''
+        if self.RandomnessOther.currentText()=='Exponential':
+            self.label_18.setEnabled(True)
+            self.label_39.setEnabled(True)
+            self.DelayBeta.setEnabled(True)
+            self.ITIBeta.setEnabled(True)
+
+        elif self.Randomness.currentText()=='Even':
             self.label_18.setEnabled(False)
             self.label_39.setEnabled(False)
-            self.BlockBeta.setEnabled(False)
             self.DelayBeta.setEnabled(False)
             self.ITIBeta.setEnabled(False)
-            # if self.Task.currentText()!='RewardN':
-            #     border_color = "rgb(100, 100, 100,80)"
-            #     border_style = "1px solid " + border_color
-            #     self.BlockBeta.setStyleSheet(f"color: gray;border:{border_style};background-color: rgba(0, 0, 0, 0);")
 
     def _AdvancedBlockAuto(self):
         '''enable/disable some fields in the AdvancedBlockAuto'''
@@ -1835,7 +1837,8 @@ class Window(QMainWindow):
         '''hide and show some fields based on the task type'''
         self.label_43.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
         self.ITIIncrease.setStyleSheet("background-color: rgba(0, 0, 0, 0); color: rgba(0, 0, 0, 0);""border: none;")
-        self._Randomness()
+        self._RandomnessBlock()
+        self._RandomnessOther()
 
         if self.Task.currentText() in ['Coupled Baiting','Coupled Without Baiting']:
             self.label_6.setEnabled(True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2793,8 +2793,6 @@ class Window(QMainWindow):
                                 self._AutoReward()
                             if key=='NextBlock':
                                 self._NextBlock()
-                    elif key=='RandomnessBlock':
-                        self._set_default_randomness(Obj['Task'])
                     else:
                         widget = widget_dict[key]
                         if not (isinstance(widget, QtWidgets.QComboBox) or isinstance(widget, QtWidgets.QPushButton)):
@@ -2865,15 +2863,6 @@ class Window(QMainWindow):
             self.NewSession.setDisabled(False)
         self.StartExcitation.setChecked(False)
         self.keyPressEvent() # Accept all updates
-
-    def _set_default_randomness(self,task):
-        '''Set the default block randomness for different tasks'''
-        if task in ['Uncoupled Baiting','Uncoupled Without Baiting']:
-            index = self.RandomnessBlock.findText('Even')
-            self.RandomnessBlock.setCurrentIndex(index)
-        elif task in ['Coupled Baiting','Coupled Without Baiting','RewardN']:
-            index = self.RandomnessBlock.findText('Exponential')
-            self.RandomnessBlock.setCurrentIndex(index)
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2793,6 +2793,8 @@ class Window(QMainWindow):
                                 self._AutoReward()
                             if key=='NextBlock':
                                 self._NextBlock()
+                    elif key=='RandomnessBlock':
+                        self._set_default_randomness(Obj['Task'])
                     else:
                         widget = widget_dict[key]
                         if not (isinstance(widget, QtWidgets.QComboBox) or isinstance(widget, QtWidgets.QPushButton)):
@@ -2863,6 +2865,15 @@ class Window(QMainWindow):
             self.NewSession.setDisabled(False)
         self.StartExcitation.setChecked(False)
         self.keyPressEvent() # Accept all updates
+
+    def _set_default_randomness(self,task):
+        '''Set the default block randomness for different tasks'''
+        if task in ['Uncoupled Baiting','Uncoupled Without Baiting']:
+            index = self.RandomnessBlock.findText('Even')
+            self.RandomnessBlock.setCurrentIndex(index)
+        elif task in ['Coupled Baiting','Coupled Without Baiting','RewardN']:
+            index = self.RandomnessBlock.findText('Exponential')
+            self.RandomnessBlock.setCurrentIndex(index)
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1577,7 +1577,7 @@ class Window(QMainWindow):
             self.label_14.setEnabled(True)
             self.BlockBeta.setEnabled(True)
 
-        elif self.Randomness.currentText()=='Even':
+        elif self.RandomnessBlock.currentText()=='Even':
             self.label_14.setEnabled(False)
             self.BlockBeta.setEnabled(False)
 
@@ -1589,7 +1589,7 @@ class Window(QMainWindow):
             self.DelayBeta.setEnabled(True)
             self.ITIBeta.setEnabled(True)
 
-        elif self.Randomness.currentText()=='Even':
+        elif self.RandomnessOther.currentText()=='Even':
             self.label_18.setEnabled(False)
             self.label_39.setEnabled(False)
             self.DelayBeta.setEnabled(False)

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -2632,9 +2632,9 @@ Double dipping:
                <widget class="QWidget" name="scrollAreaWidgetContents_2">
                 <property name="geometry">
                  <rect>
-                  <x>-258</x>
+                  <x>-475</x>
                   <y>0</y>
-                  <width>1088</width>
+                  <width>1090</width>
                   <height>457</height>
                  </rect>
                 </property>
@@ -4556,7 +4556,7 @@ Double dipping:
                          </sizepolicy>
                         </property>
                         <property name="text">
-                         <string>randomness other=</string>
+                         <string>randomness ITI/delay=</string>
                         </property>
                         <property name="textFormat">
                          <enum>Qt::AutoText</enum>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -3462,7 +3462,7 @@ Double dipping:
                          </sizepolicy>
                         </property>
                         <property name="text">
-                         <string>Reward delay=</string>
+                         <string>reward delay=</string>
                         </property>
                         <property name="textFormat">
                          <enum>Qt::AutoText</enum>
@@ -3885,7 +3885,7 @@ Double dipping:
                          </sizepolicy>
                         </property>
                         <property name="text">
-                         <string>Reward consume time =</string>
+                         <string>reward consume time =</string>
                         </property>
                         <property name="textFormat">
                          <enum>Qt::AutoText</enum>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4513,6 +4513,9 @@ Double dipping:
                           <height>16777215</height>
                          </size>
                         </property>
+                        <property name="currentIndex">
+                         <number>1</number>
+                        </property>
                         <item>
                          <property name="text">
                           <string>Exponential</string>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -910,7 +910,7 @@
             <string notr="true"/>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>2</number>
            </property>
            <widget class="QWidget" name="tab_2">
             <attribute name="title">
@@ -2632,9 +2632,9 @@ Double dipping:
                <widget class="QWidget" name="scrollAreaWidgetContents_2">
                 <property name="geometry">
                  <rect>
-                  <x>0</x>
+                  <x>-258</x>
                   <y>0</y>
-                  <width>1072</width>
+                  <width>1088</width>
                   <height>457</height>
                  </rect>
                 </property>
@@ -3741,25 +3741,6 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="0" column="8">
-                       <widget class="QLabel" name="label_9">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>randomness=</string>
-                        </property>
-                        <property name="textFormat">
-                         <enum>Qt::AutoText</enum>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                        </property>
-                       </widget>
-                      </item>
                       <item row="10" column="1" rowspan="2">
                        <widget class="Line" name="line">
                         <property name="orientation">
@@ -4146,32 +4127,6 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="0" column="9" colspan="2">
-                       <widget class="QComboBox" name="Randomness">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>70</width>
-                          <height>16777215</height>
-                         </size>
-                        </property>
-                        <item>
-                         <property name="text">
-                          <string>Exponential</string>
-                         </property>
-                        </item>
-                        <item>
-                         <property name="text">
-                          <string>Even</string>
-                         </property>
-                        </item>
-                       </widget>
-                      </item>
                       <item row="1" column="6">
                        <widget class="QDoubleSpinBox" name="RightValue">
                         <property name="sizePolicy">
@@ -4544,6 +4499,96 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
+                      <item row="0" column="6">
+                       <widget class="QComboBox" name="RandomnessBlock">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>80</width>
+                          <height>16777215</height>
+                         </size>
+                        </property>
+                        <item>
+                         <property name="text">
+                          <string>Exponential</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>Even</string>
+                         </property>
+                        </item>
+                       </widget>
+                      </item>
+                      <item row="0" column="5">
+                       <widget class="QLabel" name="label_9">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>randomness block=</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="8">
+                       <widget class="QLabel" name="label_34">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>randomness other=</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="0" column="9">
+                       <widget class="QComboBox" name="RandomnessOther">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>80</width>
+                          <height>16777215</height>
+                         </size>
+                        </property>
+                        <item>
+                         <property name="text">
+                          <string>Exponential</string>
+                         </property>
+                        </item>
+                        <item>
+                         <property name="text">
+                          <string>Even</string>
+                         </property>
+                        </item>
+                       </widget>
+                      </item>
                      </layout>
                     </item>
                    </layout>
@@ -4613,8 +4658,8 @@ Current pair:
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>722</width>
-                  <height>308</height>
+                  <width>627</width>
+                  <height>325</height>
                  </rect>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_16">
@@ -5287,7 +5332,7 @@ Current pair:
    <property name="text">
     <string>New session</string>
    </property>
-  </action> 
+  </action>
   <action name="actionLaser_Calibration">
    <property name="checkable">
     <bool>true</bool>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2470,9 +2470,9 @@
     <widget class="QLabel" name="label_30">
      <property name="geometry">
       <rect>
-       <x>760</x>
+       <x>730</x>
        <y>20</y>
-       <width>101</width>
+       <width>131</width>
        <height>23</height>
       </rect>
      </property>
@@ -2483,7 +2483,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>randomness other=</string>
+      <string>randomness ITI/delay=</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1872,9 +1872,9 @@
     <widget class="QLabel" name="label_9">
      <property name="geometry">
       <rect>
-       <x>529</x>
+       <x>509</x>
        <y>23</y>
-       <width>81</width>
+       <width>101</width>
        <height>23</height>
       </rect>
      </property>
@@ -1885,7 +1885,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>randomness=</string>
+      <string>randomness block=</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
@@ -1894,7 +1894,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QComboBox" name="Randomness">
+    <widget class="QComboBox" name="RandomnessBlock">
      <property name="geometry">
       <rect>
        <x>614</x>
@@ -2430,6 +2430,57 @@
      </property>
      <property name="text">
       <string>window size (trials)=</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="RandomnessOther">
+     <property name="geometry">
+      <rect>
+       <x>865</x>
+       <y>20</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>Exponential</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Even</string>
+      </property>
+     </item>
+    </widget>
+    <widget class="QLabel" name="label_30">
+     <property name="geometry">
+      <rect>
+       <x>760</x>
+       <y>20</y>
+       <width>101</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>randomness other=</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
@@ -4508,6 +4559,10 @@
      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
     </property>
    </widget>
+   <zorder>TrainingParameters</zorder>
+   <zorder>StartFIP</zorder>
+   <zorder>FIPMode</zorder>
+   <zorder>label_65</zorder>
    <zorder>PhotometryB</zorder>
    <zorder>infor</zorder>
    <zorder>line</zorder>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1910,7 +1910,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <item>
       <property name="text">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1549,7 +1549,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Reward consume time=</string>
+      <string>reward consume time=</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
@@ -2180,7 +2180,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Reward delay=</string>
+      <string>reward delay=</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1909,6 +1909,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
      <item>
       <property name="text">
        <string>Exponential</string>

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -366,9 +366,9 @@ class GenerateTrials():
         # get the reward probabilities of the current block
         self.B_CurrentRewardProb=RewardProbPool[random.choice(range(np.shape(RewardProbPool)[0]))]
         # randomly draw a block length between Min and Max
-        if self.TP_Randomness=='Exponential':
+        if self.TP_RandomnessBlock=='Exponential':
             self.BlockLen = np.array(int(np.random.exponential(float(self.TP_BlockBeta),1)+float(self.TP_BlockMin)))
-        elif self.TP_Randomness=='Even':
+        elif self.TP_RandomnessBlock=='Even':
             self.BlockLen=  np.array(np.random.randint(float(self.TP_BlockMin), float(self.TP_BlockMax)+1))
         if self.BlockLen>float(self.TP_BlockMax):
             self.BlockLen=int(self.TP_BlockMax)
@@ -379,13 +379,13 @@ class GenerateTrials():
 
     def _generate_next_trial_other_paras(self):
         # get the ITI time and delay time
-        if self.TP_Randomness=='Exponential':
+        if self.TP_RandomnessOther=='Exponential':
             self.CurrentITI = float(np.random.exponential(float(self.TP_ITIBeta),1)+float(self.TP_ITIMin))
         elif self.TP_Randomness=='Even':
             self.CurrentITI = random.uniform(float(self.TP_ITIMin),float(self.TP_ITIMax))
         if self.CurrentITI>float(self.TP_ITIMax):
             self.CurrentITI=float(self.TP_ITIMax)
-        if self.TP_Randomness=='Exponential':
+        if self.TP_RandomnessOther=='Exponential':
             self.CurrentDelay = float(np.random.exponential(float(self.TP_DelayBeta),1)+float(self.TP_DelayMin))
         elif self.TP_Randomness=='Even':
             self.CurrentDelay=random.uniform(float(self.TP_DelayMin),float(self.TP_DelayMax))

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -134,6 +134,8 @@ class GenerateTrials():
                     persev_add=True,  # Hard-coded to True for now
                     perseverative_limit=4, # Hard-coded to 4 for now
                     max_block_tally=3, # Hard-coded to 3 for now
+                    block_beta=float(self.TP_BlockBeta),
+                    random_distribution_block=self.TP_RandomnessBlock,
                 )
                 _, msg_uncoupled_block = self.uncoupled_blocks.next_trial()
             else:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -135,7 +135,7 @@ class GenerateTrials():
                     perseverative_limit=4, # Hard-coded to 4 for now
                     max_block_tally=3, # Hard-coded to 3 for now
                     block_beta=float(self.TP_BlockBeta),
-                    random_distribution_block=self.TP_RandomnessBlock,
+                    random_distribution_block='Even', # Hard-coded to 'Even' for now. Show be changed to `self.TP_RandomnessBlock` after updating the curriculum. 
                 )
                 _, msg_uncoupled_block = self.uncoupled_blocks.next_trial()
             else:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -135,7 +135,7 @@ class GenerateTrials():
                     perseverative_limit=4, # Hard-coded to 4 for now
                     max_block_tally=3, # Hard-coded to 3 for now
                     block_beta=float(self.TP_BlockBeta),
-                    random_distribution_block='Even', # Hard-coded to 'Even' for now. Show be changed to `self.TP_RandomnessBlock` after updating the curriculum. 
+                    random_distribution_block=self.TP_RandomnessBlock, 
                 )
                 _, msg_uncoupled_block = self.uncoupled_blocks.next_trial()
             else:

--- a/src/foraging_gui/TransferToNWB.py
+++ b/src/foraging_gui/TransferToNWB.py
@@ -347,7 +347,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
             randomness_distribution_block = 'Exponential'
             randomness_distribution_delay = 'Exponential'
             randomness_distribution_ITI = 'Exponential'
-        # The randomness distribution is defined in the task parameters both for coupled and uncoupled task
+        # The randomness distribution is defined in the task parameters (TP_RandomnessBlock and TP_RandomnessOther) both for coupled and uncoupled task
         elif hasattr(obj, 'TP_RandomnessBlock') and hasattr(obj, 'TP_RandomnessOther'):
             randomness_distribution_block = getattr(obj, 'TP_RandomnessBlock')[i]
             randomness_distribution_delay = getattr(obj, 'TP_RandomnessOther')[i]
@@ -361,7 +361,7 @@ def bonsai_to_nwb(fname, save_folder=save_folder):
                 randomness_distribution_block = getattr(obj, 'TP_Randomness')[i]
             randomness_distribution_delay = getattr(obj, 'TP_Randomness')[i]
             randomness_distribution_ITI = getattr(obj, 'TP_Randomness')[i]
-        # Before Feb 27, the randomness distribution is defined in the task parameters both for coupled and uncouplded tasks.
+        # Before Feb 27, the randomness distribution is defined in the task parameters (TP_Randomness) both for coupled and uncouplded tasks.
         else:
             randomness_distribution_block = getattr(obj, 'TP_Randomness')[i]
             randomness_distribution_delay = getattr(obj, 'TP_Randomness')[i]

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -544,25 +544,26 @@ class PlotTimeDistribution(FigureCanvas):
         FigureCanvas.__init__(self, self.fig)
     def _Update(self,win):
         # randomly draw a block length between Min and Max
-        SampleMethods=win.Randomness.currentText()
+        SampleMethodsBlock=win.RandomnessBlock.currentText()
+        SampleMethodsOther=win.RandomnessOther.currentText()
         # block length
         Min=float(win.BlockMin.text())
         Max=float(win.BlockMax.text())
         Beta=float(win.BlockBeta.text())
         DataType='int'
-        SampledBlockLen=self._Sample(Min=Min,Max=Max,SampleMethods=SampleMethods,Beta=Beta,DataType=DataType)
+        SampledBlockLen=self._Sample(Min=Min,Max=Max,SampleMethods=SampleMethodsBlock,Beta=Beta,DataType=DataType)
         # ITI 
         Min=float(win.ITIMin.text())
         Max=float(win.ITIMax.text())
         Beta=float(win.ITIBeta.text())
         DataType='float'
-        SampledITI=self._Sample(Min=Min,Max=Max,SampleMethods=SampleMethods,Beta=Beta,DataType=DataType)
+        SampledITI=self._Sample(Min=Min,Max=Max,SampleMethods=SampleMethodsOther,Beta=Beta,DataType=DataType)
         # Delay
         Min=float(win.DelayMin.text())
         Max=float(win.DelayMax.text())
         Beta=float(win.DelayBeta.text())
         DataType='float'
-        SampledDelay=self._Sample(Min=Min,Max=Max,SampleMethods=SampleMethods,Beta=Beta,DataType=DataType)
+        SampledDelay=self._Sample(Min=Min,Max=Max,SampleMethods=SampleMethodsOther,Beta=Beta,DataType=DataType)
         self.ax1.cla()
         self.ax2.cla()
         self.ax3.cla()

--- a/src/foraging_gui/reward_schedules/uncoupled_block.py
+++ b/src/foraging_gui/reward_schedules/uncoupled_block.py
@@ -21,6 +21,8 @@ class UncoupledBlocks:
                  block_min=20, block_max=35,
                  persev_add=True, perseverative_limit=4,
                  max_block_tally=4,  # Max number of consecutive blocks in which one side has higher rwd prob than the other
+                 block_beta=None, # for exponential distribution
+                 random_distribution_block='Even',
                  ) -> None:
         
         self.__dict__.update(locals())
@@ -65,8 +67,13 @@ class UncoupledBlocks:
     def generate_next_block(self, side, check_higher_in_a_row=True, check_both_lowest=True):
         msg = ''
         other_side = list({'L', 'R'} - {side})[0]
-        random_block_len = np.random.randint(low=self.block_min, high=self.block_max + 1)
-        
+        if self.random_distribution_block == 'Even':
+            random_block_len = np.random.randint(low=self.block_min, high=self.block_max + 1)
+        elif self.random_distribution_block == 'Exponential' and self.block_beta is not None:
+            self.BlockLen = np.array(int(np.random.exponential(float(self.block_beta),1)+float(self.block_min)))
+            if self.BlockLen>float(self.block_max):
+                self.BlockLen=int(self.block_max)
+
         if self.block_ind[side] == 0:  # The first block
             self.block_ends[side].append(random_block_len)
             self.block_rwd_prob[side].append(np.random.choice(self.rwd_prob_array))


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Enable to set the randomness methods (even and exponential distribution) separately for block length and ITI/Delay. 
2. Updated the NWB file to include the randomness fields.
3. The uncoupled task hard-coded the randomness methods for block length as `even`. The update allows us to control the randomness of the uncoupled tasks from the GUI.

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/542

### Describe the expected change in behavior from the perspective of the experimenter
1. The curriculum may need updating in the future (@hanhou). The `Randomness` was moved and updated with two fields called `RandomnessBlock` and `RandomnessOther`. If not provided, `RandomnessBlock` and `RandomnessOther` will default to `Even` and `Exponential` respectively.

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
- [x] tested on my own computer




