### PR TITLE
Checks for full water calibration before spot check

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -951,7 +951,7 @@ class WaterCalibrationDialog(QDialog):
                 reply = QMessageBox.critical(self, 'Spot check left', 
                     'Please perform full calibration before spot check', 
                     QMessageBox.Ok)
-                logging.error('Cannot perform spot check before full calibration')  
+                logging.warning('Cannot perform spot check before full calibration')  
                 self.SpotCheckLeft.setStyleSheet("background-color : none;")
                 self.SpotCheckLeft.setChecked(False)        
                 self.Warning.setText('')
@@ -1089,6 +1089,19 @@ class WaterCalibrationDialog(QDialog):
             return
 
         if self.SpotCheckRight.isChecked():
+            if 'Right' not in self.MainWindow.latest_fitting:
+                reply = QMessageBox.critical(self, 'Spot check right', 
+                    'Please perform full calibration before spot check', 
+                    QMessageBox.Ok)
+                logging.warning('Cannot perform spot check before full calibration')  
+                self.SpotCheckRight.setStyleSheet("background-color : none;")
+                self.SpotCheckRight.setChecked(False)        
+                self.Warning.setText('')
+                self.SpotCheckPreWeightRight.setText('')
+                self.TotalWaterSingleRight.setText('')
+                self.SaveRight.setStyleSheet("color: black;background-color : none;")               
+                return  
+
             logging.info('starting spot check right')
             self.SpotCheckRight.setStyleSheet("background-color : green;")
     

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -947,6 +947,19 @@ class WaterCalibrationDialog(QDialog):
             return
 
         if self.SpotCheckLeft.isChecked():
+            if 'Left' not in self.MainWindow.latest_fitting:
+                reply = QMessageBox.critical(self, 'Spot check left', 
+                    'Please perform full calibration before spot check', 
+                    QMessageBox.Ok)
+                logging.error('Cannot perform spot check before full calibration')  
+                self.SpotCheckLeft.setStyleSheet("background-color : none;")
+                self.SpotCheckLeft.setChecked(False)        
+                self.Warning.setText('')
+                self.SpotCheckPreWeightLeft.setText('')
+                self.TotalWaterSingleLeft.setText('')
+                self.SaveLeft.setStyleSheet("color: black;background-color : none;")               
+                return  
+ 
             logging.info('starting spot check left')
             self.SpotCheckLeft.setStyleSheet("background-color : green;")
     


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Currently, if a user attempts to perform a spot check before the full water calibration is performed, the GUI will throw a fatal error. Now we check for a full calibration before doing a spot check, and if not available give a warning. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/548

### Describe the expected change in behavior from the perspective of the experimenter
- Will give a warning if you try to do a water spot check before a full calibration

### Describe any manual update steps for task computers
- none
 
### Was this update tested in 446/447?
- tested on my laptop




