### PR TITLE
Handles dropped bonsai connection when stopping logging

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3307,6 +3307,11 @@ class Window(QMainWindow):
         self.WarningLabel_2.setText('')
         self._set_metadata_enabled(True)
 
+        self._ConnectBonsai()
+        if self.InitializeBonsaiSuccessfully == 0:
+            self.WarningLabel.setText('Lost bonsai connection')
+            self.WarningLabel.setStyleSheet(self.default_warning_color)
+
         # Reset state variables
         self._StopPhotometry() # Make sure photoexcitation is stopped 
         self.StartANewSession=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3266,16 +3266,12 @@ class Window(QMainWindow):
 
     def _stop_logging(self):
         '''Stop the logging'''
-        self._ConnectBonsai()
-        if self.InitializeBonsaiSuccessfully==0:
-            logging.info('Cannot stop logging when bonsai is disconnected')        
-        else:
-            try:
-                self.Channel.StopLogging('s')
-            except ConnectionAbortedError:
-                logging.error('Bonsai connection error')
-            except Exception as e:
-                logging.error(str(e))
+        try:
+            self.Channel.StopLogging('s')
+        except Exception as e:
+            print(type(e))
+            print(e.__dict__.keys())
+            logging.error(str(e))
 
     def _NewSession(self):
         logging.info('New Session pressed')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3269,9 +3269,10 @@ class Window(QMainWindow):
         try:
             self.Channel.StopLogging('s')
         except Exception as e:
-            print(type(e))
-            print(e.__dict__.keys())
-            logging.error(str(e))
+            logging.warning('Bonsai connection is closed')
+            self.WarningLabel.setText('Lost bonsai connection')
+            self.WarningLabel.setStyleSheet(self.default_warning_color)
+            self.InitializeBonsaiSuccessfully=0
 
     def _NewSession(self):
         logging.info('New Session pressed')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3263,12 +3263,19 @@ class Window(QMainWindow):
         if self.Camera_dialog.StartCamera.isChecked():
             self.Camera_dialog.StartCamera.setChecked(False)
             self.Camera_dialog._StartCamera()
+
     def _stop_logging(self):
         '''Stop the logging'''
-        try:
-            self.Channel.StopLogging('s')
-        except Exception as e:
-            logging.error(str(e))
+        self._ConnectBonsai()
+        if self.InitializeBonsaiSuccessfully==0:
+            logging.info('Cannot stop logging when bonsai is disconnected')        
+        else:
+            try:
+                self.Channel.StopLogging('s')
+            except ConnectionAbortedError:
+                logging.error('Bonsai connection error')
+            except Exception as e:
+                logging.error(str(e))
 
     def _NewSession(self):
         logging.info('New Session pressed')


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Right now, if the user tries to stop logging and bonsai has closed (from either a crash, or user closing the workflow), we generate a new uncaught exception. Now we handle the closed connection and add a warning to the user

### What issues or discussions does this update address?
- resolves #496 

### Describe the expected change in behavior from the perspective of the experimenter
- Should be more stable when bonsai is closed

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested on my laptop




