### PR TITLE
Checking if using a high speed camera before throwing error about missing camera trigger file

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -526,12 +526,20 @@ class Window(QMainWindow):
                     self.trigger_length=0
                     self.WarningLabelCamera.setText('')
                     self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
+                    self.to_check_drop_frames=0
                     return
-                else:
+                elif ('HighSpeedCamera' in self.SettingsBox) and (self.SettingsBox['HighSpeedCamera'] ==1):
                     self.trigger_length=0
                     logging.error('Saved video data, but no camera trigger file found')
                     self.WarningLabelCamera.setText('No camera trigger file found!')
                     self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
+                    return
+                else:
+                    logging.info('Saved video data, but not using high speed camera - skipping drop frame check')
+                    self.trigger_length=0
+                    self.WarningLabelCamera.setText('')
+                    self.WarningLabelCamera.setStyleSheet(self.default_warning_color)
+                    self.to_check_drop_frames=0
                     return
                 csv_files = [file for file in os.listdir(video_folder) if file.endswith(".csv")]
                 avi_files = [file for file in os.listdir(video_folder) if file.endswith(".avi")]


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
The FIP rigs are throwing errors about missing camera trigger files because they aren't using the high speed cameras. 

### What issues or discussions does this update address?
- resolves #489 

### Describe the expected change in behavior from the perspective of the experimenter
- removes "No camera trigger file" warning in FIP boxes

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested in 447




