### PR TITLE
Fix rig.json name

### DIFF
--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -279,15 +279,8 @@ class generate_metadata:
         if self.Obj['meta_data_dialog']['rig_metadata_file']=='' or self.Obj['MetadataFolder']=='':
             return
 
-        ## DEBUGGING        
-        #rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],self.Obj['meta_data_dialog']['rig_metadata_file'])
-        #print(self.Obj['meta_data_dialog']['rig_metadata_file'])
-        #print(rig_metadata_full_path)
-        #print(type(rig_metadata_full_path))
-        ## DEBUGGING 
-
-        rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],'rig.json') # Ignore detailed name, and save as rig.json
-        print(rig_metadata_full_path) ## DEBUG
+        # save copy as rig.json
+        rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],'rig.json') 
         with open(rig_metadata_full_path, 'w') as f:
             json.dump(self.Obj['meta_data_dialog']['rig_metadata'], f, indent=4)
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -280,6 +280,9 @@ class generate_metadata:
             return
         
         rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],self.Obj['meta_data_dialog']['rig_metadata_file'])
+        print(self.Obj['meta_data_dialog']['rig_metadata_file'])
+        print(rig_metadata_full_path)
+        print(type(rig_metadata_full_path)
         with open(rig_metadata_full_path, 'w') as f:
             json.dump(self.Obj['meta_data_dialog']['rig_metadata'], f, indent=4)
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -282,7 +282,7 @@ class generate_metadata:
         rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],self.Obj['meta_data_dialog']['rig_metadata_file'])
         print(self.Obj['meta_data_dialog']['rig_metadata_file'])
         print(rig_metadata_full_path)
-        print(type(rig_metadata_full_path)
+        print(type(rig_metadata_full_path))
         with open(rig_metadata_full_path, 'w') as f:
             json.dump(self.Obj['meta_data_dialog']['rig_metadata'], f, indent=4)
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -278,11 +278,16 @@ class generate_metadata:
         '''
         if self.Obj['meta_data_dialog']['rig_metadata_file']=='' or self.Obj['MetadataFolder']=='':
             return
-        
-        rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],self.Obj['meta_data_dialog']['rig_metadata_file'])
-        print(self.Obj['meta_data_dialog']['rig_metadata_file'])
-        print(rig_metadata_full_path)
-        print(type(rig_metadata_full_path))
+
+        ## DEBUGGING        
+        #rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],self.Obj['meta_data_dialog']['rig_metadata_file'])
+        #print(self.Obj['meta_data_dialog']['rig_metadata_file'])
+        #print(rig_metadata_full_path)
+        #print(type(rig_metadata_full_path))
+        ## DEBUGGING 
+
+        rig_metadata_full_path=os.path.join(self.Obj['MetadataFolder'],'rig.json') # Ignore detailed name, and save as rig.json
+        print(rig_metadata_full_path) ## DEBUG
         with open(rig_metadata_full_path, 'w') as f:
             json.dump(self.Obj['meta_data_dialog']['rig_metadata'], f, indent=4)
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
When uploading the rig metadata, the file must be named `rig.json` and not using the full name that specifies the behavior box and time. 

### What issues or discussions does this update address?
- resolves #564 

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested on my laptop




