### PR TITLE
Create upload manifest.yml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "openpyxl",
     "deepdiff",
     "aind-data-schema==0.36.0",
-    "aind-data-schema-models==0.1.10"
+    "aind-data-schema-models==0.1.10",
+    "pyyaml"
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ openpyxl
 deepdiff
 aind-data-schema==0.36.0
 aind-data-schema-models==0.1.10
+pyyaml

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2515,6 +2515,7 @@ class Window(QMainWindow):
         current_time = datetime.now()
         formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
         self.session_name = f'behavior_{self.ID.text()}_{formatted_datetime}'
+        self.acquisition_datetime = current_time.strftime("%Y-%m-%d %H:%M:%S%z")
         self.SessionFolder=os.path.join(self.default_saveFolder, 
             self.current_box,self.ID.text(), f'behavior_{self.ID.text()}_{formatted_datetime}')
 
@@ -4125,14 +4126,13 @@ class Window(QMainWindow):
         )
     
     def _generate_upload_manifest(self):
+
+        # Need to make sure this has run. 
         self._GetSaveFolder() ## DEBUGGING
 
-        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')## DEBUGGING
-        session_id='0'
-        filename = os.path.join(flag_dir,'manifest_{}.yml'.format(session_id))
-
+        # Define contents of manifest file
         contents = {
-            'acquisition_datetime': '?',
+            'acquisition_datetime': self.acquisition_datetime,
             'name': self.session_name,
             'platform': 'behavior',
             'subject_id': self.ID.text(),
@@ -4155,7 +4155,12 @@ class Window(QMainWindow):
             'script': {}
             }
 
+
+        # Define filename of manifest
+        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')## DEBUGGING
+        filename = os.path.join(flag_dir,'manifest_{}.yml'.format(contents['name']))
         
+        # Write the manifest file
         with open(filename,'w') as yaml_file:
             yaml.dump(contents, yaml_file, default_flow_style=False)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4143,11 +4143,11 @@ class Window(QMainWindow):
             if FIP: ## DEBUG, need to figure out how to set this flag.  
                 schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
-                mount = self.session_name 
+                mount = 'FIP' 
             else:
                 schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
-                mount = self.session_name
+                mount = 'FIP'
  
             # Define contents of manifest file
             contents = {

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4141,7 +4141,7 @@ class Window(QMainWindow):
                 'behavior':'?',
                 'behavior-videos':'?',
                 'fib':'?'
-                }
+                },
             'schemas':['?','?'],
             'schedule_time':'null',
             'project_name':'null',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -166,7 +166,8 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
-    
+        self_generate_upload_manifest(self) ## DEBUGGING, shouldnt run here
+ 
     def _load_rig_metadata(self):
         '''Load the latest rig metadata'''
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4124,6 +4124,8 @@ class Window(QMainWindow):
         )
     
     def _generate_upload_manifest(self):
+        self._GetSaveFolder() ## DEBUGGING
+
         flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')## DEBUGGING
         session_id='0'
         filename = os.path.join(flag_dir,'manifest_{}.yml'.format(session_id))
@@ -4133,19 +4135,22 @@ class Window(QMainWindow):
             'name': '?',
             'platform':'behavior',
             'subject_id':'?',
-            'capsule_id': "null",
-            'mount':'null',
+            'capsule_id': None,
+            'mount':None,
             'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
             's3_bucket':'private',
             'processor_full_name': 'dynamic foraging task gui',
             'modalities':{
-                'behavior':'?',
-                'behavior-videos':'?',
-                'fib':'?'
+                'behavior':self.TrainingFolder,
+                'behavior-videos':self.VideoFolder,
+                'fib':self.PhotometryFolder
                 },
-            'schemas':['?','?'],
-            'schedule_time':'null',
-            'project_name':'null',
+            'schemas':[
+                os.path.join(self.MetadataFolder,'session.json'),
+                os.path.join(self.MetadataFolder,'rig.json')
+                ],
+            'schedule_time':None, # Should consider adding this for FIP
+            'project_name':'?',
             'script': {}
             }
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4124,9 +4124,9 @@ class Window(QMainWindow):
         )
     
     def _generate_upload_manifest(self):
-        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs')#
+        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'manifest_dir')## DEBUGGING
         session_id='0'
-        filename = 'manifest_{}.yml'.format(session_id)
+        filename = os.path.join(flag_dir,'manifest_{}.yml'.format(session_id))
 
         contents = {
             'acquisition_datetime': '?',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -166,7 +166,6 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
-        self._generate_upload_manifest() ## DEBUGGING, shouldnt run here
  
     def _load_rig_metadata(self):
         '''Load the latest rig metadata'''
@@ -2492,11 +2491,8 @@ class Window(QMainWindow):
             self.SessionlistSpin.setEnabled(True)
             self.Sessionlist.setEnabled(True)
 
-            # Drop `finished` file with date/time
-            filepath = os.path.join(self.SessionFolder, 'finished') 
-            contents = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            with open(filepath, 'w') as finished_file:
-                finished_file.write(contents)
+            self._generate_upload_manifest() # Generate the upload manifest file
+
             if self.StartEphysRecording.isChecked():
                 QMessageBox.warning(self, '', 'Data saved successfully! However, the ephys recording is still running. Make sure to stop ephys recording and save the data again!')
                 self.unsaved_data=True
@@ -4128,9 +4124,13 @@ class Window(QMainWindow):
         )
     
     def _generate_upload_manifest(self):
-
-        # Need to make sure this has run. 
-        self._GetSaveFolder() ## DEBUGGING
+        '''
+            DEBUGGING TODO
+            Figure out how to toggle upload time based on FIP sessions
+            Do we want to trigger this at all for Ephys?
+            acqusition datetime format correct?
+            need to determine path to flag_dir
+        '''
         
         if not hasattr(self, 'project_name'):
             self.project_name = 'Behavior Platform'
@@ -4155,7 +4155,7 @@ class Window(QMainWindow):
                 os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
                 os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
                 ],
-            'schedule_time':None, # Should consider adding this for FIP
+            'schedule_time':None,
             'project_name':self.project_name,
             'script': {}
             }

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2704,8 +2704,10 @@ class Window(QMainWindow):
                         'Fundee':['nan'],
                     }
                 self.Metadata_dialog.project_info = project_info
-                self.Metadata_dialog.ProjectName.addItems(['Behavior Platform'])
-                logging.info('Setting Project name: {}'.format('Behavior Platform'))
+                project_name = 'Behavior Platform'
+                self.Metadata_dialog.ProjectName.addItems([project_name])
+                logging.info('Setting Project name: {}'.format(project_name))
+        self.project_name = project_name
 
         self.keyPressEvent(allow_reset=True) 
     
@@ -4135,7 +4137,7 @@ class Window(QMainWindow):
             'acquisition_datetime': self.acquisition_datetime,
             'name': self.session_name,
             'platform': 'behavior',
-            'subject_id': self.ID.text(),
+            'subject_id': int(self.ID.text()),
             'capsule_id': None,
             'mount':None,
             'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
@@ -4151,7 +4153,7 @@ class Window(QMainWindow):
                 os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
                 ],
             'schedule_time':None, # Should consider adding this for FIP
-            'project_name':'?', # Grab from Metadata
+            'project_name':self.project_name,
             'script': {}
             }
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1043,6 +1043,7 @@ class Window(QMainWindow):
             'name_mapper_file':os.path.join(self.SettingFolder,"name_mapper.json"),
             'create_rig_metadata':True,
             'save_each_trial':True,
+            'AutomaticUpload':True
         }
         
         # Try to load Settings_box#.csv
@@ -2491,7 +2492,10 @@ class Window(QMainWindow):
             self.SessionlistSpin.setEnabled(True)
             self.Sessionlist.setEnabled(True)
 
-            self._generate_upload_manifest() # Generate the upload manifest file
+            if self.Settings['AutomaticUpload']:
+                self._generate_upload_manifest() # Generate the upload manifest file
+            else:
+                logging.info('Skipping Automatic Upload based on ForagingSettings.json')
 
             if self.StartEphysRecording.isChecked():
                 QMessageBox.warning(self, '', 'Data saved successfully! However, the ephys recording is still running. Make sure to stop ephys recording and save the data again!')
@@ -4123,19 +4127,25 @@ class Window(QMainWindow):
                          '&session_plot_selected_draw_types=1.+Choice+history'
         )
     
-    def _generate_upload_manifest(self):
+    def _generate_upload_manifest(self,FIP=False):
         '''
             DEBUGGING TODO
             Figure out how to toggle upload time based on FIP sessions
             Do we want to trigger this at all for Ephys?
             acqusition datetime format correct?
             need to determine path to flag_dir
-            Made a toggle for FIP, which adds a trigger capsule
         '''
         try: 
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
-    
+            
+            if FIP:
+                schedule = 'midnight' ## DEBUGGING FORMAT
+                capsule_id = 'FIP trigger capsule' ## DEBUG, figure out capsule
+            else:
+                schedule = None  
+                capsule_id = None ## DEBUG, should probably trigger something? 
+ 
             # Define contents of manifest file
             contents = {
                 'acquisition_datetime': self.acquisition_datetime,
@@ -4156,7 +4166,7 @@ class Window(QMainWindow):
                     os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
                     os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
                     ],
-                'schedule_time':None,
+                'schedule_time':schedule,
                 'project_name':self.project_name,
                 'script': {}
                 }

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2514,6 +2514,7 @@ class Window(QMainWindow):
         '''
         current_time = datetime.now()
         formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
+        self.session_name = f'behavior_{self.ID.text()}_{formatted_datetime}'
         self.SessionFolder=os.path.join(self.default_saveFolder, 
             self.current_box,self.ID.text(), f'behavior_{self.ID.text()}_{formatted_datetime}')
 
@@ -4132,9 +4133,9 @@ class Window(QMainWindow):
 
         contents = {
             'acquisition_datetime': '?',
-            'name': '?',
-            'platform':'behavior',
-            'subject_id':'?',
+            'name': self.session_name,
+            'platform': 'behavior',
+            'subject_id': self.ID.text(),
             'capsule_id': None,
             'mount':None,
             'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
@@ -4150,7 +4151,7 @@ class Window(QMainWindow):
                 os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
                 ],
             'schedule_time':None, # Should consider adding this for FIP
-            'project_name':'?',
+            'project_name':'?', # Grab from Metadata
             'script': {}
             }
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4143,11 +4143,11 @@ class Window(QMainWindow):
             if FIP: ## DEBUG, need to figure out how to set this flag.  
                 schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
-                mount = None ## DEBUG, figure out if we need this
+                mount = self.session_name 
             else:
                 schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
-                mount = None
+                mount = self.session_name
  
             # Define contents of manifest file
             contents = {

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1043,7 +1043,12 @@ class Window(QMainWindow):
             'name_mapper_file':os.path.join(self.SettingFolder,"name_mapper.json"),
             'create_rig_metadata':True,
             'save_each_trial':True,
-            'AutomaticUpload':True
+            'AutomaticUpload':True,
+            'manifest_flag_dir':os.path.join(
+                os.path.expanduser("~"), 
+                "Documents",
+                'aind_watchdog_service',
+                'manifest')
         }
         
         # Try to load Settings_box#.csv
@@ -4129,20 +4134,20 @@ class Window(QMainWindow):
     
     def _generate_upload_manifest(self,FIP=False):
         '''
-            DEBUGGING TODO
-            Figure out how to toggle upload time based on FIP sessions
-            need to determine path to flag_dir
+            Generates a manifest.yml file for triggering data copy to VAST and upload to aws
         '''
         try: 
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
             
             if FIP:
-                schedule = 'midnight' ## DEBUG, figure out format
-                capsule_id = 'FIP trigger capsule' ## DEBUG, figure out capsule
+                schedule = None ## DEBUG, figure out format
+                capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
+                mount = None ## DEBUG, figure out if we need this
             else:
-                schedule = None ## DEBUG, do we want to trigger later? 
-                capsule_id = None ## DEBUG, should probably trigger something? 
+                schedule = None  
+                capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
+                mount = None
  
             # Define contents of manifest file
             contents = {
@@ -4150,8 +4155,8 @@ class Window(QMainWindow):
                 'name': self.session_name,
                 'platform': 'behavior',
                 'subject_id': int(self.ID.text()),
-                'capsule_id': None,
-                'mount':None,
+                'capsule_id': capsule_id,
+                'mount':mount,
                 'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
                 's3_bucket':'private',
                 'processor_full_name': 'AIND Behavior Team',
@@ -4170,11 +4175,11 @@ class Window(QMainWindow):
                 }
      
             # Define filename of manifest
-            ## DEBUGGING
-            flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')
-            ## DEBUGGING
-
-            filename = os.path.join(flag_dir,'manifest_{}.yml'.format(contents['name']))
+            if not os.path.exists(self.Settings['manifest_flag_dir']):
+                os.makedirs(self.Settings['manifest_flag_dir'])
+            filename = os.path.join(
+                self.Settings['manifest_flag_dir'],
+                'manifest_{}.yml'.format(contents['name']))
             
             # Write the manifest file
             with open(filename,'w') as yaml_file:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4139,15 +4139,15 @@ class Window(QMainWindow):
             'mount':None,
             'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
             's3_bucket':'private',
-            'processor_full_name': 'dynamic foraging task gui',
+            'processor_full_name': 'AIND Behavior Team',
             'modalities':{
-                'behavior':self.TrainingFolder,
-                'behavior-videos':self.VideoFolder,
-                'fib':self.PhotometryFolder
+                'behavior':self.TrainingFolder.replace('\\','/'),
+                'behavior-videos':self.VideoFolder.replace('\\','/'),
+                'fib':self.PhotometryFolder.replace('\\','/')
                 },
             'schemas':[
-                os.path.join(self.MetadataFolder,'session.json'),
-                os.path.join(self.MetadataFolder,'rig.json')
+                os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
+                os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
                 ],
             'schedule_time':None, # Should consider adding this for FIP
             'project_name':'?',

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4125,7 +4125,7 @@ class Window(QMainWindow):
     
     def _generate_upload_manifest(self):
         flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs')#
-        session_id='?'
+        session_id='0'
         filename = 'manifest_{}.yml'.format(session_id)
 
         contents = {

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -166,7 +166,7 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
-        self._generate_upload_manifest(self) ## DEBUGGING, shouldnt run here
+        self._generate_upload_manifest() ## DEBUGGING, shouldnt run here
  
     def _load_rig_metadata(self):
         '''Load the latest rig metadata'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2520,7 +2520,7 @@ class Window(QMainWindow):
         current_time = datetime.now()
         formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
         self.session_name = f'behavior_{self.ID.text()}_{formatted_datetime}'
-        self.acquisition_datetime = current_time.strftime("%Y-%m-%d %H:%M:%S%z")
+        self.acquisition_datetime = current_time.strftime("%Y-%m-%d %H:%M:%S")
         self.SessionFolder=os.path.join(self.default_saveFolder, 
             self.current_box,self.ID.text(), f'behavior_{self.ID.text()}_{formatted_datetime}')
 
@@ -4140,12 +4140,12 @@ class Window(QMainWindow):
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
             
-            if FIP:
-                schedule = None ## DEBUG, figure out format
+            if FIP: ## DEBUG, need to figure out how to set this flag.  
+                schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = None ## DEBUG, figure out if we need this
             else:
-                schedule = None  
+                schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = None
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4149,9 +4149,10 @@ class Window(QMainWindow):
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP'
  
+            date_format = "%Y-%m-%d %H:%M:%S"
             # Define contents of manifest file
             contents = {
-                'acquisition_datetime': self.acquisition_datetime,
+                'acquisition_datetime': datetime.strptime(self.acquisition_datetime,date_format),
                 'name': self.session_name,
                 'platform': 'behavior',
                 'subject_id': int(self.ID.text()),
@@ -4169,7 +4170,7 @@ class Window(QMainWindow):
                     os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
                     os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
                     ],
-                'schedule_time':schedule,
+                'schedule_time':datetime.strptime(schedule,date_format),
                 'project_name':self.project_name,
                 'script': {}
                 }

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -166,7 +166,7 @@ class Window(QMainWindow):
             '''
             self._ReconnectBonsai()   
         logging.info('Start up complete')
-        self_generate_upload_manifest(self) ## DEBUGGING, shouldnt run here
+        self._generate_upload_manifest(self) ## DEBUGGING, shouldnt run here
  
     def _load_rig_metadata(self):
         '''Load the latest rig metadata'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4131,8 +4131,6 @@ class Window(QMainWindow):
         '''
             DEBUGGING TODO
             Figure out how to toggle upload time based on FIP sessions
-            Do we want to trigger this at all for Ephys?
-            acqusition datetime format correct?
             need to determine path to flag_dir
         '''
         try: 
@@ -4140,10 +4138,10 @@ class Window(QMainWindow):
                 self.project_name = 'Behavior Platform'
             
             if FIP:
-                schedule = 'midnight' ## DEBUGGING FORMAT
+                schedule = 'midnight' ## DEBUG, figure out format
                 capsule_id = 'FIP trigger capsule' ## DEBUG, figure out capsule
             else:
-                schedule = None  
+                schedule = None ## DEBUG, do we want to trigger later? 
                 capsule_id = None ## DEBUG, should probably trigger something? 
  
             # Define contents of manifest file
@@ -4170,9 +4168,9 @@ class Window(QMainWindow):
                 'project_name':self.project_name,
                 'script': {}
                 }
-    
-    
+     
             # Define filename of manifest
+            ## DEBUGGING
             flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')
             ## DEBUGGING
 
@@ -4181,10 +4179,12 @@ class Window(QMainWindow):
             # Write the manifest file
             with open(filename,'w') as yaml_file:
                 yaml.dump(contents, yaml_file, default_flow_style=False)
+
         except Exception as e:
             logging.error('Could not generate upload manifest: {}'.format(str(e)))
             QMessageBox.critical(self, 'Upload manifest', 
-                'Could not generate upload manifest. Please alert the mouse owner that this session will not be uploaded.')
+                'Could not generate upload manifest. '+\
+                'Please alert the mouse owner that this session will not be uploaded.')
             
 
 def start_gui_log_file(box_number):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4130,6 +4130,7 @@ class Window(QMainWindow):
             Do we want to trigger this at all for Ephys?
             acqusition datetime format correct?
             need to determine path to flag_dir
+            drop this in a try/except block, and alert the user if something goes wrong
         '''
         
         if not hasattr(self, 'project_name'):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -11,6 +11,7 @@ import harp
 import pandas as pd
 import threading
 import itertools
+import yaml
 from pathlib import Path
 from datetime import date, datetime
 
@@ -4120,6 +4121,37 @@ class Window(QMainWindow):
                          '&session_plot_mode=all+sessions+filtered+from+sidebar'
                          '&session_plot_selected_draw_types=1.+Choice+history'
         )
+    
+    def _generate_upload_manifest(self):
+        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'foraging_gui_logs')#
+        session_id='?'
+        filename = 'manifest_{}.yml'.format(session_id)
+
+        contents = {
+            'acquisition_datetime': '?',
+            'name': '?',
+            'platform':'behavior',
+            'subject_id':'?',
+            'capsule_id': "null",
+            'mount':'null',
+            'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
+            's3_bucket':'private',
+            'processor_full_name': 'dynamic foraging task gui',
+            'modalities':{
+                'behavior':'?',
+                'behavior-videos':'?',
+                'fib':'?'
+                }
+            'schemas':['?','?'],
+            'schedule_time':'null',
+            'project_name':'null',
+            'script': {}
+            }
+
+        
+        with open(filename,'w') as yaml_file:
+            yaml.dump(contents, yaml_file, default_flow_style=False)
+
 
 def start_gui_log_file(box_number):
     '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4131,6 +4131,9 @@ class Window(QMainWindow):
 
         # Need to make sure this has run. 
         self._GetSaveFolder() ## DEBUGGING
+        
+        if not hasattr(self, 'project_name'):
+            self.project_name = 'Behavior Platform'
 
         # Define contents of manifest file
         contents = {

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4130,46 +4130,52 @@ class Window(QMainWindow):
             Do we want to trigger this at all for Ephys?
             acqusition datetime format correct?
             need to determine path to flag_dir
-            drop this in a try/except block, and alert the user if something goes wrong
+            Made a toggle for FIP, which adds a trigger capsule
         '''
-        
-        if not hasattr(self, 'project_name'):
-            self.project_name = 'Behavior Platform'
+        try: 
+            if not hasattr(self, 'project_name'):
+                self.project_name = 'Behavior Platform'
+    
+            # Define contents of manifest file
+            contents = {
+                'acquisition_datetime': self.acquisition_datetime,
+                'name': self.session_name,
+                'platform': 'behavior',
+                'subject_id': int(self.ID.text()),
+                'capsule_id': None,
+                'mount':None,
+                'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
+                's3_bucket':'private',
+                'processor_full_name': 'AIND Behavior Team',
+                'modalities':{
+                    'behavior':self.TrainingFolder.replace('\\','/'),
+                    'behavior-videos':self.VideoFolder.replace('\\','/'),
+                    'fib':self.PhotometryFolder.replace('\\','/')
+                    },
+                'schemas':[
+                    os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
+                    os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
+                    ],
+                'schedule_time':None,
+                'project_name':self.project_name,
+                'script': {}
+                }
+    
+    
+            # Define filename of manifest
+            flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')
+            ## DEBUGGING
 
-        # Define contents of manifest file
-        contents = {
-            'acquisition_datetime': self.acquisition_datetime,
-            'name': self.session_name,
-            'platform': 'behavior',
-            'subject_id': int(self.ID.text()),
-            'capsule_id': None,
-            'mount':None,
-            'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
-            's3_bucket':'private',
-            'processor_full_name': 'AIND Behavior Team',
-            'modalities':{
-                'behavior':self.TrainingFolder.replace('\\','/'),
-                'behavior-videos':self.VideoFolder.replace('\\','/'),
-                'fib':self.PhotometryFolder.replace('\\','/')
-                },
-            'schemas':[
-                os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
-                os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
-                ],
-            'schedule_time':None,
-            'project_name':self.project_name,
-            'script': {}
-            }
-
-
-        # Define filename of manifest
-        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')## DEBUGGING
-        filename = os.path.join(flag_dir,'manifest_{}.yml'.format(contents['name']))
-        
-        # Write the manifest file
-        with open(filename,'w') as yaml_file:
-            yaml.dump(contents, yaml_file, default_flow_style=False)
-
+            filename = os.path.join(flag_dir,'manifest_{}.yml'.format(contents['name']))
+            
+            # Write the manifest file
+            with open(filename,'w') as yaml_file:
+                yaml.dump(contents, yaml_file, default_flow_style=False)
+        except Exception as e:
+            logging.error('Could not generate upload manifest: {}'.format(str(e)))
+            QMessageBox.critical(self, 'Upload manifest', 
+                'Could not generate upload manifest. Please alert the mouse owner that this session will not be uploaded.')
+            
 
 def start_gui_log_file(box_number):
     '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4124,7 +4124,7 @@ class Window(QMainWindow):
         )
     
     def _generate_upload_manifest(self):
-        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'manifest_dir')## DEBUGGING
+        flag_dir = os.path.join(os.path.expanduser("~"), "Documents",'ForagingSettings','manifest_dir')## DEBUGGING
         session_id='0'
         filename = os.path.join(flag_dir,'manifest_{}.yml'.format(session_id))
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Generates the `manifest.yml` file that triggers `aind-watchdog-service`
- set upload times to 11:59pm for all sessions
- Adds a setting in `ForagingSettings.json` called `AutomaticUpload`, which defaults to True. To disable automatic upload (EPHYS rigs may want to do this), then set this to False.

### What issues or discussions does this update address?
- resolves #556 

### Describe the expected change in behavior from the perspective of the experimenter
- If the manifest generation fails, users will get an alert that the data will not be automatically upload
    - IMPORTANT: if this happens, alert the owner of the mouse. 

### Describe any manual update steps for task computers
- Determine if you want to opt-out of automatic uploads, and if so, set `ForagingSettings.json/AutomaticUpload` to False
    - [ ] Ephys1 @KanghoonJ 
    - [ ] Ephys3 @XX-Yin 
- Configure watchdog service (steps below)
    - [ ] Ephys1 @KanghoonJ 
    - [ ] Ephsy3 @XX-Yin 
    - [ ] 428 @hagikent 
    - [ ] 446/447 @hanhou @alexpiet 
- Install `aind-watchdog-service` on each rig computer, and enable TaskScheduler to automatically start the service
- Add a `watch_dog.yml` file to `~/Documents/aind_watchdog_service`
- Set the `WATCH_CONFIG` system variable to point to `~/Documents/aind_watchdog_service`
- `watch_dog.yml` should contain:
```
flag_dir: {~}/Documents/aind_watchdog_service/manifest
manifest_complete: {~}/Documents/aind_watchdog_service/manifest_completed
webhook_url: null
```

### Was this update tested in 446/447?
- [x] tested in 447




