### PR TITLE
updating default codec to only display warnings and errors

### DIFF
--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -28,6 +28,6 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M
+codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -28,6 +28,6 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M
+codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -28,6 +28,6 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M
+codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -28,6 +28,6 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M
+codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Changes the verbose level of ffmpeg from 40 (default) to 24 (warnings and errors only)

### What issues or discussions does this update address?
- resolves #534 by cleaning up the logs

### Describe the expected change in behavior from the perspective of the experimenter
- none, the only differences are in the logs

### Describe any manual update steps for task computers
- None required. If you want to reduce the visual clutter of the logs, add `-v 24` to the codec in `Settings_box#.csv`
    - [x] 446 @alexpiet 
    - [ ] 428 @hagikent 
    - [ ] EPHYS1 @KanghoonJ 
    - [ ] EPHYS3 @XX-Yin 

### Was this update tested in 446/447?
- [x] tested in 446




