### PR TITLE
Updates water calibration tolerance, and clarifies procedure for spot checks

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1054,7 +1054,7 @@ class WaterCalibrationDialog(QDialog):
         TOLERANCE = float(self.SpotLeftVolume.text())*.15
         if np.abs(error) > TOLERANCE:
             reply = QMessageBox.critical(self, 'Spot check left', 
-                'Measurement is outside expected tolerance. \n\nFIRST, please confirm you entered information correctly, then press save. \n\n<span style="color:purple;font-weight:bold">IMPORTANT</span>: If the measurement was correctly entered (not a typo), please repeat the spot check once. If the measurement remains outside the expected tolerance please immediately perform a full calibration.'.format(np.round(result,2)), 
+                'Measurement is outside expected tolerance. <br><br>FIRST, please confirm you entered information correctly, then press save. <br><br><span style="color:purple;font-weight:bold">IMPORTANT</span>: If the measurement was correctly entered (not a typo), please repeat the spot check once. If the measurement remains outside the expected tolerance please immediately perform a full calibration.'.format(np.round(result,2)), 
                 QMessageBox.Ok)
 
             logging.error('Water calibration spot check exceeds tolerance: {}'.format(error))  

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1051,10 +1051,10 @@ class WaterCalibrationDialog(QDialog):
             '\nFinal tube weight: {}g'.format(final_tube_weight) + \
             '\nAvg. error from target: {}uL'.format(error)
             )        
-        TOLERANCE = float(self.SpotLeftVolume.text())/10
+        TOLERANCE = float(self.SpotLeftVolume.text())*.15
         if np.abs(error) > TOLERANCE:
             reply = QMessageBox.critical(self, 'Spot check left', 
-                'Result ( {}uL ) is outside expected tolerance. \nPlease confirm you entered information correctly, then press save.'.format(np.round(result,2)), 
+                'Measurement is outside expected tolerance. \nPlease confirm you entered information correctly, then press save. \n\nIMPORTANT: If the measurement was correctly entered, please repeat the spot check once. If the measurement remains outside the expecte tolerance please immediately perform a full calibration.'.format(np.round(result,2)), 
                 QMessageBox.Ok)
             logging.error('Water calibration spot check exceeds tolerance: {}'.format(error))  
             self.SaveLeft.setStyleSheet("color: white;background-color : mediumorchid;")

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1054,8 +1054,9 @@ class WaterCalibrationDialog(QDialog):
         TOLERANCE = float(self.SpotLeftVolume.text())*.15
         if np.abs(error) > TOLERANCE:
             reply = QMessageBox.critical(self, 'Spot check left', 
-                'Measurement is outside expected tolerance. \nPlease confirm you entered information correctly, then press save. \n\nIMPORTANT: If the measurement was correctly entered, please repeat the spot check once. If the measurement remains outside the expecte tolerance please immediately perform a full calibration.'.format(np.round(result,2)), 
+                'Measurement is outside expected tolerance. \n\nFIRST, please confirm you entered information correctly, then press save. \n\n<span style="color:purple;font-weight:bold">IMPORTANT</span>: If the measurement was correctly entered (not a typo), please repeat the spot check once. If the measurement remains outside the expected tolerance please immediately perform a full calibration.'.format(np.round(result,2)), 
                 QMessageBox.Ok)
+
             logging.error('Water calibration spot check exceeds tolerance: {}'.format(error))  
             self.SaveLeft.setStyleSheet("color: white;background-color : mediumorchid;")
             self.Warning.setText(


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Increases the tolerance for the spot checks from 10% to 15%
- Clarifies the text when spot checks are outside of the tolerance that the user should (1) double check the entered values, (2) repeat the spot check, (3) do a full calibration if the second spot check is still outside the bounds. 

### What issues or discussions does this update address?
- resolves #561 

### Describe the expected change in behavior from the perspective of the experimenter
- More clear instructions

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested on my laptop




