### PR TITLE
confirm the experimenter name

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3507,7 +3507,7 @@ class Window(QMainWindow):
             # check experimenter name
             reply = QMessageBox.critical(self,
                 'Box {}, Start'.format(self.box_letter),    
-                f'The experimenter is <span style="color:red;">{self.Experimenter.text()}</span>. Is it correct?',
+                f'The experimenter is <span style="color:red;">{self.Experimenter.text()}</span>. Is this correct?',
                 QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
             if reply == QMessageBox.No:
                 self.Start.setChecked(False)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3503,17 +3503,16 @@ class Window(QMainWindow):
                     self.Start.setChecked(False)
                     logging.info('User declines continuation of session')
                     return
-
+                
             # check experimenter name
-            if self.Experimenter.text() == "the ghost in the shell":
-                reply = QMessageBox.critical(self,
-                    'Box {}, Start'.format(self.box_letter),    
-                    'Experimenter field set to default, continue anyways?',
-                    QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-                if reply == QMessageBox.No:
-                    self.Start.setChecked(False)
-                    logging.info('User declines using default name')
-                    return                
+            reply = QMessageBox.critical(self,
+                'Box {}, Start'.format(self.box_letter),    
+                f'The experimenter is <span style="color:red;">{self.Experimenter.text()}</span>. Is it correct?',
+                QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+            if reply == QMessageBox.No:
+                self.Start.setChecked(False)
+                logging.info('User declines using default name')
+                return                
             logging.info('Starting session, with experimenter: {}'.format(self.Experimenter.text()))
 
             # check repo status


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Make it mandatory to check the experimenter's name. A window will pop up when the `Start` is clicked. 

![image](https://github.com/user-attachments/assets/ea77be0e-aac2-470d-b81a-84bc7d67a897)

- If you select "Yes", the session will start. If you select "No", the session will not start.


### What issues or discussions does this update address?
I frequently started sessions with the wrong default experimenter name, especially I trained the same mice with other people in different sessions. I think the same may happen to others. Having the experimenter check the experimenter's name will fix this problem.

### Describe the expected change in behavior from the perspective of the experimenter
A window will pop up asking for checking experimenter's name. 

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
Tested on my own computer




