### PR TITLE
Lick visualization window name

### DIFF
--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -31,3 +31,4 @@ FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
+current_box,4xx-x-A

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -31,3 +31,4 @@ FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
+current_box,4xx-x-B

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -31,3 +31,4 @@ FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
+current_box,4xx-x-C

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -31,3 +31,4 @@ FipObjectiveSerialNumber,0
 codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
+current_box,4xx-x-D

--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -8663,8 +8663,24 @@
               <Name>LeftLick</Name>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ComPorts</Name>
+            </Expression>
+            <Expression xsi:type="Index">
+              <Operand xsi:type="StringProperty">
+                <Value>current_box</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>LickVis: {0}</Format>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Name" />
+              </PropertyMappings>
+            </Expression>
             <Expression xsi:type="viz:TableLayoutPanelBuilder">
-              <viz:Name>LickVis</viz:Name>
+              <viz:Name>LickVis: 428-9-A</viz:Name>
               <viz:ColumnCount>1</viz:ColumnCount>
               <viz:RowCount>2</viz:RowCount>
               <viz:ColumnStyles />
@@ -8679,9 +8695,13 @@
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="4" Label="Source1" />
+            <Edge From="1" To="8" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="3" To="8" Label="Source2" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source3" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/workflows/foraging.bonsai.layout
+++ b/src/workflows/foraging.bonsai.layout
@@ -8608,8 +8608,8 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>856</X>
-        <Y>512</Y>
+        <X>855</X>
+        <Y>460</Y>
       </Location>
       <Size>
         <Width>575</Width>
@@ -9419,6 +9419,54 @@
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
     <EditorVisualizerLayout>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
       <DialogSettings>
         <Visible>false</Visible>
         <Location>


### PR DESCRIPTION
### Describe changes:
Added rig name to the lick real time vis window.
![Capture3](https://github.com/user-attachments/assets/0a164907-aaa0-4aa2-8695-cf9c0ae387bb)

Templates for `Settings_box.csv` was also updated accordingly.

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/492
Specifically the comment by @NgD-Huy 
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/492#issuecomment-2236990030  

### Describe the expected change in behavior from the perspective of the experimenter
![Capture](https://github.com/user-attachments/assets/e8d33404-043d-4ab8-b3ec-ff508d600aed)
Now no confusion between two rigs run by the same PC.

### Describe any manual update steps for task computers
![Capture2](https://github.com/user-attachments/assets/b40cccde-1369-411c-9868-47a59c61e19c)

`Settings_BoxX.csv` needs to be modified -- add `current_box` entry as shown above (replace with the actual rig name). 
(don't forget to have a blank row in the very bottom, otherwise Bonsai cannot read .csv somehow)

I saw @NgD-Huy made this change for the test rigs (477-1-C/D). Please make sure that all the other rigs in 446/447 would get same local changes by next Tue evening! Otherwise Bonsai may crash when opening up.

### Was this update tested in 446/447?
Tested in 428-9-A




