### PR TITLE
Fixing off by one error with spot checks

### DIFF
--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -415,7 +415,7 @@ class PlotWaterCalibration(FigureCanvas):
         all_dates = []
         while counter < showrecent:
             print('counter: {}, iterator: {}'.format(counter,iterator))
-            if iterator > len(sorted_dates):
+            if iterator >= len(sorted_dates):
                 break
             iterator +=1
             if ('Left' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()) or ('Right' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()):

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -414,6 +414,7 @@ class PlotWaterCalibration(FigureCanvas):
         counter = 0
         all_dates = []
         while counter < showrecent:
+            print('counter: {}, iterator: {}'.format(counter,iterator))
             if iterator > len(sorted_dates):
                 break
             iterator +=1

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -416,7 +416,7 @@ class PlotWaterCalibration(FigureCanvas):
             if iterator >= len(sorted_dates):
                 break
             iterator +=1
-            if ('Left' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()) or 
+            if ('Left' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()) or \
                 ('Right' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()):
                 counter += 1 
         all_dates = sorted_dates[-iterator:]

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -407,18 +407,17 @@ class PlotWaterCalibration(FigureCanvas):
             showrecent=1
         if showrecent>len(sorted_dates):
             showrecent=len(sorted_dates)
-        print(sorted_dates)        
 
         # Dont count spot checks against "show last" number
         iterator = 0
         counter = 0
         all_dates = []
         while counter < showrecent:
-            print('counter: {}, iterator: {}'.format(counter,iterator))
             if iterator >= len(sorted_dates):
                 break
             iterator +=1
-            if ('Left' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()) or ('Right' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()):
+            if ('Left' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()) or 
+                ('Right' in self.WaterCalibrationResults[sorted_dates[-iterator]].keys()):
                 counter += 1 
         all_dates = sorted_dates[-iterator:]
 

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -407,7 +407,8 @@ class PlotWaterCalibration(FigureCanvas):
             showrecent=1
         if showrecent>len(sorted_dates):
             showrecent=len(sorted_dates)
-        
+        print(sorted_dates)        
+
         # Dont count spot checks against "show last" number
         iterator = 0
         counter = 0


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- The water calibration plotting function had an off by one error. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/511

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested in 446




