### PR TITLE
Upload manifest fixes

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4218,11 +4218,11 @@ class Window(QMainWindow):
                 self.project_name = 'Behavior Platform'
             
             if FIP: ## DEBUG, need to figure out how to set this flag.  
-                schedule = self.acquisition_datetime.split('_')[0]+' 23:59:00'
+                schedule = self.acquisition_datetime.split('_')[0]+'_23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP' 
             else:
-                schedule = self.acquisition_datetime.split('_')[0]+' 23:59:00'
+                schedule = self.acquisition_datetime.split('_')[0]+'_23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP'
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2571,6 +2571,7 @@ class Window(QMainWindow):
             formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
             self._get_folder_structure_new(formatted_datetime)
             self.acquisition_datetime = formatted_datetime 
+            self.session_name=f'behavior_{self.ID.text()}_{formated_datetime}'
         elif self.load_tag==1:
             self._parse_folder_structure()
             

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2570,6 +2570,7 @@ class Window(QMainWindow):
             current_time = datetime.now()
             formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
             self._get_folder_structure_new(formatted_datetime)
+            self.acquisition_datetime = formatted_datetime 
         elif self.load_tag==1:
             self._parse_folder_structure()
             
@@ -4216,11 +4217,11 @@ class Window(QMainWindow):
                 self.project_name = 'Behavior Platform'
             
             if FIP: ## DEBUG, need to figure out how to set this flag.  
-                schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
+                schedule = self.acquisition_datetime.split('_')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP' 
             else:
-                schedule = self.acquisition_datetime.split(' ')[0]+' 23:59:00'
+                schedule = self.acquisition_datetime.split('_')[0]+' 23:59:00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP'
  

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1089,7 +1089,7 @@ class Window(QMainWindow):
 
         # check that the SettingsBox has each of the values in mandatory_fields as a key, if not log an error for the missing key
 
-        csv_mandatory_fields = ['Behavior', 'Soundcard', 'BonsaiOsc1', 'BonsaiOsc2', 'BonsaiOsc3', 'BonsaiOsc4','AttenuationLeft','AttenuationRight']
+        csv_mandatory_fields = ['Behavior', 'Soundcard', 'BonsaiOsc1', 'BonsaiOsc2', 'BonsaiOsc3', 'BonsaiOsc4','AttenuationLeft','AttenuationRight','current_box']
         for field in csv_mandatory_fields:
             if field not in self.SettingsBox.keys():
                 logging.error('Missing key ({}) in settings_box file'.format(field))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4237,9 +4237,9 @@ class Window(QMainWindow):
                 's3_bucket':'private',
                 'processor_full_name': 'AIND Behavior Team',
                 'modalities':{
-                    'behavior':self.TrainingFolder.replace('\\','/'),
-                    'behavior-videos':self.VideoFolder.replace('\\','/'),
-                    'fib':self.PhotometryFolder.replace('\\','/')
+                    'behavior':[self.TrainingFolder.replace('\\','/')],
+                    'behavior-videos':[self.VideoFolder.replace('\\','/')],
+                    'fib':[self.PhotometryFolder.replace('\\','/')]
                     },
                 'schemas':[
                     os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2571,7 +2571,7 @@ class Window(QMainWindow):
             formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
             self._get_folder_structure_new(formatted_datetime)
             self.acquisition_datetime = formatted_datetime 
-            self.session_name=f'behavior_{self.ID.text()}_{formated_datetime}'
+            self.session_name=f'behavior_{self.ID.text()}_{formatted_datetime}'
         elif self.load_tag==1:
             self._parse_folder_structure()
             

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4218,11 +4218,11 @@ class Window(QMainWindow):
                 self.project_name = 'Behavior Platform'
             
             if FIP: ## DEBUG, need to figure out how to set this flag.  
-                schedule = self.acquisition_datetime.split('_')[0]+'_23:59:00'
+                schedule = self.acquisition_datetime.split('_')[0]+'_23-59-00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP' 
             else:
-                schedule = self.acquisition_datetime.split('_')[0]+'_23:59:00'
+                schedule = self.acquisition_datetime.split('_')[0]+'_23-59-00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c' 
                 mount = 'FIP'
  


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- changes the data modalities in the upload manifest to be lists, in accordance with the aind-watchdog-service format
- Adds back `Window.session_name` and `Window.acqusition_datetime`, which are required fields for creating the upload manifest. They were deleted in https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/597, and broke all upload manifest generation. 

### What issues or discussions does this update address?
- resolves #622 
- https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/517

### Describe the expected change in behavior from the perspective of the experimenter
- None

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested on my laptop
- [ ] tested in 446/447




