### PR TITLE
hide figure legend

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -241,7 +241,7 @@ class Window(QMainWindow):
         self.AutoWaterType.currentIndexChanged.connect(self._keyPressEvent)
         self.UncoupledReward.textChanged.connect(self._ShowRewardPairs)
         self.UncoupledReward.returnPressed.connect(self._ShowRewardPairs)
-                                
+        self.HideLegend.clicked.connect(self._hide_legend)
         # Connect to ID change in the mainwindow
         self.ID.returnPressed.connect(
             lambda: self.AutoTrain_dialog.update_auto_train_lock(engaged=False)
@@ -308,6 +308,26 @@ class Window(QMainWindow):
             for child in container.findChildren((QtWidgets.QLineEdit)):   
                 child.returnPressed.connect(self.keyPressEvent)
     
+    def _hide_legend(self):
+        '''Hide the legend of the plot'''
+        
+        if 'PlotM' not in self.__dict__:
+            self.HideLegend.setChecked(False)
+            return
+        
+        if 'ax1' not in self.PlotM.__dict__ or 'ax2' not in self.PlotM.__dict__:
+            self.HideLegend.setChecked(False)
+            return
+        
+        if self.HideLegend.isChecked():
+            self.PlotM.ax1.legend().set_visible(False)
+            self.PlotM.ax2.legend().set_visible(False)
+            self.PlotM.draw()
+        else:
+            self.PlotM.ax1.legend(loc='lower left', fontsize=8).set_visible(True)
+            self.PlotM.ax2.legend(loc='lower left', fontsize=8).set_visible(True)
+            self.PlotM.draw()
+
     def _set_reference(self):
         '''
         set the reference point for lick spout position in the metadata dialog
@@ -3079,7 +3099,7 @@ class Window(QMainWindow):
             self.GeneratedTrials.B_GoCueTime=self.GeneratedTrials.B_GoCueTime[0]
             self.GeneratedTrials.B_RewardOutcomeTime=self.GeneratedTrials.B_RewardOutcomeTime[0]
             
-        PlotM=PlotV(win=self,GeneratedTrials=self.GeneratedTrials,width=5, height=4)
+        self.PlotM=PlotV(win=self,GeneratedTrials=self.GeneratedTrials,width=5, height=4)
         layout=self.Visualization.layout()
         if layout is not None:
             for i in reversed(range(layout.count())):
@@ -3088,12 +3108,12 @@ class Window(QMainWindow):
         layout=self.Visualization.layout()
         if layout is None:
             layout=QVBoxLayout(self.Visualization)
-        toolbar = NavigationToolbar(PlotM, self)
+        toolbar = NavigationToolbar(self.PlotM, self)
         toolbar.setMaximumHeight(20)
         toolbar.setMaximumWidth(300)
         layout.addWidget(toolbar)
-        layout.addWidget(PlotM)
-        PlotM._Update(GeneratedTrials=self.GeneratedTrials)
+        layout.addWidget(self.PlotM)
+        self.PlotM._Update(GeneratedTrials=self.GeneratedTrials)
         self.PlotLick._Update(GeneratedTrials=self.GeneratedTrials)
 
     def _Clear(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -253,8 +253,6 @@ class Window(QMainWindow):
                 )
             )
         self.AutoTrain.clicked.connect(self._auto_train_clicked)
-        
-        
         self.pushButton_streamlit.clicked.connect(self._open_mouse_on_streamlit)
         self.Task.currentIndexChanged.connect(self._ShowRewardPairs)
         self.Task.currentIndexChanged.connect(self._Task)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1083,6 +1083,7 @@ class Window(QMainWindow):
                 'aind_watchdog_service',
                 'manifest'),
             'auto_engage':True,
+            'clear_figure_after_save':True,
         }
         
         # Try to load Settings_box#.csv
@@ -1169,7 +1170,7 @@ class Window(QMainWindow):
         self.name_mapper_file = self.Settings['name_mapper_file']
         self.save_each_trial = self.Settings['save_each_trial']
         self.auto_engage = self.Settings['auto_engage']
-
+        self.clear_figure_after_save = self.Settings['clear_figure_after_save']
         if not is_absolute_path(self.project_info_file):
             self.project_info_file = os.path.join(self.SettingFolder,self.project_info_file)
         # Also stream log info to the console if enabled
@@ -3455,7 +3456,7 @@ class Window(QMainWindow):
             del self.fiber_photometry_end_time 
 
         # Clear Plots
-        if hasattr(self, 'PlotM'): 
+        if hasattr(self, 'PlotM') and self.clear_figure_after_save: 
             self.PlotM._Update(GeneratedTrials=None,Channel=None)
 
         # Add note to log

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -297,7 +297,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>hide legend</string>
+           <string>Hide legend</string>
           </property>
           <property name="checkable">
            <bool>true</bool>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -113,7 +113,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,0,0,0,0,0,0,0,0,0,0">
+       <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,0,0,0,0,0,0,0,0,0,0,0">
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
@@ -126,20 +126,7 @@
         <property name="rightMargin">
          <number>4</number>
         </property>
-        <item row="0" column="0">
-         <widget class="QPushButton" name="Load">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Load</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
+        <item row="2" column="3">
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -152,7 +139,7 @@
           </property>
          </spacer>
         </item>
-        <item row="0" column="6">
+        <item row="2" column="7">
          <widget class="QSpinBox" name="SessionlistSpin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -177,8 +164,8 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="10">
-         <widget class="QPushButton" name="Clear">
+        <item row="2" column="0">
+         <widget class="QPushButton" name="Load">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -186,11 +173,33 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Clear</string>
+           <string>Load</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="8" alignment="Qt::AlignRight">
+        <item row="2" column="4">
+         <widget class="QLabel" name="label_73">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>session=</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::AutoText</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="9" alignment="Qt::AlignRight">
          <widget class="QPushButton" name="NewSession">
           <property name="enabled">
            <bool>true</bool>
@@ -215,7 +224,20 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
+        <item row="2" column="11">
+         <widget class="QPushButton" name="Clear">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
          <widget class="QPushButton" name="Start">
           <property name="enabled">
            <bool>true</bool>
@@ -240,8 +262,31 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="4">
-         <widget class="QLabel" name="label_73">
+        <item row="2" column="1">
+         <widget class="QPushButton" name="Save">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="5">
+         <widget class="QComboBox" name="Sessionlist">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="8">
+         <widget class="QPushButton" name="HideLegend">
           <property name="enabled">
            <bool>true</bool>
           </property>
@@ -252,36 +297,10 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>session=</string>
+           <string>hide legend</string>
           </property>
-          <property name="textFormat">
-           <enum>Qt::AutoText</enum>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="5">
-         <widget class="QComboBox" name="Sessionlist">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QPushButton" name="Save">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Save</string>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -2701,7 +2720,7 @@ Double dipping:
                <widget class="QWidget" name="scrollAreaWidgetContents_2">
                 <property name="geometry">
                  <rect>
-                  <x>-297</x>
+                  <x>0</x>
                   <y>0</y>
                   <width>1068</width>
                   <height>463</height>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2687,7 +2687,7 @@
     <widget class="QLabel" name="label_69">
      <property name="geometry">
       <rect>
-       <x>585</x>
+       <x>610</x>
        <y>10</y>
        <width>121</width>
        <height>20</height>
@@ -2787,7 +2787,7 @@
     <widget class="QSpinBox" name="RunLength">
      <property name="geometry">
       <rect>
-       <x>710</x>
+       <x>735</x>
        <y>10</y>
        <width>61</width>
        <height>22</height>
@@ -2863,7 +2863,7 @@
     <widget class="QLabel" name="label_73">
      <property name="geometry">
       <rect>
-       <x>210</x>
+       <x>190</x>
        <y>10</y>
        <width>121</width>
        <height>20</height>
@@ -2888,7 +2888,7 @@
     <widget class="QSpinBox" name="SessionlistSpin">
      <property name="geometry">
       <rect>
-       <x>530</x>
+       <x>510</x>
        <y>10</y>
        <width>41</width>
        <height>22</height>
@@ -2913,11 +2913,36 @@
     <widget class="QComboBox" name="Sessionlist">
      <property name="geometry">
       <rect>
-       <x>340</x>
+       <x>320</x>
        <y>10</y>
        <width>191</width>
        <height>22</height>
       </rect>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="HideLegend">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="geometry">
+      <rect>
+       <x>560</x>
+       <y>10</y>
+       <width>75</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>hide legend</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
      </property>
     </widget>
    </widget>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2939,7 +2939,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>hide legend</string>
+      <string>Hide legend</string>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -356,11 +356,15 @@ class PlotV(FigureCanvas):
         self.ax1.set_yticks([0,1])
         self.ax1.set_yticklabels(['L', 'R'])
         self.ax1.set_ylim(-0.6, 1.6)
-        self.ax1.legend(loc='lower left', fontsize=8)
         self.ax2.set_yticks([0,1])
         self.ax2.set_yticklabels(['L', 'R'])
         self.ax2.set_ylim(-0.15, 1.15)
-        self.ax2.legend(loc='lower left', fontsize=8)
+        if self.main_win.HideLegend.isChecked():
+            self.ax1.legend().set_visible(False)
+            self.ax2.legend().set_visible(False)
+        else:
+            self.ax1.legend(loc='lower left', fontsize=8)
+            self.ax2.legend(loc='lower left', fontsize=8)
 
 class PlotWaterCalibration(FigureCanvas):
     def __init__(self,water_win,dpi=100,width=5, height=4):


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. Added a button to hide/show figure legend. 
2. Added an option (`clear_figure_after_save`) in the foraging settings file to not clear the figure after clicking Save. `clear_figure_after_save` is set to `true` by default. 

### What issues or discussions does this update address?
The figure legend hides part of the figure. 

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
tested on my own computer. 




