### PR TITLE
Skip upload manifest for test mouse, clarify alert text for upload manifest failures

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4232,6 +4232,9 @@ class Window(QMainWindow):
         '''
             Generates a manifest.yml file for triggering data copy to VAST and upload to aws
         '''
+        if self.ID.text() == '0':
+            logging.info('Skipping upload manifest, because this is the test mouse')
+            return
         try: 
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
@@ -4286,7 +4289,7 @@ class Window(QMainWindow):
             logging.error('Could not generate upload manifest: {}'.format(str(e)))
             QMessageBox.critical(self, 'Upload manifest', 
                 'Could not generate upload manifest. '+\
-                'Please alert the mouse owner that this session will not be uploaded.')
+                'Please alert the mouse owner, and report on github.')
             
 
 def start_gui_log_file(box_number):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3619,7 +3619,7 @@ class Window(QMainWindow):
             logging.info('Starting session, with experimenter: {}'.format(self.Experimenter.text()))
 
             # check repo status
-            if (self.current_branch not in ['main','production_testing']) & (self.ID.text() != '0'):
+            if (self.current_branch not in ['main','production_testing']) & (self.ID.text() not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # Prompt user over off-pipeline branch
                 reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
@@ -3635,7 +3635,7 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch))
 
             # Check for untracked local changes
-            if self.repo_dirty_flag & (self.ID.text() != '0'):
+            if self.repo_dirty_flag & (self.ID.text() not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # prompt user over untracked local changes
                 reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),    
@@ -4232,7 +4232,7 @@ class Window(QMainWindow):
         '''
             Generates a manifest.yml file for triggering data copy to VAST and upload to aws
         '''
-        if self.ID.text() == '0':
+        if self.ID.text() in ['0','1','2','3','4','5','6','7','8','9','10']:
             logging.info('Skipping upload manifest, because this is the test mouse')
             return
         try: 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Does not generate an upload manifest for the test mouse (any ID <= 10)
- Changes the alert text to: "Could not generate upload manifest. Please alert the mouse owner, and report on github."

### What issues or discussions does this update address?
- resolves #626 
- resolves #627 

### Describe the expected change in behavior from the perspective of the experimenter

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested in 447




