### PR TITLE
hot fix

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3153,7 +3153,7 @@ class Window(QMainWindow):
                 logging.warning('FIP workflow already started, user restarts')
 
         # Start logging
-        self.CreateNewFolder=1
+        self.load_tag=0
         self.Ot_log_folder=self._restartlogging()
 
         # Start the FIP workflow
@@ -3726,7 +3726,6 @@ class Window(QMainWindow):
             try:
                 # Do not start a new session if the camera is already open, this means the session log has been started or the existing session has not been completed.
                 if (not (self.Camera_dialog.StartRecording.isChecked() and self.Camera_dialog.AutoControl.currentText()=='No')) and (not self.FIP_started):
-                    self.CreateNewFolder=1
                     self.Ot_log_folder=self._restartlogging()
             except Exception as e:
                 if 'ConnectionAbortedError' in str(e):


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Create new folders when restarting logging from the `_StartFIP`. 

### What issues or discussions does this update address?
When `Start FIP workflow` is clicked, it will try to restart logging. However, if a previous json file has already been loaded, the folder will not be recreated, and logging will use the previous folder instead, which cause "'loggerstarted.csv' already exists" error. This error is introduced by PR https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/597 when I tried to protect the behavior json from being overwritten when loaded into the GUI. And I didn't realize that there is also a restart logging in the `_StartFIP`. 

This error is only happening in photometry session. 

Fixed:
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/524#issuecomment-2260979583
https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/632

Seems that this issue is also related:
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/538#issuecomment-2261066756

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
Yes in 447




