### PR TITLE
Feat: auto engage AutoTrain when user Loads a session

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2752,7 +2752,8 @@ class Window(QMainWindow):
 
         # Set ID, clear weight information
         logging.info('User starting a new mouse: {}'.format(mouse_id))
-        self.ID.setText(mouse_id)   
+        self.ID.setText(mouse_id) 
+        self.ID.returnPressed.emit()
         self.BaseWeight.setText('')
         self.WeightAfter.setText('')
         self.TargetRatio.setText('0.85')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3066,6 +3066,7 @@ class Window(QMainWindow):
         self.StartExcitation.setChecked(False)
         self.keyPressEvent() # Accept all updates
         self.load_tag=1
+        self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''


### PR DESCRIPTION
### Describe changes:
- Always mimic a ReturnPress when the user changes the the subject ID by pressing the "Load" button.

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/541

### Describe the expected change in behavior from the perspective of the experimenter
- In all these three cases, AutoTrain will be automatically engaged (given the mouse is already in AutoTrain):
    - Press the Load button and successfully load a previous session
    - Press the Load button but there is no local session for this mouse
    - Manually change the subject ID and hit Return.

### Describe any manual update steps for task computers
None

### Was this update tested in 446/447?
Tested on my PC.




