### PR TITLE
Clarifying spot check error messages

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -993,7 +993,6 @@ class WaterCalibrationDialog(QDialog):
             self.SpotCheckPreWeightLeft.setText(str(empty_tube_weight))
 
         # Determine what open time to use
-        self.SpotLeftFinished=0
         self.SpotLeftOpenTime = self._VolumeToTime(float(self.SpotLeftVolume.text()),'Left')
         self.SpotLeftOpenTime = np.round(self.SpotLeftOpenTime,4)
         logging.info('Using a calibration spot check of {}s to deliver {}uL'.format(self.SpotLeftOpenTime,self.SpotLeftVolume.text()))
@@ -1074,7 +1073,6 @@ class WaterCalibrationDialog(QDialog):
                 '\nCalibration saved'
                 )
             self._SaveLeft()
-
 
         # set the default valve open time
         self.MainWindow.Channel.LeftValue(float(self.MainWindow.LeftValue.text())*1000)
@@ -1187,7 +1185,12 @@ class WaterCalibrationDialog(QDialog):
         result = (final_tube_weight - empty_tube_weight)/int(self.SpotCycle)*1000
         error = result - float(self.SpotRightVolume.text())
         error = np.round(error,4)
-        
+        self.Warning.setText(
+            'Measuring right valve: {}uL'.format(self.SpotRightVolume.text()) + \
+            '\nEmpty tube weight: {}g'.format(empty_tube_weight) + \
+            '\nFinal tube weight: {}g'.format(final_tube_weight) + \
+            '\nAvg. error from target: {}uL'.format(error)
+            )                
         TOLERANCE = float(self.SpotRightVolume.text())*.15
         if np.abs(error) > TOLERANCE:
             reply = QMessageBox.critical(self, 'Spot check left', 

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1188,11 +1188,12 @@ class WaterCalibrationDialog(QDialog):
         error = result - float(self.SpotRightVolume.text())
         error = np.round(error,4)
         
-        TOLERANCE = float(self.SpotRightVolume.text())/10
+        TOLERANCE = float(self.SpotRightVolume.text())*.15
         if np.abs(error) > TOLERANCE:
-            reply = QMessageBox.critical(self, 'Spot check right', 
-                'Result ( {}uL ) is outside expected tolerance. \nPlease confirm you entered information correctly, then press save.'.format(np.round(result,2)), 
+            reply = QMessageBox.critical(self, 'Spot check left', 
+                'Measurement is outside expected tolerance. <br><br>FIRST, please confirm you entered information correctly, then press save. <br><br><span style="color:purple;font-weight:bold">IMPORTANT</span>: If the measurement was correctly entered (not a typo), please repeat the spot check once. If the measurement remains outside the expected tolerance please immediately perform a full calibration.'.format(np.round(result,2)), 
                 QMessageBox.Ok)
+
             logging.error('Water calibration spot check exceeds tolerance: {}'.format(error))  
             self.SaveRight.setStyleSheet("color: white;background-color : mediumorchid;")
             self.Warning.setText(


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
If the spot check fails, you will see this message. 
![354015979-aca469b0-1b53-44eb-aee4-abb590f73700](https://github.com/user-attachments/assets/41540ecf-0afb-4253-889a-82b0a6b14433)

Please verify that you didn't mis-type the measurement. Then repeat the spot check. If both spot checks fail, then do a full calibration of that solenoid. 

This was already the policy, but I had failed to update the text when the spot check failed. 

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/543

### Describe the expected change in behavior from the perspective of the experimenter
See above

### Describe any manual update steps for task computers
None

### Was this update tested in 446/447?
- [ ] tested in 447




