### PR TITLE
Lick visualizer bug fix

### DIFF
--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -2915,11 +2915,11 @@
                       <Value>0</Value>
                     </Operand>
                   </Expression>
-                  <Expression xsi:type="rx:PublishSubject">
-                    <Name>LeftLick</Name>
-                  </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
+                  <Expression xsi:type="rx:PublishSubject">
+                    <Name>LeftLick</Name>
                   </Expression>
                   <Expression xsi:type="rx:Condition">
                     <Workflow>
@@ -2967,11 +2967,11 @@
                       <Value>0</Value>
                     </Operand>
                   </Expression>
-                  <Expression xsi:type="rx:PublishSubject">
-                    <Name>RightLick</Name>
-                  </Expression>
                   <Expression xsi:type="Combinator">
                     <Combinator xsi:type="rx:DistinctUntilChanged" />
+                  </Expression>
+                  <Expression xsi:type="rx:PublishSubject">
+                    <Name>RightLick</Name>
                   </Expression>
                   <Expression xsi:type="rx:Condition">
                     <Workflow>
@@ -7964,7 +7964,7 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="spk:SpinnakerCapture">
                             <spk:Index xsi:nil="true" />
-                            <spk:SerialNumber>23045805</spk:SerialNumber>
+                            <spk:SerialNumber>23022715</spk:SerialNumber>
                             <spk:ColorProcessing>Default</spk:ColorProcessing>
                           </Combinator>
                         </Expression>
@@ -8002,7 +8002,7 @@
                           </PropertyMappings>
                         </Expression>
                         <Expression xsi:type="io:CsvWriter">
-                          <io:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2024-04-05_10-37-19\behavior\raw.harp/../../behavior-videos/bottom_camera.csv</io:FileName>
+                          <io:FileName>C:\Users\svc_aind_behavior\Documents\temporaryvideo\2024-08-05_11-56-50\behavior\raw.harp/../../behavior-videos/bottom_camera.csv</io:FileName>
                           <io:Append>false</io:Append>
                           <io:Overwrite>true</io:Overwrite>
                           <io:Suffix>None</io:Suffix>
@@ -8050,7 +8050,7 @@
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="ffmpeg:VideoWriter">
-                            <ffmpeg:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2024-04-05_10-37-19\behavior\raw.harp/../../behavior-videos/bottom_camera.avi</ffmpeg:FileName>
+                            <ffmpeg:FileName>C:\Users\svc_aind_behavior\Documents\temporaryvideo\2024-08-05_11-56-50\behavior\raw.harp/../../behavior-videos/bottom_camera.avi</ffmpeg:FileName>
                             <ffmpeg:Suffix>None</ffmpeg:Suffix>
                             <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
                             <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
@@ -8135,7 +8135,7 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="spk:SpinnakerCapture">
                             <spk:Index xsi:nil="true" />
-                            <spk:SerialNumber>23022710</spk:SerialNumber>
+                            <spk:SerialNumber>22511925</spk:SerialNumber>
                             <spk:ColorProcessing>Default</spk:ColorProcessing>
                           </Combinator>
                         </Expression>
@@ -8173,7 +8173,7 @@
                           </PropertyMappings>
                         </Expression>
                         <Expression xsi:type="io:CsvWriter">
-                          <io:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2024-04-05_10-37-19\behavior\raw.harp/../../behavior-videos/side_camera_right.csv</io:FileName>
+                          <io:FileName>C:\Users\svc_aind_behavior\Documents\temporaryvideo\2024-08-05_11-56-50\behavior\raw.harp/../../behavior-videos/side_camera_right.csv</io:FileName>
                           <io:Append>false</io:Append>
                           <io:Overwrite>true</io:Overwrite>
                           <io:Suffix>None</io:Suffix>
@@ -8221,7 +8221,7 @@
                         </Expression>
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="ffmpeg:VideoWriter">
-                            <ffmpeg:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2024-04-05_10-37-19\behavior\raw.harp/../../behavior-videos/side_camera_right.avi</ffmpeg:FileName>
+                            <ffmpeg:FileName>C:\Users\svc_aind_behavior\Documents\temporaryvideo\2024-08-05_11-56-50\behavior\raw.harp/../../behavior-videos/side_camera_right.avi</ffmpeg:FileName>
                             <ffmpeg:Suffix>None</ffmpeg:Suffix>
                             <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
                             <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
@@ -8525,9 +8525,19 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>CameraImage_Bottom</Name>
             </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="cv:Flip">
+                <cv:Mode>Horizontal</cv:Mode>
+              </Combinator>
+            </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
               <Name>CameraImage_Side</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="cv:Flip">
+                <cv:Mode>Horizontal</cv:Mode>
+              </Combinator>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="viz:TableLayoutPanelBuilder">
@@ -8618,10 +8628,12 @@
             <Edge From="46" To="47" Label="Source1" />
             <Edge From="47" To="48" Label="Source2" />
             <Edge From="49" To="50" Label="Source1" />
-            <Edge From="50" To="53" Label="Source1" />
-            <Edge From="51" To="52" Label="Source1" />
-            <Edge From="52" To="53" Label="Source2" />
-            <Edge From="54" To="55" Label="Source1" />
+            <Edge From="50" To="51" Label="Source1" />
+            <Edge From="51" To="55" Label="Source1" />
+            <Edge From="52" To="53" Label="Source1" />
+            <Edge From="53" To="54" Label="Source1" />
+            <Edge From="54" To="55" Label="Source2" />
+            <Edge From="56" To="57" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -8672,7 +8684,7 @@
               </Operand>
             </Expression>
             <Expression xsi:type="Format">
-              <Format>LickVis: {0}</Format>
+              <Format>LickVis: {0} -- Top:R / Bottom:L</Format>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -8680,7 +8692,7 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="viz:TableLayoutPanelBuilder">
-              <viz:Name>LickVis: 428-9-A</viz:Name>
+              <viz:Name>LickVis: 428-9-A -- Top:R / Bottom:L</viz:Name>
               <viz:ColumnCount>1</viz:ColumnCount>
               <viz:RowCount>2</viz:RowCount>
               <viz:ColumnStyles />

--- a/src/workflows/foraging.bonsai.layout
+++ b/src/workflows/foraging.bonsai.layout
@@ -4385,18 +4385,6 @@
           <DialogSettings>
             <Visible>false</Visible>
             <Location>
-              <X>234</X>
-              <Y>234</Y>
-            </Location>
-            <Size>
-              <Width>416</Width>
-              <Height>279</Height>
-            </Size>
-            <WindowState>Normal</WindowState>
-          </DialogSettings>
-          <DialogSettings>
-            <Visible>false</Visible>
-            <Location>
               <X>0</X>
               <Y>0</Y>
             </Location>
@@ -4529,12 +4517,24 @@
           <DialogSettings>
             <Visible>false</Visible>
             <Location>
-              <X>235</X>
-              <Y>514</Y>
+              <X>0</X>
+              <Y>0</Y>
             </Location>
             <Size>
-              <Width>416</Width>
-              <Height>279</Height>
+              <Width>0</Width>
+              <Height>0</Height>
+            </Size>
+            <WindowState>Normal</WindowState>
+          </DialogSettings>
+          <DialogSettings>
+            <Visible>false</Visible>
+            <Location>
+              <X>0</X>
+              <Y>0</Y>
+            </Location>
+            <Size>
+              <Width>0</Width>
+              <Height>0</Height>
             </Size>
             <WindowState>Normal</WindowState>
           </DialogSettings>
@@ -8608,8 +8608,8 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>855</X>
-        <Y>460</Y>
+        <X>759</X>
+        <Y>405</Y>
       </Location>
       <Size>
         <Width>575</Width>
@@ -9255,13 +9255,37 @@
         <WindowState>Normal</WindowState>
       </DialogSettings>
       <DialogSettings>
-        <Visible>true</Visible>
+        <Visible>false</Visible>
         <Location>
-          <X>96</X>
-          <Y>373</Y>
+          <X>0</X>
+          <Y>0</Y>
         </Location>
         <Size>
-          <Width>573</Width>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>false</Visible>
+        <Location>
+          <X>0</X>
+          <Y>0</Y>
+        </Location>
+        <Size>
+          <Width>0</Width>
+          <Height>0</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>true</Visible>
+        <Location>
+          <X>105</X>
+          <Y>380</Y>
+        </Location>
+        <Size>
+          <Width>519</Width>
           <Height>279</Height>
         </Size>
         <WindowState>Normal</WindowState>
@@ -9269,14 +9293,14 @@
         <VisualizerSettings>
           <TableLayoutPanelVisualizer>
             <MashupSettings>
-              <Source>49</Source>
+              <Source>50</Source>
               <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <IplImageVisualizer />
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <Source>51</Source>
+              <Source>52</Source>
               <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <IplImageVisualizer />
@@ -9398,12 +9422,12 @@
   <DialogSettings xsi:type="WorkflowEditorSettings">
     <Visible>false</Visible>
     <Location>
-      <X>0</X>
-      <Y>0</Y>
+      <X>130</X>
+      <Y>130</Y>
     </Location>
     <Size>
-      <Width>0</Width>
-      <Height>0</Height>
+      <Width>336</Width>
+      <Height>65</Height>
     </Size>
     <WindowState>Normal</WindowState>
     <EditorDialogSettings>
@@ -9446,12 +9470,12 @@
       <DialogSettings>
         <Visible>false</Visible>
         <Location>
-          <X>0</X>
-          <Y>0</Y>
+          <X>182</X>
+          <Y>182</Y>
         </Location>
         <Size>
-          <Width>0</Width>
-          <Height>0</Height>
+          <Width>416</Width>
+          <Height>279</Height>
         </Size>
         <WindowState>Normal</WindowState>
       </DialogSettings>
@@ -9518,12 +9542,12 @@
       <DialogSettings>
         <Visible>true</Visible>
         <Location>
-          <X>97</X>
-          <Y>656</Y>
+          <X>105</X>
+          <Y>658</Y>
         </Location>
         <Size>
-          <Width>291</Width>
-          <Height>231</Height>
+          <Width>736</Width>
+          <Height>346</Height>
         </Size>
         <WindowState>Normal</WindowState>
         <VisualizerTypeName>Bonsai.Design.Visualizers.TableLayoutPanelVisualizer</VisualizerTypeName>
@@ -9545,6 +9569,27 @@
                 <BooleanTimeSeriesVisualizer>
                   <Capacity>100</Capacity>
                 </BooleanTimeSeriesVisualizer>
+              </VisualizerSettings>
+            </MashupSettings>
+            <MashupSettings>
+              <Source>8</Source>
+              <VisualizerTypeName>Bonsai.Design.ObjectTextVisualizer</VisualizerTypeName>
+              <VisualizerSettings>
+                <ObjectTextVisualizer />
+              </VisualizerSettings>
+            </MashupSettings>
+            <MashupSettings>
+              <Source>8</Source>
+              <VisualizerTypeName>Bonsai.Design.ObjectTextVisualizer</VisualizerTypeName>
+              <VisualizerSettings>
+                <ObjectTextVisualizer />
+              </VisualizerSettings>
+            </MashupSettings>
+            <MashupSettings>
+              <Source>8</Source>
+              <VisualizerTypeName>Bonsai.Design.ObjectTextVisualizer</VisualizerTypeName>
+              <VisualizerSettings>
+                <ObjectTextVisualizer />
               </VisualizerSettings>
             </MashupSettings>
           </TableLayoutPanelVisualizer>


### PR DESCRIPTION
### Describe changes:
Minor bug fix in the (pseudo)realtime lick visualization window. 

### What issues or discussions does this update address?
Primarily
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/530
and secondarily
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/519

### Describe the expected change in behavior from the perspective of the experimenter
-consistent lick visualizer behavior across FIP and non-FIP sessions
-better labeling in lick visualizer
-high-speed behavior cams in 446 will be horizontally flipped so that it matches with lick visualizers (both realtime and trial-based in the GUI)

### Describe any manual update steps for task computers
N/A

### Was this update tested in 446/447?
tested in 428




