### PR TITLE
Making water calibration plot show spot check failures

### DIFF
--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -455,17 +455,18 @@ class PlotWaterCalibration(FigureCanvas):
                     X,Y=self._GetWaterSpotCheck(self.WaterCalibrationResults,current_date,current_valve)      
                     print(Y)
                     print(type(Y))
-                    FAILED = (Y[0] < 2*(1-.15)) or (Y[0] > 2*(1.15))             
-                    if current_valve=='SpotLeft':
-                        if FAILED:
-                            line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot left (FAIL)')
-                        else:
-                            line=self.ax1.plot(X, Y, 'o',label=current_date+'_spot left')
-                    elif current_valve=='SpotRight':
-                        if FAILED:
-                            line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot right (FAIL)')
-                        else:
-                            line=self.ax1.plot(X, Y, 'o',label=current_date+'_spot right')
+                    for index, y in enumerate(Y):
+                        FAILED = (y < 2*(1-.15)) or (y > 2*(1.15))             
+                        if current_valve=='SpotLeft':
+                            if FAILED:
+                                line=self.ax1.plot(x, y, 'x',label=current_date+'_spot left (FAIL)')
+                            else:
+                                line=self.ax1.plot(x, y, 'o',label=current_date+'_spot left')
+                        elif current_valve=='SpotRight':
+                            if FAILED:
+                                line=self.ax1.plot(x, y, 'x',label=current_date+'_spot right (FAIL)')
+                            else:
+                                line=self.ax1.plot(x, y, 'o',label=current_date+'_spot right')
         self.ax1.set_xlabel('valve open time(s)')
         self.ax1.set_ylabel('water(mg)')
         self.ax1.legend(loc='lower right', fontsize=8)

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -456,6 +456,7 @@ class PlotWaterCalibration(FigureCanvas):
                     print(Y)
                     print(type(Y))
                     for index, y in enumerate(Y):
+                        x = X[index]
                         FAILED = (y < 2*(1-.15)) or (y > 2*(1.15))             
                         if current_valve=='SpotLeft':
                             if FAILED:

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -453,8 +453,6 @@ class PlotWaterCalibration(FigureCanvas):
                     self.FittingResults[current_date][current_valve]=[slope,intercept]
                 elif (current_valve in ['SpotLeft','SpotRight'])and(current_date in all_dates):
                     X,Y=self._GetWaterSpotCheck(self.WaterCalibrationResults,current_date,current_valve)      
-                    print(Y)
-                    print(type(Y))
                     for index, y in enumerate(Y):
                         x = X[index]
                         FAILED = (y < 2*(1-.15)) or (y > 2*(1.15))             

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -453,7 +453,9 @@ class PlotWaterCalibration(FigureCanvas):
                     self.FittingResults[current_date][current_valve]=[slope,intercept]
                 elif (current_valve in ['SpotLeft','SpotRight'])and(current_date in all_dates):
                     X,Y=self._GetWaterSpotCheck(self.WaterCalibrationResults,current_date,current_valve)      
-                    FAILED = (Y < 2*(1-.15)) or (Y > 2*(1.15))             
+                    print(Y)
+                    print(type(Y))
+                    FAILED = (Y[0] < 2*(1-.15)) or (Y[0] > 2*(1.15))             
                     if current_valve=='SpotLeft':
                         if FAILED:
                             line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot left (FAIL)')

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -452,11 +452,18 @@ class PlotWaterCalibration(FigureCanvas):
                         self.FittingResults[current_date][current_valve]={}
                     self.FittingResults[current_date][current_valve]=[slope,intercept]
                 elif (current_valve in ['SpotLeft','SpotRight'])and(current_date in all_dates):
-                    X,Y=self._GetWaterSpotCheck(self.WaterCalibrationResults,current_date,current_valve)                   
+                    X,Y=self._GetWaterSpotCheck(self.WaterCalibrationResults,current_date,current_valve)      
+                    FAILED = (Y < 2*(1-.15)) or (Y > 2*(1.15))             
                     if current_valve=='SpotLeft':
-                        line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot left')
+                        if FAILED:
+                            line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot left (FAIL)')
+                        else:
+                            line=self.ax1.plot(X, Y, 'o',label=current_date+'_spot left')
                     elif current_valve=='SpotRight':
-                        line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot right')
+                        if FAILED:
+                            line=self.ax1.plot(X, Y, 'x',label=current_date+'_spot right (FAIL)')
+                        else:
+                            line=self.ax1.plot(X, Y, 'o',label=current_date+'_spot right')
         self.ax1.set_xlabel('valve open time(s)')
         self.ax1.set_ylabel('water(mg)')
         self.ax1.legend(loc='lower right', fontsize=8)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/548

### Describe the expected change in behavior from the perspective of the experimenter
- Spot checks that fail will show as "X", and the legend will say "FAIL
- Spot checks that pass will show as "O", and the legend will just say the date/valve (like before)

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested in 447




