### PR TITLE
Update codec and decibel

### DIFF
--- a/src/setting_templates/ForagingSettings.json
+++ b/src/setting_templates/ForagingSettings.json
@@ -14,5 +14,9 @@
     "newscale_serial_num_box3":"",
     "newscale_serial_num_box4":"",
     "default_ui":"ForagingGUI.ui",
-    "open_ephys_machine_ip_address":""
+    "open_ephys_machine_ip_address":"",
+    "go_cue_decibel_box1":73,
+    "go_cue_decibel_box2":73,
+    "go_cue_decibel_box3":73,
+    "go_cue_decibel_box4":73
 }

--- a/src/setting_templates/Settings_box1.csv
+++ b/src/setting_templates/Settings_box1.csv
@@ -28,7 +28,7 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
+codec,-vcodec h264_nvenc -rc vbr -cq 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
 current_box,4xx-x-A

--- a/src/setting_templates/Settings_box2.csv
+++ b/src/setting_templates/Settings_box2.csv
@@ -28,7 +28,7 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
+codec,-vcodec h264_nvenc -rc vbr -cq 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
 current_box,4xx-x-B

--- a/src/setting_templates/Settings_box3.csv
+++ b/src/setting_templates/Settings_box3.csv
@@ -28,7 +28,7 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
+codec,-vcodec h264_nvenc -rc vbr -cq 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
 current_box,4xx-x-C

--- a/src/setting_templates/Settings_box4.csv
+++ b/src/setting_templates/Settings_box4.csv
@@ -28,7 +28,7 @@ OptoLaser2SerialNumber,0
 FipRedCMOSSerialNumber,0
 FipGreenCMOSSerialNumber,0
 FipObjectiveSerialNumber,0
-codec,-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24
+codec,-vcodec h264_nvenc -rc vbr -cq 23 -preset fast -b:v 50M -v 24
 AttenuationLeft,0
 AttenuationRight,0
 current_box,4xx-x-D


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
1. In Settings_boxX file, video compression codec parameters were modified to gpu version.
2. In ForagingSettings file, four fields ('go_cue_decibel_box'x4) were added to document the decibel level of go cue in four boxes.
### What issues or discussions does this update address?
This issue: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/588
And tone calibration record keeping.
### Describe the expected change in behavior from the perspective of the experimenter
There should be no change from perspective of the experimenter.
### Describe any manual update steps for task computers
In short term, no immediate update is required on current boxes in 446 and 447. But would be nice to make the formats consistent across boxes once we have time.
### Was this update tested in 446/447?
Yes, tested in 446 computers with manual modification of settings files.




