### PR TITLE
Check disk space

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -186,6 +186,7 @@ class Window(QMainWindow):
         self.DiskSpaceProgreeBar.setValue(int(used/total*100))
         if free/1024**3 < 100 or used/total > 0.9:
             self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-"+self.default_warning_color+"}")
+            logging.warning(f"Low disk space  Used space: {used/1024**3:.2f}GB    Free space: {free/1024**3:.2f}GB")
         else:
             self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-color: green;}")
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -13,7 +13,7 @@ import threading
 import itertools
 import yaml
 import copy
-import psutil
+import shutil
 from pathlib import Path
 from datetime import date, datetime
 
@@ -162,6 +162,8 @@ class Window(QMainWindow):
         self.open_ephys=[]
         # load the rig metadata
         self._load_rig_metadata()
+        # show disk space
+        self._show_disk_space()
         if not self.start_bonsai_ide:
             '''
                 When starting bonsai without the IDE the connection is always unstable.
@@ -176,6 +178,12 @@ class Window(QMainWindow):
         rig_json, rig_json_file= self._load_most_recent_rig_json()
         self.latest_rig_metadata_file = rig_json_file 
         self.Metadata_dialog._SelectRigMetadata(self.latest_rig_metadata_file)
+
+    def _show_disk_space(self):
+        '''Show the disk space of the current computer'''
+        total, used, free = shutil.disk_usage(self.default_saveFolder)
+        self.diskspace.setText(f"Disk space: {free/total*100:.2f}% free")
+        self.DiskSpaceProgreeBar.setValue(int(used/total*100))
 
     def _LoadUI(self):
         '''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -13,6 +13,7 @@ import threading
 import itertools
 import yaml
 import copy
+import psutil
 from pathlib import Path
 from datetime import date, datetime
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3965,6 +3965,9 @@ class Window(QMainWindow):
                 if self.NewTrialRewardOrder==1:
                     GeneratedTrials._GenerateATrial(self.Channel4)   
 
+                # show disk space
+                self._show_disk_space()
+                
             elif ((time.time() - last_trial_start) >stall_duration*stall_iteration) and \
                 ((time.time() - self.Channel.last_message_time) > stall_duration*stall_iteration):
                 # Elapsed time since last trial is more than tolerance

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -185,7 +185,7 @@ class Window(QMainWindow):
         self.diskspace.setText(f"Used space: {used/1024**3:.2f}GB    Free space: {free/1024**3:.2f}GB")
         self.DiskSpaceProgreeBar.setValue(int(used/total*100))
         if free/1024**3 < 100 or used/total > 0.9:
-            self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-color: red;}")
+            self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-"+self.default_warning_color+"}")
         else:
             self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-color: green;}")
 
@@ -3967,7 +3967,7 @@ class Window(QMainWindow):
 
                 # show disk space
                 self._show_disk_space()
-                
+
             elif ((time.time() - last_trial_start) >stall_duration*stall_iteration) and \
                 ((time.time() - self.Channel.last_message_time) > stall_duration*stall_iteration):
                 # Elapsed time since last trial is more than tolerance

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -182,7 +182,7 @@ class Window(QMainWindow):
     def _show_disk_space(self):
         '''Show the disk space of the current computer'''
         total, used, free = shutil.disk_usage(self.default_saveFolder)
-        self.diskspace.setText(f"Disk space: {free/total*100:.2f}% free")
+        self.diskspace.setText(f"Disk space: {free/1024**3:.2f}GB free {total/1024**3:.2f}GB total")
         self.DiskSpaceProgreeBar.setValue(int(used/total*100))
 
     def _LoadUI(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -182,8 +182,12 @@ class Window(QMainWindow):
     def _show_disk_space(self):
         '''Show the disk space of the current computer'''
         total, used, free = shutil.disk_usage(self.default_saveFolder)
-        self.diskspace.setText(f"Disk space: {free/1024**3:.2f}GB free {total/1024**3:.2f}GB total")
+        self.diskspace.setText(f"Used space: {used/1024**3:.2f}GB    Free space: {free/1024**3:.2f}GB")
         self.DiskSpaceProgreeBar.setValue(int(used/total*100))
+        if free/1024**3 < 100 or used/total > 0.9:
+            self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-color: red;}")
+        else:
+            self.DiskSpaceProgreeBar.setStyleSheet("QProgressBar::chunk {background-color: green;}")
 
     def _LoadUI(self):
         '''

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -126,7 +126,20 @@
         <property name="rightMargin">
          <number>4</number>
         </property>
-        <item row="2" column="3">
+        <item row="1" column="11">
+         <widget class="QPushButton" name="Clear">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Clear</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -139,67 +152,7 @@
           </property>
          </spacer>
         </item>
-        <item row="2" column="7">
-         <widget class="QSpinBox" name="SessionlistSpin">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="maximum">
-           <number>100000</number>
-          </property>
-          <property name="value">
-           <number>1</number>
-          </property>
-          <property name="displayIntegerBase">
-           <number>10</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QPushButton" name="Load">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Load</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="4">
-         <widget class="QLabel" name="label_73">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>session=</string>
-          </property>
-          <property name="textFormat">
-           <enum>Qt::AutoText</enum>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="9" alignment="Qt::AlignRight">
+        <item row="1" column="9" alignment="Qt::AlignRight">
          <widget class="QPushButton" name="NewSession">
           <property name="enabled">
            <bool>true</bool>
@@ -224,8 +177,33 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="11">
-         <widget class="QPushButton" name="Clear">
+        <item row="1" column="7">
+         <widget class="QSpinBox" name="SessionlistSpin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="maximum">
+           <number>100000</number>
+          </property>
+          <property name="value">
+           <number>1</number>
+          </property>
+          <property name="displayIntegerBase">
+           <number>10</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="Load">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -233,11 +211,56 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Clear</string>
+           <string>Load</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
+        <item row="1" column="5">
+         <widget class="QLabel" name="label_73">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>session=</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::AutoText</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="6">
+         <widget class="QComboBox" name="Sessionlist">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="Save">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
          <widget class="QPushButton" name="Start">
           <property name="enabled">
            <bool>true</bool>
@@ -259,48 +282,6 @@
           </property>
           <property name="checked">
            <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QPushButton" name="Save">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Save</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="5">
-         <widget class="QComboBox" name="Sessionlist">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="8">
-         <widget class="QPushButton" name="HideLegend">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Hide legend</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -604,8 +585,35 @@
                 <property name="title">
                  <string>Warning</string>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_2">
-                 <item>
+                <layout class="QGridLayout" name="gridLayout_7">
+                 <item row="1" column="0">
+                  <widget class="QProgressBar" name="DiskSpaceProgreeBar">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>15</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <stylestrategy>PreferDefault</stylestrategy>
+                    </font>
+                   </property>
+                   <property name="whatsThis">
+                    <string/>
+                   </property>
+                   <property name="value">
+                    <number>24</number>
+                   </property>
+                   <property name="textVisible">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
                   <widget class="QScrollArea" name="scrollArea_6">
                    <property name="widgetResizable">
                     <bool>true</bool>
@@ -902,6 +910,13 @@
                      </item>
                     </layout>
                    </widget>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="diskspace">
+                   <property name="text">
+                    <string>free/total(GB) : </string>
+                   </property>
                   </widget>
                  </item>
                 </layout>
@@ -5558,8 +5573,8 @@ Current pair:
    <slot>click()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>412</x>
-     <y>128</y>
+     <x>411</x>
+     <y>543</y>
     </hint>
     <hint type="destinationlabel">
      <x>337</x>
@@ -5574,8 +5589,8 @@ Current pair:
    <slot>click()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>487</x>
-     <y>132</y>
+     <x>519</x>
+     <y>543</y>
     </hint>
     <hint type="destinationlabel">
      <x>404</x>

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -611,6 +611,9 @@
                    <property name="textVisible">
                     <bool>true</bool>
                    </property>
+                   <property name="format">
+                    <string>%p% used</string>
+                   </property>
                   </widget>
                  </item>
                  <item row="0" column="0">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -126,20 +126,7 @@
         <property name="rightMargin">
          <number>4</number>
         </property>
-        <item row="1" column="11">
-         <widget class="QPushButton" name="Clear">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Clear</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
+        <item row="2" column="3">
          <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -152,32 +139,7 @@
           </property>
          </spacer>
         </item>
-        <item row="1" column="9" alignment="Qt::AlignRight">
-         <widget class="QPushButton" name="NewSession">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>New Session</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="7">
+        <item row="2" column="7">
          <widget class="QSpinBox" name="SessionlistSpin">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -202,7 +164,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QPushButton" name="Load">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -215,7 +177,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="5">
+        <item row="2" column="4">
          <widget class="QLabel" name="label_73">
           <property name="enabled">
            <bool>true</bool>
@@ -237,18 +199,33 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="6">
-         <widget class="QComboBox" name="Sessionlist">
+        <item row="2" column="9" alignment="Qt::AlignRight">
+         <widget class="QPushButton" name="NewSession">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>200</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
+          <property name="text">
+           <string>New Session</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QPushButton" name="Save">
+        <item row="2" column="11">
+         <widget class="QPushButton" name="Clear">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -256,11 +233,11 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Save</string>
+           <string>Clear</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="2" column="2">
          <widget class="QPushButton" name="Start">
           <property name="enabled">
            <bool>true</bool>
@@ -282,6 +259,48 @@
           </property>
           <property name="checked">
            <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QPushButton" name="Save">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="5">
+         <widget class="QComboBox" name="Sessionlist">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="8">
+         <widget class="QPushButton" name="HideLegend">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Hide legend</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -571,6 +590,12 @@
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>0</height>
+                 </size>
+                </property>
                 <property name="maximumSize">
                  <size>
                   <width>100000</width>
@@ -585,38 +610,8 @@
                 <property name="title">
                  <string>Warning</string>
                 </property>
-                <layout class="QGridLayout" name="gridLayout_7">
-                 <item row="1" column="0">
-                  <widget class="QProgressBar" name="DiskSpaceProgreeBar">
-                   <property name="enabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>15</height>
-                    </size>
-                   </property>
-                   <property name="font">
-                    <font>
-                     <stylestrategy>PreferDefault</stylestrategy>
-                    </font>
-                   </property>
-                   <property name="whatsThis">
-                    <string/>
-                   </property>
-                   <property name="value">
-                    <number>24</number>
-                   </property>
-                   <property name="textVisible">
-                    <bool>true</bool>
-                   </property>
-                   <property name="format">
-                    <string>%p% used</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="0">
+                <layout class="QVBoxLayout" name="verticalLayout_2">
+                 <item>
                   <widget class="QScrollArea" name="scrollArea_6">
                    <property name="widgetResizable">
                     <bool>true</bool>
@@ -915,10 +910,40 @@
                    </widget>
                   </widget>
                  </item>
-                 <item row="2" column="0">
+                 <item>
                   <widget class="QLabel" name="diskspace">
                    <property name="text">
-                    <string>free/total(GB) : </string>
+                    <string>Disk space:  (free/total(GB))  </string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QProgressBar" name="DiskSpaceProgreeBar">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>15</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <stylestrategy>PreferDefault</stylestrategy>
+                    </font>
+                   </property>
+                   <property name="whatsThis">
+                    <string/>
+                   </property>
+                   <property name="value">
+                    <number>24</number>
+                   </property>
+                   <property name="textVisible">
+                    <bool>true</bool>
+                   </property>
+                   <property name="format">
+                    <string>%p% used</string>
                    </property>
                   </widget>
                  </item>
@@ -5576,8 +5601,8 @@ Current pair:
    <slot>click()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>411</x>
-     <y>543</y>
+     <x>412</x>
+     <y>128</y>
     </hint>
     <hint type="destinationlabel">
      <x>337</x>
@@ -5592,8 +5617,8 @@ Current pair:
    <slot>click()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>519</x>
-     <y>543</y>
+     <x>487</x>
+     <y>132</y>
     </hint>
     <hint type="destinationlabel">
      <x>404</x>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4658,7 +4658,7 @@
      <rect>
       <x>1540</x>
       <y>290</y>
-      <width>331</width>
+      <width>321</width>
       <height>15</height>
      </rect>
     </property>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4682,14 +4682,17 @@
     <property name="textVisible">
      <bool>true</bool>
     </property>
+    <property name="format">
+     <string>%p% used</string>
+    </property>
    </widget>
    <widget class="QLabel" name="diskspace">
     <property name="geometry">
      <rect>
       <x>1540</x>
       <y>270</y>
-      <width>197</width>
-      <height>13</height>
+      <width>321</width>
+      <height>16</height>
      </rect>
     </property>
     <property name="text">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -4650,6 +4650,52 @@
      <string/>
     </property>
    </widget>
+   <widget class="QProgressBar" name="DiskSpaceProgreeBar">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>1540</x>
+      <y>290</y>
+      <width>331</width>
+      <height>15</height>
+     </rect>
+    </property>
+    <property name="maximumSize">
+     <size>
+      <width>16777215</width>
+      <height>15</height>
+     </size>
+    </property>
+    <property name="font">
+     <font>
+      <stylestrategy>PreferDefault</stylestrategy>
+     </font>
+    </property>
+    <property name="whatsThis">
+     <string/>
+    </property>
+    <property name="value">
+     <number>24</number>
+    </property>
+    <property name="textVisible">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="diskspace">
+    <property name="geometry">
+     <rect>
+      <x>1540</x>
+      <y>270</y>
+      <width>197</width>
+      <height>13</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Disk space:  (free/total(GB))  </string>
+    </property>
+   </widget>
    <zorder>TrainingParameters</zorder>
    <zorder>StartFIP</zorder>
    <zorder>FIPMode</zorder>
@@ -4690,6 +4736,8 @@
    <zorder>OpenEphysRecordingType</zorder>
    <zorder>ManualWaterWarning</zorder>
    <zorder>MetadataWarning</zorder>
+   <zorder>DiskSpaceProgreeBar</zorder>
+   <zorder>diskspace</zorder>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Displays disk space and warns users of low disk space when the available space is less than 100G or less than 1% of the total space.

![image](https://github.com/user-attachments/assets/442662c3-da57-459b-b460-b2300adc973a)


### What issues or discussions does this update address?
Avoid disk fullness
Related: https://github.com/orgs/AllenNeuralDynamics/projects/47/views/7?pane=issue&itemId=71011651

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
Tested on my own computer. 




