### PR TITLE
Disable default selection

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -325,6 +325,11 @@ class WaterCalibrationDialog(QDialog):
         self.setWindowTitle('Water Calibration: {}'.format(self.MainWindow.current_box))
         self.Warning.setText('')
         self.Warning.setStyleSheet(self.MainWindow.default_warning_color)
+        # find all buttons and set them to not be the default button
+        for container in [self]:
+            for child in container.findChildren((QtWidgets.QPushButton)):     
+                child.setDefault(False)
+                child.setAutoDefault(False)
 
     def _connectSignalsSlots(self):
         self.SpotCheckLeft.clicked.connect(self._SpotCheckLeft)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Set the pushbutton in the water calibration dialog not to be the default button. 

### What issues or discussions does this update address?
resolved: https://github.com/orgs/AllenNeuralDynamics/projects/47/views/7?pane=issue&itemId=73071378

### Describe the expected change in behavior from the perspective of the experimenter
No

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
Tested on my own computer. 




