### PR TITLE
handle edge case metadata opto calibration

### DIFF
--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -1116,6 +1116,8 @@ class generate_metadata:
                                         laser_voltage_power=eval(str(current_calibration[i]))
                                         voltage.append(laser_voltage_power[0])
                                         power.append(laser_voltage_power[1])
+                                    if voltage==[] or power==[]:
+                                        continue
                                     voltage, power = zip(*sorted(zip(voltage, power), key=lambda x: x[0]))
                                     self.parsed_optocalibration.append({'laser name':laser,'latest_calibration_date':latest_calibration_date,'Color':color, 'Protocol':Protocol, 'Frequency':Frequency, 'Laser tag':laser_tag, 'Voltage':voltage, 'Power':power})
                             elif Protocol=='Constant':
@@ -1281,5 +1283,5 @@ class generate_metadata:
 
 if __name__ == '__main__':
     
-    generate_metadata(json_file=r'I:\BehaviorData\323_EPHYS3\713377\behavior_713377_2024-06-14_15-05-53\behavior\713377_2024-06-14_15-05-53.json')
+    generate_metadata(json_file=r'Y:\711256\behavior_711256_2024-08-15_11-17-57\behavior\711256_2024-08-15_11-17-57.json')
     #generate_metadata(json_file=r'F:\Test\Metadata\715083_2024-04-22_14-32-07.json', dialog_metadata_file=r'C:\Users\xinxin.yin\Documents\ForagingSettings\metadata_dialog\323_EPHYS3_2024-05-09_12-42-30_metadata_dialog.json', output_folder=r'F:\Test\Metadata')

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -1112,12 +1112,12 @@ class generate_metadata:
                                             current_calibration=RecentLaserCalibration[color][Protocol][Frequency]["Left"]['LaserPowerVoltage']
                                         elif laser_tag==2:
                                             current_calibration=RecentLaserCalibration[color][Protocol][Frequency]["Right"]['LaserPowerVoltage']
+                                    if current_calibration==[]:
+                                        continue
                                     for i in range(len(current_calibration)):
                                         laser_voltage_power=eval(str(current_calibration[i]))
                                         voltage.append(laser_voltage_power[0])
                                         power.append(laser_voltage_power[1])
-                                    if voltage==[] or power==[]:
-                                        continue
                                     voltage, power = zip(*sorted(zip(voltage, power), key=lambda x: x[0]))
                                     self.parsed_optocalibration.append({'laser name':laser,'latest_calibration_date':latest_calibration_date,'Color':color, 'Protocol':Protocol, 'Frequency':Frequency, 'Laser tag':laser_tag, 'Voltage':voltage, 'Power':power})
                             elif Protocol=='Constant':
@@ -1130,6 +1130,8 @@ class generate_metadata:
                                         current_calibration=RecentLaserCalibration[color][Protocol]["Left"]['LaserPowerVoltage']
                                     elif laser_tag==2:
                                         current_calibration=RecentLaserCalibration[color][Protocol]["Right"]['LaserPowerVoltage']
+                                if current_calibration==[]:
+                                    continue
                                 for i in range(len(current_calibration)):
                                     laser_voltage_power=eval(str(current_calibration[i]))
                                     voltage.append(laser_voltage_power[0])


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Check empty calibration. When we only calibrate one laser, the calibration data of the other laser with the same color will be empty.  

### What issues or discussions does this update address?
Avoid empty calibration. 

### Describe the expected change in behavior from the perspective of the experimenter
No 

### Describe any manual update steps for task computers
No

### Was this update tested in 446/447?
Tested on my own computer. 





