### PR TITLE
Visualizer orientation/direction fix, incorporating new visualizer function

### DIFF
--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -20,6 +20,7 @@
                  xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
                  xmlns:spk="clr-namespace:Bonsai.Spinnaker;assembly=Bonsai.Spinnaker"
                  xmlns:ffmpeg="clr-namespace:Bonsai.FFmpeg;assembly=Bonsai.FFmpeg"
+                 xmlns:p4="clr-namespace:;assembly=Extensions"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -1529,7 +1530,7 @@
                       <harp:VisualIndicators>On</harp:VisualIndicators>
                       <harp:Heartbeat>Disabled</harp:Heartbeat>
                       <harp:IgnoreErrors>false</harp:IgnoreErrors>
-                      <harp:PortName>COM10</harp:PortName>
+                      <harp:PortName>COM11</harp:PortName>
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="rx:BehaviorSubject">
@@ -1554,7 +1555,7 @@
                   <Expression xsi:type="p1:CreateMessage">
                     <harp:MessageType>Write</harp:MessageType>
                     <harp:Payload xsi:type="p1:CreateAttenuationLeftPayload">
-                      <p1:AttenuationLeft>0</p1:AttenuationLeft>
+                      <p1:AttenuationLeft>300</p1:AttenuationLeft>
                     </harp:Payload>
                   </Expression>
                   <Expression xsi:type="MulticastSubject">
@@ -1579,7 +1580,7 @@
                   <Expression xsi:type="p1:CreateMessage">
                     <harp:MessageType>Write</harp:MessageType>
                     <harp:Payload xsi:type="p1:CreateAttenuationRightPayload">
-                      <p1:AttenuationRight>0</p1:AttenuationRight>
+                      <p1:AttenuationRight>300</p1:AttenuationRight>
                     </harp:Payload>
                   </Expression>
                   <Expression xsi:type="MulticastSubject">
@@ -2834,7 +2835,7 @@
                 <harp:VisualIndicators>On</harp:VisualIndicators>
                 <harp:Heartbeat>Disabled</harp:Heartbeat>
                 <harp:IgnoreErrors>false</harp:IgnoreErrors>
-                <harp:PortName>COM3</harp:PortName>
+                <harp:PortName>COM6</harp:PortName>
               </Combinator>
             </Expression>
             <Expression xsi:type="rx:PublishSubject">
@@ -8574,21 +8575,15 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>CameraImage_Bottom</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="cv:Flip">
-                <cv:Mode>Horizontal</cv:Mode>
-              </Combinator>
+            <Expression xsi:type="VisualizerMapping">
+              <VisualizerType xsi:type="TypeMapping" TypeArguments="p4:IplImageRotateVisualizer" />
             </Expression>
-            <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
               <Name>CameraImage_Right</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="cv:Flip">
-                <cv:Mode>Horizontal</cv:Mode>
-              </Combinator>
+            <Expression xsi:type="VisualizerMapping">
+              <VisualizerType xsi:type="TypeMapping" TypeArguments="p4:IplImageRotateVisualizer" />
             </Expression>
-            <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="viz:TableLayoutPanelBuilder">
               <viz:Name>CameraRecording</viz:Name>
               <viz:ColumnCount>2</viz:ColumnCount>
@@ -8677,12 +8672,10 @@
             <Edge From="46" To="47" Label="Source1" />
             <Edge From="47" To="48" Label="Source2" />
             <Edge From="49" To="50" Label="Source1" />
-            <Edge From="50" To="51" Label="Source1" />
-            <Edge From="51" To="55" Label="Source1" />
-            <Edge From="52" To="53" Label="Source1" />
-            <Edge From="53" To="54" Label="Source1" />
-            <Edge From="54" To="55" Label="Source2" />
-            <Edge From="56" To="57" Label="Source1" />
+            <Edge From="50" To="53" Label="Source1" />
+            <Edge From="51" To="52" Label="Source1" />
+            <Edge From="52" To="53" Label="Source2" />
+            <Edge From="54" To="55" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -8696,7 +8689,7 @@
         <Property Name="FileName" DisplayName="SettingsPath" />
       </Expression>
       <Expression xsi:type="io:CsvReader">
-        <io:FileName>C:\Users\xinxin.yin\Documents\ForagingSettings\Settings_box1.csv</io:FileName>
+        <io:FileName>C:\Users\svc_aind_behavior\Documents\ForagingSettings\Settings_box1.csv</io:FileName>
         <io:ScanPattern>%s,%s</io:ScanPattern>
         <io:SkipRows>0</io:SkipRows>
       </Expression>
@@ -8717,11 +8710,11 @@
         <Workflow>
           <Nodes>
             <Expression xsi:type="SubscribeSubject">
-              <Name>RightLick</Name>
+              <Name>LeftLick</Name>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
-              <Name>LeftLick</Name>
+              <Name>RightLick</Name>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
@@ -8733,7 +8726,7 @@
               </Operand>
             </Expression>
             <Expression xsi:type="Format">
-              <Format>LickVis: {0} -- Top:R / Bottom:L</Format>
+              <Format>LickVis: {0} -- Top:L / Bottom:R</Format>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -8741,7 +8734,7 @@
               </PropertyMappings>
             </Expression>
             <Expression xsi:type="viz:TableLayoutPanelBuilder">
-              <viz:Name>LickVis: 4xx-x-A -- Top:R / Bottom:L</viz:Name>
+              <viz:Name>LickVis: 428-9-A -- Top:L / Bottom:R</viz:Name>
               <viz:ColumnCount>1</viz:ColumnCount>
               <viz:RowCount>2</viz:RowCount>
               <viz:ColumnStyles />
@@ -9213,21 +9206,15 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>CameraImage_Bottom_Preview</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="cv:Flip">
-                <cv:Mode>Horizontal</cv:Mode>
-              </Combinator>
+            <Expression xsi:type="VisualizerMapping">
+              <VisualizerType xsi:type="TypeMapping" TypeArguments="p4:IplImageRotateVisualizer" />
             </Expression>
-            <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
               <Name>CameraImage_Right_Preview</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="cv:Flip">
-                <cv:Mode>Horizontal</cv:Mode>
-              </Combinator>
+            <Expression xsi:type="VisualizerMapping">
+              <VisualizerType xsi:type="TypeMapping" TypeArguments="p4:IplImageRotateVisualizer" />
             </Expression>
-            <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="viz:TableLayoutPanelBuilder">
               <viz:Name>CameraPreview</viz:Name>
               <viz:ColumnCount>2</viz:ColumnCount>
@@ -9257,14 +9244,12 @@
             <Edge From="3" To="4" Label="Source1" />
             <Edge From="4" To="5" Label="Source2" />
             <Edge From="6" To="7" Label="Source1" />
-            <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="12" Label="Source1" />
-            <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="12" Label="Source2" />
+            <Edge From="7" To="10" Label="Source1" />
+            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="9" To="10" Label="Source2" />
+            <Edge From="11" To="12" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
-            <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/workflows/foraging.bonsai.layout
+++ b/src/workflows/foraging.bonsai.layout
@@ -116,8 +116,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1506</Width>
-        <Height>903</Height>
+        <Width>836</Width>
+        <Height>698</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -260,8 +260,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>1506</Width>
-            <Height>903</Height>
+            <Width>836</Width>
+            <Height>698</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -401,18 +401,6 @@
           <DialogSettings>
             <Visible>false</Visible>
             <Location>
-              <X>234</X>
-              <Y>234</Y>
-            </Location>
-            <Size>
-              <Width>416</Width>
-              <Height>279</Height>
-            </Size>
-            <WindowState>Normal</WindowState>
-          </DialogSettings>
-          <DialogSettings>
-            <Visible>false</Visible>
-            <Location>
               <X>0</X>
               <Y>0</Y>
             </Location>
@@ -545,12 +533,24 @@
           <DialogSettings>
             <Visible>false</Visible>
             <Location>
-              <X>235</X>
-              <Y>514</Y>
+              <X>0</X>
+              <Y>0</Y>
             </Location>
             <Size>
-              <Width>416</Width>
-              <Height>279</Height>
+              <Width>0</Width>
+              <Height>0</Height>
+            </Size>
+            <WindowState>Normal</WindowState>
+          </DialogSettings>
+          <DialogSettings>
+            <Visible>false</Visible>
+            <Location>
+              <X>0</X>
+              <Y>0</Y>
+            </Location>
+            <Size>
+              <Width>0</Width>
+              <Height>0</Height>
             </Size>
             <WindowState>Normal</WindowState>
           </DialogSettings>
@@ -742,8 +742,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>1506</Width>
-            <Height>903</Height>
+            <Width>836</Width>
+            <Height>698</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -1274,8 +1274,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1506</Width>
-        <Height>903</Height>
+        <Width>836</Width>
+        <Height>698</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -1298,8 +1298,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>1506</Width>
-            <Height>903</Height>
+            <Width>836</Width>
+            <Height>698</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -3148,8 +3148,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>1506</Width>
-            <Height>903</Height>
+            <Width>836</Width>
+            <Height>698</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -4660,40 +4660,16 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>785</X>
-        <Y>392</Y>
+        <X>721</X>
+        <Y>742</Y>
       </Location>
       <Size>
-        <Width>978</Width>
-        <Height>624</Height>
+        <Width>316</Width>
+        <Height>239</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
     <EditorVisualizerLayout>
-      <DialogSettings>
-        <Visible>false</Visible>
-        <Location>
-          <X>0</X>
-          <Y>0</Y>
-        </Location>
-        <Size>
-          <Width>0</Width>
-          <Height>0</Height>
-        </Size>
-        <WindowState>Normal</WindowState>
-      </DialogSettings>
-      <DialogSettings>
-        <Visible>false</Visible>
-        <Location>
-          <X>0</X>
-          <Y>0</Y>
-        </Location>
-        <Size>
-          <Width>0</Width>
-          <Height>0</Height>
-        </Size>
-        <WindowState>Normal</WindowState>
-      </DialogSettings>
       <DialogSettings>
         <Visible>false</Visible>
         <Location>
@@ -5334,28 +5310,36 @@
         <Visible>true</Visible>
         <Location>
           <X>90</X>
-          <Y>421</Y>
+          <Y>329</Y>
         </Location>
         <Size>
-          <Width>336</Width>
-          <Height>279</Height>
+          <Width>417</Width>
+          <Height>220</Height>
         </Size>
         <WindowState>Normal</WindowState>
         <VisualizerTypeName>Bonsai.Design.Visualizers.TableLayoutPanelVisualizer</VisualizerTypeName>
         <VisualizerSettings>
           <TableLayoutPanelVisualizer>
             <MashupSettings>
-              <Source>50</Source>
-              <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
+              <Source>49</Source>
+              <VisualizerTypeName>IplImageRotateVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <IplImageVisualizer />
+                <IplImageRotateVisualizer>
+                  <InvertHorizontal>true</InvertHorizontal>
+                  <InvertVertical>false</InvertVertical>
+                  <RotateAngle>0</RotateAngle>
+                </IplImageRotateVisualizer>
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <Source>53</Source>
-              <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
+              <Source>51</Source>
+              <VisualizerTypeName>IplImageRotateVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <IplImageVisualizer />
+                <IplImageRotateVisualizer>
+                  <InvertHorizontal>false</InvertHorizontal>
+                  <InvertVertical>false</InvertVertical>
+                  <RotateAngle>0</RotateAngle>
+                </IplImageRotateVisualizer>
               </VisualizerSettings>
             </MashupSettings>
           </TableLayoutPanelVisualizer>
@@ -5474,12 +5458,12 @@
   <DialogSettings xsi:type="WorkflowEditorSettings">
     <Visible>false</Visible>
     <Location>
-      <X>0</X>
-      <Y>0</Y>
+      <X>78</X>
+      <Y>78</Y>
     </Location>
     <Size>
-      <Width>0</Width>
-      <Height>0</Height>
+      <Width>336</Width>
+      <Height>65</Height>
     </Size>
     <WindowState>Normal</WindowState>
     <EditorDialogSettings>
@@ -5489,8 +5473,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1506</Width>
-        <Height>903</Height>
+        <Width>836</Width>
+        <Height>698</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -5595,7 +5579,7 @@
         <Visible>true</Visible>
         <Location>
           <X>91</X>
-          <Y>707</Y>
+          <Y>554</Y>
         </Location>
         <Size>
           <Width>336</Width>
@@ -5610,7 +5594,7 @@
               <VisualizerTypeName>Bonsai.Design.Visualizers.BooleanTimeSeriesVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <BooleanTimeSeriesVisualizer>
-                  <Capacity>640</Capacity>
+                  <Capacity>60</Capacity>
                 </BooleanTimeSeriesVisualizer>
               </VisualizerSettings>
             </MashupSettings>
@@ -5619,7 +5603,7 @@
               <VisualizerTypeName>Bonsai.Design.Visualizers.BooleanTimeSeriesVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <BooleanTimeSeriesVisualizer>
-                  <Capacity>640</Capacity>
+                  <Capacity>60</Capacity>
                 </BooleanTimeSeriesVisualizer>
               </VisualizerSettings>
             </MashupSettings>
@@ -5631,12 +5615,12 @@
   <DialogSettings xsi:type="WorkflowEditorSettings">
     <Visible>false</Visible>
     <Location>
-      <X>0</X>
-      <Y>0</Y>
+      <X>208</X>
+      <Y>208</Y>
     </Location>
     <Size>
-      <Width>0</Width>
-      <Height>0</Height>
+      <Width>416</Width>
+      <Height>279</Height>
     </Size>
     <WindowState>Normal</WindowState>
     <EditorDialogSettings>
@@ -5646,8 +5630,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1506</Width>
-        <Height>903</Height>
+        <Width>836</Width>
+        <Height>698</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -5670,8 +5654,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>1506</Width>
-            <Height>903</Height>
+            <Width>836</Width>
+            <Height>698</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -5847,55 +5831,39 @@
         <WindowState>Normal</WindowState>
       </DialogSettings>
       <DialogSettings>
-        <Visible>false</Visible>
-        <Location>
-          <X>0</X>
-          <Y>0</Y>
-        </Location>
-        <Size>
-          <Width>0</Width>
-          <Height>0</Height>
-        </Size>
-        <WindowState>Normal</WindowState>
-      </DialogSettings>
-      <DialogSettings>
-        <Visible>false</Visible>
-        <Location>
-          <X>0</X>
-          <Y>0</Y>
-        </Location>
-        <Size>
-          <Width>0</Width>
-          <Height>0</Height>
-        </Size>
-        <WindowState>Normal</WindowState>
-      </DialogSettings>
-      <DialogSettings>
         <Visible>true</Visible>
         <Location>
           <X>89</X>
           <Y>102</Y>
         </Location>
         <Size>
-          <Width>336</Width>
-          <Height>314</Height>
+          <Width>415</Width>
+          <Height>226</Height>
         </Size>
         <WindowState>Normal</WindowState>
         <VisualizerTypeName>Bonsai.Design.Visualizers.TableLayoutPanelVisualizer</VisualizerTypeName>
         <VisualizerSettings>
           <TableLayoutPanelVisualizer>
             <MashupSettings>
-              <Source>7</Source>
-              <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
+              <Source>6</Source>
+              <VisualizerTypeName>IplImageRotateVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <IplImageVisualizer />
+                <IplImageRotateVisualizer>
+                  <InvertHorizontal>true</InvertHorizontal>
+                  <InvertVertical>false</InvertVertical>
+                  <RotateAngle>0</RotateAngle>
+                </IplImageRotateVisualizer>
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <Source>10</Source>
-              <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
+              <Source>8</Source>
+              <VisualizerTypeName>IplImageRotateVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <IplImageVisualizer />
+                <IplImageRotateVisualizer>
+                  <InvertHorizontal>false</InvertHorizontal>
+                  <InvertVertical>false</InvertVertical>
+                  <RotateAngle>0</RotateAngle>
+                </IplImageRotateVisualizer>
               </VisualizerSettings>
             </MashupSettings>
           </TableLayoutPanelVisualizer>


### PR DESCRIPTION
### Describe changes:
As requested by RAs (see https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/668), I made change in the orientation/direction of the visualization as shown below.

<img width="290" alt="Screenshot 2024-08-30 at 12 46 46 PM" src="https://github.com/user-attachments/assets/fbe42a76-1c6b-4cf1-b2d0-ae1afad359bc">


In addition, those `preview` and `recording` windows are now using a new feature `IplImageRotateVisualizer` recently developed by @bruno-f-cruz 
See corresponding PR: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/673#event-14086168712

By using this, we don't have to use the `Flip` node which is CPU-expensive.

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/668

### Describe the expected change in behavior from the perspective of the experimenter
Visualizer direction will be changed (fixed)

### Describe any manual update steps for task computers
In ephys rigs, where positions of the cameras are different, you might want to use toggle button function to flip visualization online. Right click -> change the toggle button as shown below. Note, DO NOT `save` bonsai workflow after changing the button as it will be save in the .layout file. The layout file is designed for 446/447 training usage.

<img width="248" alt="Screenshot 2024-08-30 at 12 47 06 PM" src="https://github.com/user-attachments/assets/5cc59900-d640-4364-9109-276ab63d9489">


### Was this update tested in 446/447?
Tested in 428.