### PR TITLE
Feat 517 upload manifest fix

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2607,6 +2607,7 @@ class Window(QMainWindow):
             current_time = datetime.now()
             formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
             self._get_folder_structure_new(formatted_datetime)
+            self.acquisition_datetime = formatted_datetime
             self.session_name=f'behavior_{self.ID.text()}_{formatted_datetime}'
         elif self.load_tag==1:
             self._parse_folder_structure()
@@ -3863,13 +3864,12 @@ class Window(QMainWindow):
             GeneratedTrials._GenerateATrial(self.Channel4)
             # delete licks from the previous session
             GeneratedTrials._DeletePreviousLicks(self.Channel2)
-        else:
-            GeneratedTrials=self.GeneratedTrials
-
             if self.Settings['AutomaticUpload']:
                 self._generate_upload_manifest()  # Generate the upload manifest file
             else:
                 logging.info('Skipping Automatic Upload based on ForagingSettings.json')
+        else:
+            GeneratedTrials=self.GeneratedTrials
 
         if self.ToInitializeVisual==1: # only run once
             self.PlotM=PlotM

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2607,7 +2607,6 @@ class Window(QMainWindow):
             current_time = datetime.now()
             formatted_datetime = current_time.strftime("%Y-%m-%d_%H-%M-%S")
             self._get_folder_structure_new(formatted_datetime)
-            self.acquisition_datetime = formatted_datetime 
             self.session_name=f'behavior_{self.ID.text()}_{formatted_datetime}'
         elif self.load_tag==1:
             self._parse_folder_structure()
@@ -3728,11 +3727,6 @@ class Window(QMainWindow):
             # disable metadata fields
             self._set_metadata_enabled(False)
 
-            if self.Settings['AutomaticUpload']:
-                self._generate_upload_manifest()  # Generate the upload manifest file
-            else:
-                logging.info('Skipping Automatic Upload based on ForagingSettings.json')
-
             # Set IACUC protocol in metadata based on schedule
             protocol = self._GetInfoFromSchedule(mouse_id, 'Protocol')
             if protocol is not None:
@@ -3871,6 +3865,11 @@ class Window(QMainWindow):
             GeneratedTrials._DeletePreviousLicks(self.Channel2)
         else:
             GeneratedTrials=self.GeneratedTrials
+
+            if self.Settings['AutomaticUpload']:
+                self._generate_upload_manifest()  # Generate the upload manifest file
+            else:
+                logging.info('Skipping Automatic Upload based on ForagingSettings.json')
 
         if self.ToInitializeVisual==1: # only run once
             self.PlotM=PlotM


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- generate upload manifest is called after acquisition_datetime has been populated
### What issues or discussions does this update address?
[#517](https://github.com/AllenNeuralDynamics/aind-behavior-blog)
### Describe the expected change in behavior from the perspective of the experimenter

### Describe any manual update steps for task computers

### Was this update tested in 446/447?
- [x] 446




