### PR TITLE
Feat 620 changeable autostop

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2878,7 +2878,7 @@ class AutoTrainDialog(QDialog):
             for widget in self.widgets_locked_by_auto_train:
                 # Exclude some fields so that RAs can change them without going off-curriculum
                 # See https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/620
-                if widget.objectName in ["StopIgnores", "MaxTrial", "MaxTime"]:
+                if widget.objectName() in ["StopIgnores", "MaxTrial", "MaxTime"]:
                     continue
                 widget.setEnabled(False)
                 # set the border color to green

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2876,9 +2876,14 @@ class AutoTrainDialog(QDialog):
 
             # lock the widgets that have been set by auto training 
             for widget in self.widgets_locked_by_auto_train:
+                # Exclude some fields so that RAs can change them without going off-curriculum
+                # See https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/620
+                if widget.objectName in ["StopIgnores", "MaxTrial", "MaxTime"]:
+                    continue
                 widget.setEnabled(False)
                 # set the border color to green
                 widget.setStyleSheet("border: 2px solid  rgb(0, 214, 103);")
+                
             self.MainWindow.TrainingParameters.setStyleSheet(
                 '''QGroupBox {
                         border: 5px solid  rgb(0, 214, 103)


### PR DESCRIPTION
### Describe changes:
- Unlocked the "StopIgnore", "MaxTrial", and "MaxTime" in AutoTrain. Now users are free to change them and still stay "on-curriculum".

![image](https://github.com/user-attachments/assets/6c26c088-847d-4f6b-8b2d-16e974389eb6)

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/620

### Describe the expected change in behavior from the perspective of the experimenter
- "StopIgnore", "MaxTrial", and "MaxTime" are free to change even with AutoTrain engaged.

### Describe any manual update steps for task computers
N/A

### Was this update tested in 446/447?
- [x] Tested on my PC




