### PR TITLE
Ensures project name is always set even if its not in the schedule

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3784,6 +3784,8 @@ class Window(QMainWindow):
                     logging.info('Setting Project name: {}'.format(project_name))
                     add_default = False
             if add_default:
+                project_name = 'Behavior Platform'
+                logging.info('Setting Project name: {}'.format('Behavior Platform'))
                 projects = [self.Metadata_dialog.ProjectName.itemText(i)
                             for i in range(self.Metadata_dialog.ProjectName.count())]
                 index = np.where(np.array(projects) == 'Behavior Platform')[0]
@@ -3791,7 +3793,6 @@ class Window(QMainWindow):
                     index = index[0]
                     self.Metadata_dialog.ProjectName.setCurrentIndex(index)
                     self.Metadata_dialog._show_project_info()
-                    logging.info('Setting Project name: {}'.format('Behavior Platform'))
                 else:
                     project_info = {
                         'Funding Institution': ['Allen Institute'],
@@ -3800,9 +3801,7 @@ class Window(QMainWindow):
                         'Fundee': ['nan'],
                     }
                     self.Metadata_dialog.project_info = project_info
-                    project_name = 'Behavior Platform'
                     self.Metadata_dialog.ProjectName.addItems([project_name])
-                    logging.info('Setting Project name: {}'.format(project_name))
             self.project_name = project_name
 
             self.session_run = True   # session has been started


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Fixes a small bug where `project_name` is not set in the manifest if its not on the schedule. The default `Behavior Platform` was correctly set in the metadata, but not the upload manifest. 

### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter
none

### Describe any manual update steps for task computers
none

### Was this update tested in 446/447?
- [ ] tested in 447




