### PR TITLE
Feat 555 flush line open

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -333,8 +333,8 @@ class WaterCalibrationDialog(QDialog):
                 child.setAutoDefault(False)
 
         # setup flags to keep lines open
-        self.left_valve_open_timer = QTimer(timeout=lambda: self.open_valve('left'), interval=10000)
-        self.right_valve_open_timer = QTimer(timeout=lambda: self.open_valve('right'), interval=10000)
+        self.left_valve_open_timer = QTimer(timeout=lambda: self.reopen_valve('left'), interval=10000)
+        self.right_valve_open_timer = QTimer(timeout=lambda: self.reopen_valve('right'), interval=10000)
 
 
     def _connectSignalsSlots(self):
@@ -885,7 +885,8 @@ class WaterCalibrationDialog(QDialog):
         if self.OpenLeftForever.isChecked():
             # change button color
             self.OpenLeftForever.setStyleSheet("background-color : green;")
-            self.open_valve('left') # initially open valve
+            self.MainWindow.Channel.LeftValue(float(1000) * 1000)  # set the valve open time
+            self.MainWindow.Channel3.ManualWater_Left(int(1))  # set valve initially open
             self.left_valve_open_timer.start()
         else:
             # change button color
@@ -907,7 +908,8 @@ class WaterCalibrationDialog(QDialog):
         if self.OpenRightForever.isChecked():
             # change button color
             self.OpenRightForever.setStyleSheet("background-color : green;")
-            self.open_valve('right')    # initially open valve
+            self.MainWindow.Channel.RightValue(float(1000) * 1000)  # set the valve open time
+            self.MainWindow.Channel3.ManualWater_Right(int(1))  # set valve initially open
             self.right_valve_open_timer.start()
 
         else:
@@ -923,19 +925,15 @@ class WaterCalibrationDialog(QDialog):
             time.sleep(0.01) 
             self.MainWindow.Channel.RightValue(float(self.MainWindow.RightValue.text())*1000)
 
-    def open_valve(self, valve: Literal['left', 'right']):
-        """function to call the right or left water line open
+    def reopen_valve(self, valve: Literal['left', 'right']):
+        """function to reopen the right or left water line open. Valve must be open prior to calling this function.
+        Calling ManualWater_ will toggle state of valve so need to call twice on already open valve.
         :param valve: string specifying right or left valve"""
 
-        if valve == 'right':    # open right
-            self.MainWindow.Channel.RightValue(float(1000) * 1000)  # set the valve open time
-            time.sleep(0.01)
-            self.MainWindow.Channel3.ManualWater_Right(int(1))  # open the valve
-        else:   # open left
-            self.MainWindow.Channel.LeftValue(float(1000) * 1000)   # set the valve open time
-            time.sleep(0.01)
-            self.MainWindow.Channel3.ManualWater_Left(int(1))   # open the valve
 
+        # get correct function based on input valve name
+        getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # close valve
+        getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # open valve
 
     def _TimeRemaining(self,i, cycles, opentime, interval):
         total_seconds = (cycles-i)*(opentime+interval)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -334,7 +334,6 @@ class WaterCalibrationDialog(QDialog):
 
         # setup flags to keep lines open
         self.left_valve_open_timer = QTimer(timeout=lambda: self.open_valve('left'), interval=10000)
-        print(self.left_valve_open_timer.interval())
         self.right_valve_open_timer = QTimer(timeout=lambda: self.open_valve('right'), interval=10000)
 
 
@@ -927,7 +926,7 @@ class WaterCalibrationDialog(QDialog):
     def open_valve(self, valve: Literal['left', 'right']):
         """function to call the right or left water line open
         :param valve: string specifying right or left valve"""
-        print('opening', valve)
+
         if valve == 'right':    # open right
             self.MainWindow.Channel.RightValue(float(1000) * 1000)  # set the valve open time
             time.sleep(0.01)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -928,7 +928,7 @@ class WaterCalibrationDialog(QDialog):
     def reopen_valve(self, valve: Literal['left', 'right']):
         """function to reopen the right or left water line open. Valve must be open prior to calling this function.
         Calling ManualWater_ will toggle state of valve so need to call twice on already open valve.
-        :param valve: string specifying right or left valve"""
+        param valve: string specifying right or left valve"""
 
         # get correct function based on input valve name
         getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # close valve

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -930,7 +930,6 @@ class WaterCalibrationDialog(QDialog):
         Calling ManualWater_ will toggle state of valve so need to call twice on already open valve.
         :param valve: string specifying right or left valve"""
 
-
         # get correct function based on input valve name
         getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # close valve
         getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # open valve

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -333,8 +333,8 @@ class WaterCalibrationDialog(QDialog):
                 child.setAutoDefault(False)
 
         # setup flags to keep lines open
-        self.left_valve_open_timer = QTimer(timeout=lambda: self.reopen_valve('left'), interval=10000)
-        self.right_valve_open_timer = QTimer(timeout=lambda: self.reopen_valve('right'), interval=10000)
+        self.left_valve_open_timer = QTimer(timeout=lambda: self.reopen_valve('Left'), interval=10000)
+        self.right_valve_open_timer = QTimer(timeout=lambda: self.reopen_valve('Right'), interval=10000)
 
 
     def _connectSignalsSlots(self):
@@ -925,14 +925,14 @@ class WaterCalibrationDialog(QDialog):
             time.sleep(0.01) 
             self.MainWindow.Channel.RightValue(float(self.MainWindow.RightValue.text())*1000)
 
-    def reopen_valve(self, valve: Literal['left', 'right']):
-        """function to reopen the right or left water line open. Valve must be open prior to calling this function.
+    def reopen_valve(self, valve: Literal['Left', 'Right']):
+        """Function to reopen the right or left water line open. Valve must be open prior to calling this function.
         Calling ManualWater_ will toggle state of valve so need to call twice on already open valve.
         param valve: string specifying right or left valve"""
 
         # get correct function based on input valve name
-        getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # close valve
-        getattr(self.MainWindow.Channel3, f'ManualWater_{valve.capitalize()}')(int(1))  # open valve
+        getattr(self.MainWindow.Channel3, f'ManualWater_{valve}')(int(1))  # close valve
+        getattr(self.MainWindow.Channel3, f'ManualWater_{valve}')(int(1))  # open valve
 
     def _TimeRemaining(self,i, cycles, opentime, interval):
         total_seconds = (cycles-i)*(opentime+interval)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- waterline should stay open continuously if user presses button  
### What issues or discussions does this update address?
- #555 
### Describe the expected change in behavior from the perspective of the experimenter
- Waterlines will continually stay open 
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446




