### PR TITLE
 5ml water flushing

### DIFF
--- a/src/foraging_gui/Calibration.ui
+++ b/src/foraging_gui/Calibration.ui
@@ -126,9 +126,9 @@
         <property name="geometry">
             <rect>
                 <x>10</x>
-                <y>10</y>
+                <y>0</y>
                 <width>330</width>
-                <height>60</height>
+                <height>80</height>
             </rect>
         </property>
         <property name="title">
@@ -138,7 +138,7 @@
             <property name="geometry">
                 <rect>
                     <x>40</x>
-                    <y>20</y>
+                    <y>15</y>
                     <width>100</width>
                     <height>25</height>
                 </rect>
@@ -154,13 +154,45 @@
             <property name="geometry">
                 <rect>
                     <x>180</x>
-                    <y>20</y>
+                    <y>15</y>
                     <width>100</width>
                     <height>25</height>
                 </rect>
             </property>
             <property name="text">
                 <string>Keep right open</string>
+            </property>
+            <property name="checkable">
+                <bool>true</bool>
+            </property>
+        </widget>
+        <widget class="QPushButton" name="OpenLeft5ml">
+            <property name="geometry">
+                <rect>
+                    <x>40</x>
+                    <y>50</y>
+                    <width>100</width>
+                    <height>25</height>
+                </rect>
+            </property>
+            <property name="text">
+                <string>Open left 5ml</string>
+            </property>
+            <property name="checkable">
+                <bool>true</bool>
+            </property>
+        </widget>
+        <widget class="QPushButton" name="OpenRight5ml">
+            <property name="geometry">
+                <rect>
+                    <x>180</x>
+                    <y>50</y>
+                    <width>100</width>
+                    <height>25</height>
+                </rect>
+            </property>
+            <property name="text">
+                <string>Open right 5ml</string>
             </property>
             <property name="checkable">
                 <bool>true</bool>

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -931,7 +931,6 @@ class WaterCalibrationDialog(QDialog):
 
             open_timer.start()
 
-
         else:   # close open valve
             # change button color
             button.setStyleSheet("background-color : none")

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -348,11 +348,6 @@ class WaterCalibrationDialog(QDialog):
                      self.OpenRight5ml.setText(f'Open right 5ml: {round(self.right_close_timer.remainingTime()/1000)}s'),
                      interval=1000)
 
-        # Disable 5ml buttons if no water calibration curve
-        if not hasattr(self.MainWindow, 'latest_fitting'):
-            self.OpenLeft5ml.setEnabled(False)
-            self.OpenRight5ml.setEnabled(False)
-
     def _connectSignalsSlots(self):
         self.SpotCheckLeft.clicked.connect(self._SpotCheckLeft)
         self.SpotCheckRight.clicked.connect(self._SpotCheckRight)
@@ -911,7 +906,7 @@ class WaterCalibrationDialog(QDialog):
         :param button: button that was pressed
         :param valve: which valve to open. Restricted to Right or Left
         """
-       
+
         self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return
@@ -928,7 +923,7 @@ class WaterCalibrationDialog(QDialog):
             toggle_valve_state(int(1))  # set valve initially open
 
             if button.text() == f'Open {valve.lower()} 5ml':    # set up additional logic to only open for 5ml
-                five_ml_time_ms = round(self._VolumeToTime(5, valve) * 1000)  # calculate time for valve to stay open
+                five_ml_time_ms = round(self._VolumeToTime(5000, valve) * 1000)  # calculate time for valve to stay open
                 close_timer.setInterval(five_ml_time_ms)  # set interval of valve close time to be five_ml_time_ms
                 close_timer.setSingleShot(True)  # only trigger once when 5ml has been expelled
                 text_timer.start()  # start timer to update text
@@ -976,7 +971,6 @@ class WaterCalibrationDialog(QDialog):
         """
         # x = (y-b)/m
         if hasattr(self.MainWindow, 'latest_fitting') and self.MainWindow.latest_fitting != {}:
-            print(self.MainWindow.latest_fitting)
             fit = self.MainWindow.latest_fitting[valve]
             m = fit[0]
             b = fit[1] 

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -349,9 +349,9 @@ class WaterCalibrationDialog(QDialog):
                      interval=1000)
 
         # Disable 5ml buttons if no water calibration curve
-        # if not hasattr(self.MainWindow, 'latest_fitting'):
-        #     self.OpenLeft5ml.setEnabled(False)
-        #     self.OpenRight5ml.setEnabled(False)
+        if not hasattr(self.MainWindow, 'latest_fitting'):
+            self.OpenLeft5ml.setEnabled(False)
+            self.OpenRight5ml.setEnabled(False)
 
     def _connectSignalsSlots(self):
         self.SpotCheckLeft.clicked.connect(self._SpotCheckLeft)
@@ -911,7 +911,7 @@ class WaterCalibrationDialog(QDialog):
         :param button: button that was pressed
         :param valve: which valve to open. Restricted to Right or Left
         """
-        print('in toggle valve', button, valve)
+       
         self.MainWindow._ConnectBonsai()
         if self.MainWindow.InitializeBonsaiSuccessfully==0:
             return


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- added buttons to be able to flush 5ml of water based on water calibration curve
### What issues or discussions does this update address?
[#494](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/494)
### Describe the expected change in behavior from the perspective of the experimenter
- User does not have to moniter gui while flushing 5ml of water
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 447



