### PR TITLE
removing reference of waterlog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "deepdiff",
     "aind-data-schema==0.36.0",
     "aind-data-schema-models==0.1.10",
-    "pydantic==2.8.2",
+    #"pydantic==2.8.2",
     "pyyaml"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ openpyxl
 deepdiff
 aind-data-schema==0.36.0
 aind-data-schema-models==0.1.10
-pydantic==2.8.2
 pyyaml

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -15,8 +15,8 @@ import copy
 import shutil
 from pathlib import Path
 from datetime import date, datetime, timezone
-from aind_slims_api import SlimsClient
-from aind_slims_api import models
+# from aind_slims_api import SlimsClient    # comment out untill schema has been updated
+# from aind_slims_api import models
 import serial 
 import numpy as np
 import pandas as pd
@@ -112,7 +112,7 @@ class Window(QMainWindow):
         self._InitializeBonsai()
 
         # connect to Slims
-        self._ConnectSlims()
+        #self._ConnectSlims()
 
         # Set up threads 
         self.threadpool=QThreadPool() # get animal response
@@ -2689,7 +2689,8 @@ class Window(QMainWindow):
 
             if save_clicked:    # create water log result if weight after filled and uncheck save
                 if self.BaseWeight.text() != '' and self.WeightAfter.text() != '' and self.ID.text() not in ['0','1','2','3','4','5','6','7','8','9','10']:
-                    self._AddWaterLogResult(generated_metadata._session())
+                    pass
+                    #self._AddWaterLogResult(generated_metadata._session())
 
 
         except Exception as e:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- revert waterlog changes since conflicting versions of pydantic are used for aind-slims-api and aind-data-schema
### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter

### Describe any manual update steps for task computers

### Was this update tested in 446/447?





