### PR TITLE
Auto lickport movement when bias is over

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4323,7 +4323,7 @@ class Window(QMainWindow):
             direction = -1 if bias < 0 else 1  # TODO: Check if this is true
             if self.Settings['newscale_serial_num_box{}'.format(self.box_number)] != '':    # newscale stage
                 self._Move('y', self.bias_step_size_mm*direction)
-            else:   # aind-scale
+            elif hasattr(self, 'stage_widget'):   # aind-scale. Not implemented so skip
                 self.stage_widget.stage_model.move_relative([1,2], self.bias_step_size_mm, direction)
 
             # reset stage_moved variable

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -130,7 +130,7 @@ class Window(QMainWindow):
 
         # create bias indicator and initialize parameters
         self.bias_n_size = 500
-        self.bias_step_size_mm = 10    # TODO: What value to set this at initially? Where to store?
+        self.bias_step_size_mm = .2    # TODO: What value to set this at initially? Where to store?
         self.wait_trial_count = 50      # TODO: What value to set this at initially? Where to store?
         self.stage_moved_trial = 0      # initialize variable to 0
         self.bias_indicator = BiasIndicator(x_range=self.bias_n_size)  # TODO: Where to store bias_threshold parameter? self.Settings?
@@ -4322,7 +4322,7 @@ class Window(QMainWindow):
         if trial_number-self.stage_moved_trial > self.wait_trial_count:   # check that minimum trials happened  # TODO: Should this be timed based or trial based? As of now, trial based
             direction = -1 if bias < 0 else 1  # TODO: Check if this is true
             if self.Settings['newscale_serial_num_box{}'.format(self.box_number)] != '':    # newscale stage
-                self._Move('y', self.bias_step_size_mm*direction)
+                self._Move('y', self.bias_step_size_mm*direction*1000)  # TODO: Check if _Move is expecting mm or um
             elif hasattr(self, 'stage_widget'):   # aind-scale. Not implemented so skip
                 self.stage_widget.stage_model.move_relative([1,2], self.bias_step_size_mm, direction)
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- if the bias indicator calculates a bias with a magnitude that exceeds the set threshold, the stage will move a step size in the biased direction
### What issues or discussions does this update address?
- part of #238 
### Describe the expected change in behavior from the perspective of the experimenter
- Manual movement of stage to account for bias will be reduced
### Describe any manual update steps for task computers
- NA
### Was this update tested in 446/447?
- [ ] 447 
- Testing is contingent on #769 being implemented




