### PR TITLE
change modality in upload_manifest if fib is being run or not

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4605,7 +4605,7 @@ class Window(QMainWindow):
                          '&session_plot_selected_draw_types=1.+Choice+history'
         )
 
-    def _generate_upload_manifest(self,FIP=False):
+    def _generate_upload_manifest(self,FIP=False):  # FIXME: How does this ever get set to True?
         '''
             Generates a manifest.yml file for triggering data copy to VAST and upload to aws
         '''
@@ -4616,6 +4616,7 @@ class Window(QMainWindow):
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
 
+            # FIXME: How is this if statement working if it does the exact same thing for each condition?
             if FIP: ## DEBUG, need to figure out how to set this flag.
                 schedule = self.acquisition_datetime.split('_')[0]+'_20-30-00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c1'
@@ -4624,6 +4625,18 @@ class Window(QMainWindow):
                 schedule = self.acquisition_datetime.split('_')[0]+'_20-30-00'
                 capsule_id = 'c089614a-347e-4696-b17e-86980bb782c1'
                 mount = 'FIP'
+
+            # only include fib and behavior videos if fib is being run
+            if self.PhotometryB.currentText()=='on':
+                modalities = {
+                    'behavior':[self.TrainingFolder.replace('\\','/')],
+                    'behavior-videos':[self.VideoFolder.replace('\\','/')],
+                    'fib':[self.PhotometryFolder.replace('\\','/')]
+                    }
+            else:
+                modalities = {
+                    'behavior': [self.TrainingFolder.replace('\\', '/')]
+                }
 
             date_format = "%Y-%m-%d_%H-%M-%S"
             # Define contents of manifest file
@@ -4637,11 +4650,7 @@ class Window(QMainWindow):
                 'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
                 's3_bucket':'private',
                 'processor_full_name': 'AIND Behavior Team',
-                'modalities':{
-                    'behavior':[self.TrainingFolder.replace('\\','/')],
-                    'behavior-videos':[self.VideoFolder.replace('\\','/')],
-                    'fib':[self.PhotometryFolder.replace('\\','/')]
-                    },
+                'modalities':modalities,
                 'schemas':[
                     os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
                     os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4605,7 +4605,7 @@ class Window(QMainWindow):
                          '&session_plot_selected_draw_types=1.+Choice+history'
         )
 
-    def _generate_upload_manifest(self,FIP=False):  # FIXME: How does this ever get set to True?
+    def _generate_upload_manifest(self):
         '''
             Generates a manifest.yml file for triggering data copy to VAST and upload to aws
         '''
@@ -4616,28 +4616,10 @@ class Window(QMainWindow):
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
 
-            # FIXME: How is this if statement working if it does the exact same thing for each condition?
-            if FIP: ## DEBUG, need to figure out how to set this flag.
-                schedule = self.acquisition_datetime.split('_')[0]+'_20-30-00'
-                capsule_id = 'c089614a-347e-4696-b17e-86980bb782c1'
-                mount = 'FIP'
-            else:
-                schedule = self.acquisition_datetime.split('_')[0]+'_20-30-00'
-                capsule_id = 'c089614a-347e-4696-b17e-86980bb782c1'
-                mount = 'FIP'
-
-            # only include fib and behavior videos if fib is being run
-            if self.PhotometryB.currentText()=='on':
-                modalities = {
-                    'behavior':[self.TrainingFolder.replace('\\','/')],
-                    'behavior-videos':[self.VideoFolder.replace('\\','/')],
-                    'fib':[self.PhotometryFolder.replace('\\','/')]
-                    }
-            else:
-                modalities = {
-                    'behavior': [self.TrainingFolder.replace('\\', '/')]
-                }
-
+            schedule = self.acquisition_datetime.split('_')[0]+'_20-30-00'
+            capsule_id = 'c089614a-347e-4696-b17e-86980bb782c1'
+            mount = 'FIP'
+            
             date_format = "%Y-%m-%d_%H-%M-%S"
             # Define contents of manifest file
             contents = {
@@ -4650,10 +4632,15 @@ class Window(QMainWindow):
                 'destination': '//allen/aind/scratch/dynamic_foraging_rig_transfer',
                 's3_bucket':'private',
                 'processor_full_name': 'AIND Behavior Team',
-                'modalities':modalities,
+                'modalities':{
+                    'behavior':[self.TrainingFolder.replace('\\','/')],
+                    'behavior-videos':[self.VideoFolder.replace('\\','/')],
+                    'fib':[self.PhotometryFolder.replace('\\','/')]
+                    },
                 'schemas':[
                     os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
-                    os.path.join(self.MetadataFolder,'rig.json').replace('\\','/')
+                    os.path.join(self.MetadataFolder,'rig.json').replace('\\','/'),
+                    os.path.join(self.MetadataFolder, 'data_description.json').replace('\\', '/')
                     ],
                 'schedule_time':datetime.strptime(schedule,date_format),
                 'project_name':self.project_name,


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Update the upload manifests to only list "fib" and "behavior-videos" if they are actually recorded in the session
### What issues or discussions does this update address?
- resolves #793 
### Describe the expected change in behavior from the perspective of the experimenter
- none
### Describe any manual update steps for task computers
- none
### Was this update tested in 446/447?
- [x] 446/7



