### PR TITLE
Feat 682 end fib on timeout

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3995,6 +3995,17 @@ class Window(QMainWindow):
             b_bias_len = len(self.GeneratedTrials.B_Bias)
             self.GeneratedTrials.B_Bias += [last_bias]*((self.GeneratedTrials.B_CurrentTrialN+1)-b_bias_len)
 
+            # stop FIB if Teensy_COM is attribute and if found in com port list
+            if hasattr(self, 'Teensy_COM') and \
+                    self.Teensy_COM in [port.name for port in serial.tools.list_ports.comports()]:
+                ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
+                # Trigger Teensy with the above specified exp mode
+                ser.write(b's')
+                ser.close()
+                self.TeensyWarning.setText('Stopped FIP excitation')
+                self.TeensyWarning.setStyleSheet(self.default_warning_color)
+                self.fiber_photometry_end_time = str(datetime.now())
+
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish
             self._StopCurrentSession()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3995,16 +3995,9 @@ class Window(QMainWindow):
             b_bias_len = len(self.GeneratedTrials.B_Bias)
             self.GeneratedTrials.B_Bias += [last_bias]*((self.GeneratedTrials.B_CurrentTrialN+1)-b_bias_len)
 
-            # stop FIB if Teensy_COM is attribute and if found in com port list
-            if hasattr(self, 'Teensy_COM') and \
-                    self.Teensy_COM in [port.name for port in serial.tools.list_ports.comports()]:
-                ser = serial.Serial(self.Teensy_COM, 9600, timeout=1)
-                # Trigger Teensy with the above specified exp mode
-                ser.write(b's')
-                ser.close()
-                self.TeensyWarning.setText('Stopped FIP excitation')
-                self.TeensyWarning.setStyleSheet(self.default_warning_color)
-                self.fiber_photometry_end_time = str(datetime.now())
+            # stop FIB if running
+            if self.Teensy_COM != '' and  self.StartExcitation.isChecked():
+               self._StartExcitation()
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3996,8 +3996,9 @@ class Window(QMainWindow):
             self.GeneratedTrials.B_Bias += [last_bias]*((self.GeneratedTrials.B_CurrentTrialN+1)-b_bias_len)
 
             # stop FIB if running
-            if self.Teensy_COM != '' and  self.StartExcitation.isChecked():
-               self._StartExcitation()
+            if self.StartExcitation.isChecked():
+                self.StartExcitation.setChecked(False)
+                self._StartExcitation()
 
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3995,11 +3995,6 @@ class Window(QMainWindow):
             b_bias_len = len(self.GeneratedTrials.B_Bias)
             self.GeneratedTrials.B_Bias += [last_bias]*((self.GeneratedTrials.B_CurrentTrialN+1)-b_bias_len)
 
-            # stop FIB if running
-            if self.StartExcitation.isChecked():
-                self.StartExcitation.setChecked(False)
-                self._StartExcitation()
-
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish
             self._StopCurrentSession()

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1129,6 +1129,10 @@ class GenerateTrials():
             self.win.Start.setChecked(False)
             reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
             self.win._Start()  # trigger stopping logic after window
+            # stop FIB if running
+            if self.win.StartExcitation.isChecked():
+                self.win.StartExcitation.setChecked(False)
+                self.win._StartExcitation()
     
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1126,8 +1126,9 @@ class GenerateTrials():
         # If we should stop trials, uncheck the start button
         if stop:           
             self.win.Start.setStyleSheet("background-color : none")
-            self.win.Start.setChecked(False)        
+            self.win.Start.setChecked(False)
             reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
+            self.win._Start()  # trigger stopping logic after window
     
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- when _Start function is used when Start button is checked, FIB excitation is turned off if in use
### What issues or discussions does this update address?
- resolves [#682](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/682)
### Describe the expected change in behavior from the perspective of the experimenter
- if session is stopped, whether from time out or user presses a checked Start button, FIB excitation will end 
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7




