### PR TITLE
Changing Slims logs to warning when adding mice

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1312,8 +1312,8 @@ class Window(QMainWindow):
                         logging.info(f'Mouse {session.subject_id} successfully added to slims with pk {mouse.pk}')
                     except Exception as e:
                         if '"cntn_barCode":"This field should be unique"' in str(e):    # error if mouse already exists
-                            logging.error(f'Mouse {session.subject_id} exists in Slims but contains validations errors.'
-                                          f'Waterlog needs to be added manually to Slims.')
+                            logging.warning(f'Mouse {session.subject_id} exists in Slims but contains validations '
+                                            f'errors. Waterlog needs to be added manually to Slims.')
                             QMessageBox.critical(self,
                                                  'Adding Waterlog',
                                                  f'Mouse {session.subject_id} exists in Slims but contains validations '
@@ -1325,8 +1325,8 @@ class Window(QMainWindow):
                             raise e
 
                 else:   # Not enough info in schedule to create mouse
-                    logging.error(f'Mouse {session.subject_id} does not exist in Slims, and schedule does not contain '
-                                  f'enough information to add mouse. Waterlog needs to be added manually to Slims.')
+                    logging.warning(f'Mouse {session.subject_id} does not exist in Slims, and schedule does not contain'
+                                    f' enough information to add mouse. Waterlog needs to be added manually to Slims.')
                     QMessageBox.critical(self,
                                          'Adding Waterlog',
                                          f'Mouse {session.subject_id} does not exist in Slims, and schedule does not '

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1292,8 +1292,8 @@ class Window(QMainWindow):
             mouse = self.slims_client.fetch_model(models.SlimsMouseContent, barcode=session.subject_id)
         except Exception as e:
             if 'No record found' in str(e):    # if no mouse found or validation errors on mouse
-                logging.error(f'"No record found" error while trying to fetch mouse {session.subject_id}. '
-                              f'Attempting to add mouse model to Slims.')
+                logging.warning(f'"No record found" error while trying to fetch mouse {session.subject_id}. '
+                                f'Attempting to add mouse model to Slims.')
                 # check schedule to make sure enough information is known about mouse to create model in slims
                 if not pd.isnull((curr_st := self._GetInfoFromSchedule(session.subject_id, 'Current State'))) \
                         and not pd.isnull((point_of_contact := self._GetInfoFromSchedule(session.subject_id, 'PI'))):


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- logs will be warning instead of errors when mouse not found in slims since LAS isn't tracking mice on SLIMS yet
### What issues or discussions does this update address?
- N/A
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [ ] 446/7





