### PR TITLE
changing logic to prevent empy stings in water calibrations

### DIFF
--- a/src/foraging_gui/Calibration.ui
+++ b/src/foraging_gui/Calibration.ui
@@ -646,7 +646,7 @@
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="QLineEdit" name="WeightAfterLeft">
+        <widget class="QLabel" name="WeightAfterLeft">
             <property name="geometry">
                 <rect>
                     <x>510</x>
@@ -659,7 +659,7 @@
                 <string/>
             </property>
         </widget>
-        <widget class="QLineEdit" name="WeightAfterRight">
+        <widget class="QLabel" name="WeightAfterRight">
             <property name="geometry">
                 <rect>
                     <x>510</x>
@@ -790,7 +790,7 @@
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="QLineEdit" name="WeightBeforeLeft">
+        <widget class="QLabel" name="WeightBeforeLeft">
             <property name="geometry">
                 <rect>
                     <x>360</x>
@@ -803,7 +803,7 @@
                 <string/>
             </property>
         </widget>
-        <widget class="QLineEdit" name="WeightBeforeRight">
+        <widget class="QLabel" name="WeightBeforeRight">
             <property name="geometry">
                 <rect>
                     <x>360</x>

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -672,8 +672,8 @@ class WaterCalibrationDialog(QDialog):
             valve_open_time=str(current_valve_opentime),
             valve_open_interval=str(self.params['Interval']),
             cycle=str(self.params['Cycle']),
-            total_water=float(self.WeightAfterLeft.text()),
-            tube_weight=float(self.WeightBeforeLeft.text())
+            total_water=float(final_tube_weight),
+            tube_weight=float(before_weight)
             )
         self._UpdateFigure()
 
@@ -807,6 +807,7 @@ class WaterCalibrationDialog(QDialog):
             "Weight after (g): ", 
             final_tube_weight,
             0, 1000, 4)
+        print(final_tube_weight, ok)
         if not ok:
             self.Warning.setText('Please repeat measurement')
             self.WeightBeforeRight.setText('')
@@ -823,8 +824,8 @@ class WaterCalibrationDialog(QDialog):
             valve_open_time=str(current_valve_opentime),
             valve_open_interval=str(self.params['Interval']),
             cycle=str(self.params['Cycle']),
-            total_water=float(self.WeightAfterRight.text()),
-            tube_weight=float(self.WeightBeforeRight.text())
+            total_water=float(final_tube_weight),
+            tube_weight=float(before_weight)
             )
         self._UpdateFigure()
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- For water calibration, input boxes were replaced with labels to avoid accidental clearing and subsequent crashing
### What issues or discussions does this update address?
- resolves #716 
### Describe the expected change in behavior from the perspective of the experimenter
- User can not change WeightBeforeLeft/Right or WeightAfterLeft/Right after initial entry
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446




