### PR TITLE
Feat 444 organize warning labels

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -805,7 +805,6 @@ class WaterCalibrationDialog(QDialog):
             "Weight after (g): ", 
             final_tube_weight,
             0, 1000, 4)
-        print(final_tube_weight, ok)
         if not ok:
             self.Warning.setText('Please repeat measurement')
             self.WeightBeforeRight.setText('')
@@ -1278,7 +1277,13 @@ class CameraDialog(QDialog):
         self._connectSignalsSlots()
         self.camera_start_time=''
         self.camera_stop_time=''
-        
+
+        self.info_label = QLabel(parent=self)
+        self.info_label.setStyleSheet(f'color: {self.MainWindow.default_warning_color};')
+        self.info_label.move(50, 350)
+        self.info_label.setFixedSize(171, 51)
+        self.info_label.setAlignment(Qt.AlignCenter)
+
     def _connectSignalsSlots(self):
         self.StartRecording.toggled.connect(self._StartCamera)
         self.StartPreview.toggled.connect(self._start_preview)
@@ -1287,14 +1292,20 @@ class CameraDialog(QDialog):
 
     def _OpenSaveFolder(self):
         '''Open the log/save folder of the camera'''
+
+        text = self.info_label.text()
         if hasattr(self.MainWindow,'Ot_log_folder'):
             try:
                 subprocess.Popen(['explorer', os.path.join(os.path.dirname(os.path.dirname(self.MainWindow.Ot_log_folder)),'behavior-videos')])
             except Exception as e:
                 logging.error(str(e))
                 logging.warning('No logging folder found!', extra={'tags': self.MainWindow.warning_log_tag})
+                if 'No logging folder found!' not in text:
+                    self.info_label.setText(text + '\n No logging folder found!')
         else:
             logging.warning('No logging folder found!', extra={'tags': self.MainWindow.warning_log_tag})
+            if 'No logging folder found!' not in text:
+                self.info_label.setText(text + '\n No logging folder found!')
 
     def _start_preview(self):
         '''Start the camera preview'''
@@ -1313,6 +1324,8 @@ class CameraDialog(QDialog):
 
             self.StartPreview.setStyleSheet("background-color : green;")
             logging.info('Camera is on', extra={'tags': self.MainWindow.warning_log_tag})
+            self.info_label.setText('Camera is on')
+
         else:
             # enable the start recording button
             self.StartRecording.setEnabled(True)
@@ -1323,6 +1336,7 @@ class CameraDialog(QDialog):
 
             self.StartPreview.setStyleSheet("background-color : none;")
             logging.info('Camera is off', extra={'tags': self.MainWindow.warning_log_tag})
+            self.info_label.setText('Camera is off')
 
     def _AutoControl(self):
         '''Trigger the camera during the start of a new behavior session'''
@@ -1338,6 +1352,7 @@ class CameraDialog(QDialog):
         if self.StartRecording.isChecked():
             self.StartRecording.setStyleSheet("background-color : green;")
             logging.info('Camera is turning on', extra={'tags': self.MainWindow.warning_log_tag})
+            self.info_label.setText('Camera is turning on')
             QApplication.processEvents()
             # untoggle the preview button
             if self.StartPreview.isChecked():
@@ -1364,14 +1379,17 @@ class CameraDialog(QDialog):
             time.sleep(5)
             self.camera_start_time = str(datetime.now())
             logging.info('Camera is on!', extra={'tags': [self.MainWindow.warning_log_tag]})
+            self.info_label.setText('Camera is on!')
         else:
             self.StartRecording.setStyleSheet("background-color : none")
             logging.info('Camera is turning off', extra={'tags': self.MainWindow.warning_log_tag})
+            self.info_label.setText('Camera is turning off')
             QApplication.processEvents()
             self.MainWindow.Channel.CameraControl(int(2))
             self.camera_stop_time = str(datetime.now())
             time.sleep(5)
             logging.info('Camera is off!', extra={'tags': [self.MainWindow.warning_log_tag]})
+            self.info_label.setText('Camera is off!')
 
 def is_file_in_use(file_path):
     '''check if the file is open'''

--- a/src/foraging_gui/warning_widget.py
+++ b/src/foraging_gui/warning_widget.py
@@ -3,7 +3,7 @@ from queue import Queue
 from logging.handlers import QueueHandler
 from random import randint
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel, QSizePolicy
+from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel
 import sys
 
 
@@ -135,6 +135,8 @@ class WarningFilter(logging.Filter):
 if __name__ == '__main__':
     app = QApplication(sys.argv)
 
+    logging.basicConfig(level=logging.INFO)
+
     logger = logging.getLogger()
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel('INFO')
@@ -144,7 +146,6 @@ if __name__ == '__main__':
     logger.root.addHandler(stream_handler)
 
     warn_widget = WarningWidget()
-    warn_widget.show()
 
     warnings = ['this is a warning', 'this is also a warning', 'this is a warning too', 'Warn warn warn',
                 'are you warned yet?', '']

--- a/src/foraging_gui/warning_widget.py
+++ b/src/foraging_gui/warning_widget.py
@@ -146,6 +146,7 @@ if __name__ == '__main__':
     logger.root.addHandler(stream_handler)
 
     warn_widget = WarningWidget()
+    warn_widget.show()
 
     warnings = ['this is a warning', 'this is also a warning', 'this is a warning too', 'Warn warn warn',
                 'are you warned yet?', '']

--- a/src/foraging_gui/warning_widget.py
+++ b/src/foraging_gui/warning_widget.py
@@ -59,7 +59,6 @@ class WarningWidget(QWidget):
             if log.getMessage()[12:].strip():   # skip empty messages
                 label = QLabel(log.getMessage())
                 label.setWordWrap(True)
-                print(log.levelno, logging.WARNING)
                 if log.levelno == logging.WARNING:
                     label.setStyleSheet(f'color: {self._warning_color};')
                 elif log.levelno == logging.ERROR:

--- a/src/foraging_gui/warning_widget.py
+++ b/src/foraging_gui/warning_widget.py
@@ -3,9 +3,9 @@ from queue import Queue
 from logging.handlers import QueueHandler
 from random import randint
 from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel
+from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QLabel, QScrollArea
 import sys
-
+from time import sleep
 
 class WarningWidget(QWidget):
     """Widget that uses a logging QueueHandler to display log errors and warning"""
@@ -145,8 +145,12 @@ if __name__ == '__main__':
     stream_handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=log_datefmt))
     logger.root.addHandler(stream_handler)
 
-    warn_widget = WarningWidget()
-    warn_widget.show()
+    scroll = QScrollArea()
+    warn_widget = WarningWidget(parent=scroll)
+    scroll.setWidget(warn_widget)
+    scroll.setWidgetResizable(True)
+    scroll.show()
+
 
     warnings = ['this is a warning', 'this is also a warning', 'this is a warning too', 'Warn warn warn',
                 'are you warned yet?', '']
@@ -157,12 +161,15 @@ if __name__ == '__main__':
                                                           extra={'tags': 'warning_widget'}), interval=1000)
 
     info_timer = QTimer(timeout=lambda: logger.info(infos[randint(0, 2)],
-                                                          extra={'tags': 'warning_widget'}), interval=1000)
+                                                          extra={'tags': 'warning_widget'}), interval=1500)
     error_timer = QTimer(timeout=lambda: logger.error(errors[randint(0, 2)],
-                                                    extra={'tags': 'warning_widget'}), interval=1000)
+                                                    extra={'tags': 'warning_widget'}), interval=1750)
 
     warning_timer.start()
+    sleep(.5)
     info_timer.start()
+    sleep(1)
     error_timer.start()
+    sleep(1)
 
     sys.exit(app.exec_())


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- warning box is now a widget what displays log warnings
### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/444
### Describe the expected change in behavior from the perspective of the experimenter
-  Warning box will display newest log messages at top of box. Warning will not be removed anymore
### Describe any manual update steps for task computers
- None 
### Was this update tested in 446/447?
- [x] 446/447
