### PR TITLE
manual water water and valve time are same as earned reward

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -361,12 +361,8 @@ class Window(QMainWindow):
         self.actionOpen_video_folder.triggered.connect(self._OpenVideoFolder)
         self.LeftValue.textChanged.connect(self._WaterVolumnManage1)
         self.RightValue.textChanged.connect(self._WaterVolumnManage1)
-        self.GiveWaterL.textChanged.connect(self._WaterVolumnManage1)
-        self.GiveWaterR.textChanged.connect(self._WaterVolumnManage1)
         self.LeftValue_volume.textChanged.connect(self._WaterVolumnManage2)
         self.RightValue_volume.textChanged.connect(self._WaterVolumnManage2)
-        self.GiveWaterL_volume.textChanged.connect(self._WaterVolumnManage2)
-        self.GiveWaterR_volume.textChanged.connect(self._WaterVolumnManage2)
         self.MoveXP.clicked.connect(self._MoveXP)
         self.MoveYP.clicked.connect(self._MoveYP)
         self.MoveZP.clicked.connect(self._MoveZP)
@@ -385,6 +381,18 @@ class Window(QMainWindow):
         self.Opto_dialog.laser_2_calibration_voltage.textChanged.connect(self._toggle_save_color)
         self.Opto_dialog.laser_1_calibration_power.textChanged.connect(self._toggle_save_color)
         self.Opto_dialog.laser_2_calibration_power.textChanged.connect(self._toggle_save_color)
+
+        # Set manual water volume to earned reward and trigger update if changed
+        for side in ['Left', 'Right']:
+            reward_volume_widget = getattr(self, f'{side}Value_volume')
+            manual_volume_widget = getattr(self, f'GiveWater{side[0]}_volume')
+            manual_volume_widget.setValue(reward_volume_widget.value())
+            reward_volume_widget.valueChanged.connect(manual_volume_widget.setValue)
+
+            reward_time_widget = getattr(self, f'{side}Value')
+            manual_time_widget = getattr(self, f'GiveWater{side[0]}')
+            manual_time_widget.setValue(reward_time_widget.value())
+            reward_time_widget.valueChanged.connect(manual_time_widget.setValue)
 
         # check the change of all of the QLineEdit, QDoubleSpinBox and QSpinBox
         for container in [self.TrainingParameters, self.centralwidget, self.Opto_dialog,self.Metadata_dialog]:
@@ -1598,12 +1606,8 @@ class Window(QMainWindow):
         '''Change the water volume based on the valve open time'''
         self.LeftValue.textChanged.disconnect(self._WaterVolumnManage1)
         self.RightValue.textChanged.disconnect(self._WaterVolumnManage1)
-        self.GiveWaterL.textChanged.disconnect(self._WaterVolumnManage1)
-        self.GiveWaterR.textChanged.disconnect(self._WaterVolumnManage1)
         self.LeftValue_volume.textChanged.disconnect(self._WaterVolumnManage2)
         self.RightValue_volume.textChanged.disconnect(self._WaterVolumnManage2)
-        self.GiveWaterL_volume.textChanged.disconnect(self._WaterVolumnManage2)
-        self.GiveWaterR_volume.textChanged.disconnect(self._WaterVolumnManage2)
         # use the latest calibration result
         if hasattr(self, 'WaterCalibration_dialog'):
             if hasattr(self.WaterCalibration_dialog, 'PlotM'):
@@ -1614,40 +1618,26 @@ class Window(QMainWindow):
             self._GetLatestFitting(FittingResults)
             self._ValvetimeVolumnTransformation(widget2=self.LeftValue_volume,widget1=self.LeftValue,direction=1,valve='Left')
             self._ValvetimeVolumnTransformation(widget2=self.RightValue_volume,widget1=self.RightValue,direction=1,valve='Right')
-            self._ValvetimeVolumnTransformation(widget2=self.GiveWaterL_volume,widget1=self.GiveWaterL,direction=1,valve='Left')
-            self._ValvetimeVolumnTransformation(widget2=self.GiveWaterR_volume,widget1=self.GiveWaterR,direction=1,valve='Right')
             self.LeftValue_volume.setEnabled(True)
             self.RightValue_volume.setEnabled(True)
-            self.GiveWaterL_volume.setEnabled(True)
-            self.GiveWaterR_volume.setEnabled(True)
             self.label_28.setEnabled(True)
             self.label_29.setEnabled(True)
         else:
             self.LeftValue_volume.setEnabled(False)
             self.RightValue_volume.setEnabled(False)
-            self.GiveWaterL_volume.setEnabled(False)
-            self.GiveWaterR_volume.setEnabled(False)
             self.label_28.setEnabled(False)
             self.label_29.setEnabled(False)
         self.LeftValue.textChanged.connect(self._WaterVolumnManage1)
         self.RightValue.textChanged.connect(self._WaterVolumnManage1)
-        self.GiveWaterL.textChanged.connect(self._WaterVolumnManage1)
-        self.GiveWaterR.textChanged.connect(self._WaterVolumnManage1)
         self.LeftValue_volume.textChanged.connect(self._WaterVolumnManage2)
         self.RightValue_volume.textChanged.connect(self._WaterVolumnManage2)
-        self.GiveWaterL_volume.textChanged.connect(self._WaterVolumnManage2)
-        self.GiveWaterR_volume.textChanged.connect(self._WaterVolumnManage2)
 
     def _WaterVolumnManage2(self):
         '''Change the valve open time based on the water volume'''
         self.LeftValue.textChanged.disconnect(self._WaterVolumnManage1)
         self.RightValue.textChanged.disconnect(self._WaterVolumnManage1)
-        self.GiveWaterL.textChanged.disconnect(self._WaterVolumnManage1)
-        self.GiveWaterR.textChanged.disconnect(self._WaterVolumnManage1)
         self.LeftValue_volume.textChanged.disconnect(self._WaterVolumnManage2)
         self.RightValue_volume.textChanged.disconnect(self._WaterVolumnManage2)
-        self.GiveWaterL_volume.textChanged.disconnect(self._WaterVolumnManage2)
-        self.GiveWaterR_volume.textChanged.disconnect(self._WaterVolumnManage2)
         # use the latest calibration result
         if hasattr(self, 'WaterCalibration_dialog'):
             if hasattr(self.WaterCalibration_dialog, 'PlotM'):
@@ -1658,23 +1648,15 @@ class Window(QMainWindow):
             self._GetLatestFitting(FittingResults)
             self._ValvetimeVolumnTransformation(widget1=self.LeftValue_volume,widget2=self.LeftValue,direction=-1,valve='Left')
             self._ValvetimeVolumnTransformation(widget1=self.RightValue_volume,widget2=self.RightValue,direction=-1,valve='Right')
-            self._ValvetimeVolumnTransformation(widget1=self.GiveWaterL_volume,widget2=self.GiveWaterL,direction=-1,valve='Left')
-            self._ValvetimeVolumnTransformation(widget1=self.GiveWaterR_volume,widget2=self.GiveWaterR,direction=-1,valve='Right')
         else:
             self.LeftValue_volume.setEnabled(False)
             self.RightValue_volume.setEnabled(False)
-            self.GiveWaterL_volume.setEnabled(False)
-            self.GiveWaterR_volume.setEnabled(False)
             self.label_28.setEnabled(False)
             self.label_29.setEnabled(False)
         self.LeftValue.textChanged.connect(self._WaterVolumnManage1)
         self.RightValue.textChanged.connect(self._WaterVolumnManage1)
-        self.GiveWaterL.textChanged.connect(self._WaterVolumnManage1)
-        self.GiveWaterR.textChanged.connect(self._WaterVolumnManage1)
         self.LeftValue_volume.textChanged.connect(self._WaterVolumnManage2)
         self.RightValue_volume.textChanged.connect(self._WaterVolumnManage2)
-        self.GiveWaterL_volume.textChanged.connect(self._WaterVolumnManage2)
-        self.GiveWaterR_volume.textChanged.connect(self._WaterVolumnManage2)
 
     def _ValvetimeVolumnTransformation(self,widget1,widget2,direction,valve):
         '''Transformation between valve open time the the water volume'''

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -1731,6 +1731,9 @@
                          <property name="value">
                           <double>0.030000000000000</double>
                          </property>
+                         <property name="disabled">
+                          <bool>true</bool>
+                         </property>
                         </widget>
                        </item>
                        <item row="2" column="2">
@@ -1755,6 +1758,9 @@
                          </property>
                          <property name="value">
                           <double>0.030000000000000</double>
+                         </property>
+                         <property name="disabled">
+                         <bool>true</bool>
                          </property>
                         </widget>
                        </item>
@@ -1807,6 +1813,9 @@
                          <property name="value">
                           <double>3.000000000000000</double>
                          </property>
+                          <property name="disabled">
+                          <bool>true</bool>
+                         </property>
                         </widget>
                        </item>
                        <item row="3" column="2">
@@ -1832,6 +1841,9 @@
                          <property name="value">
                           <double>3.000000000000000</double>
                          </property>
+                         <property name="disabled">
+                         <bool>true</bool>
+                        </property>
                         </widget>
                        </item>
                        <item row="2" column="3">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1507,6 +1507,9 @@
      <property name="value">
       <double>0.030000000000000</double>
      </property>
+     <property name="disabled">
+     <bool>true</bool>
+    </property>
     </widget>
     <widget class="QDoubleSpinBox" name="GiveWaterR">
      <property name="geometry">
@@ -1532,6 +1535,9 @@
      <property name="value">
       <double>0.030000000000000</double>
      </property>
+     <property name="disabled">
+     <bool>true</bool>
+    </property>
     </widget>
     <widget class="QLabel" name="label_56">
      <property name="geometry">
@@ -2010,6 +2016,9 @@
      <property name="value">
       <double>3.000000000000000</double>
      </property>
+     <property name="disabled">
+     <bool>true</bool>
+    </property>
     </widget>
     <widget class="QDoubleSpinBox" name="GiveWaterR_volume">
      <property name="geometry">
@@ -2035,6 +2044,9 @@
      <property name="value">
       <double>3.000000000000000</double>
      </property>
+     <property name="disabled">
+     <bool>true</bool>
+    </property>
     </widget>
     <widget class="QDoubleSpinBox" name="RightValue_volume">
      <property name="geometry">


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- manual water water and valve time are same as earned reward
### What issues or discussions does this update address?
- resolves [#681](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/681)
### Describe the expected change in behavior from the perspective of the experimenter
- user cannot change manual water 
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7




