### PR TITLE
creating model and saving

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aind-auto-train@git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main",
     "aind-slims-api@git+https://github.com/AllenNeuralDynamics/aind-slims-api@main",
     "aind-dynamic-foraging-models@git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main",
+    "Aind.Behavior.Services@git+https://github.com/AllenNeuralDynamics/Aind.Behavior.Services@main"
     "pynwb",
     "requests",
     "harp-python",
@@ -37,7 +38,6 @@ dependencies = [
     "aind-data-schema-models==0.5.6",
     "pydantic==2.9.2",
     "stagewidget==1.0.4.dev0",
-
     "pyyaml",
     "pyqtgraph"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "aind-auto-train@git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main",
     "aind-slims-api@git+https://github.com/AllenNeuralDynamics/aind-slims-api@main",
     "aind-dynamic-foraging-models@git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main",
-    "Aind.Behavior.Services@git+https://github.com/AllenNeuralDynamics/Aind.Behavior.Services@main"
+    "aind-behavior-services==0.8.0rc1",
     "pynwb",
     "requests",
     "harp-python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "aind-auto-train@git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main",
     "aind-slims-api@git+https://github.com/AllenNeuralDynamics/aind-slims-api@main",
     "aind-dynamic-foraging-models@git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main",
-    "aind-behavior-services==0.8.0rc1",
+    "aind-behavior-services<0.9",
     "pynwb",
     "requests",
     "harp-python",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ git+https://github.com/AllenNeuralDynamics/python-newscale@axes-on-target
 git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main
 git+https://github.com/AllenNeuralDynamics/aind-slims-api@main
 git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main
+git+https://github.com/AllenNeuralDynamics/Aind.Behavior.Services@main
 pynwb
 requests
 harp-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/AllenNeuralDynamics/python-newscale@axes-on-target
 git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main
 git+https://github.com/AllenNeuralDynamics/aind-slims-api@main
 git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main
-aind-behavior-services==0.8.0rcl
+aind-behavior-services<0.9
 pynwb
 requests
 harp-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ git+https://github.com/AllenNeuralDynamics/python-newscale@axes-on-target
 git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main
 git+https://github.com/AllenNeuralDynamics/aind-slims-api@main
 git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main
-git+https://github.com/AllenNeuralDynamics/Aind.Behavior.Services@main
+aind-behavior-services==0.8.0rcl
 pynwb
 requests
 harp-python

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2335,7 +2335,7 @@ class AutoTrainDialog(QDialog):
         self._setup_allbacks()
         
         # Sync selected subject_id
-        self.update_auto_train_fields(subject_id=self.MainWindow.ID.text())
+        self.update_auto_train_fields(subject_id=self.MainWindow.behavior_session_model.subject)
                 
     def _setup_allbacks(self):
         self.checkBox_show_this_mouse_only.stateChanged.connect(

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -49,8 +49,6 @@ from aind_data_schema.core.session import Session
 from aind_data_schema_models.modalities import Modality
 from aind_behavior_services.session import AindBehaviorSessionModel
 
-from pprint import pprint
-
 logger = logging.getLogger(__name__)
 logger.root.handlers.clear() # clear handlers so console output can be configured
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -29,6 +29,7 @@ from PyQt5 import QtWidgets,QtGui,QtCore, uic
 from PyQt5.QtCore import QThreadPool,Qt,QThread
 from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
+from pydantic import ValidationError
 
 from StageWidget.main import get_stage_widget
 
@@ -3977,6 +3978,11 @@ class Window(QMainWindow):
             # stop lick interval calculation
             self.GeneratedTrials.lick_interval_time.stop()  # stop lick interval calculation
 
+            # validate behavior session model and document validation errors if any
+            try:
+                AindBehaviorSessionModel(**self.behavior_session_model.model_dump())
+            except ValidationError as e:
+                logging.error(str(e), extra={'tags': [self.warning_log_tag]})
             # save behavior session model
             with open(self.behavior_session_modelJson, "w") as outfile:
                 outfile.write(self.behavior_session_model.model_dump_json())

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -49,6 +49,8 @@ from aind_data_schema.core.session import Session
 from aind_data_schema_models.modalities import Modality
 from aind_behavior_services.session import AindBehaviorSessionModel
 
+from pprint import pprint
+
 logger = logging.getLogger(__name__)
 logger.root.handlers.clear() # clear handlers so console output can be configured
 
@@ -402,7 +404,9 @@ class Window(QMainWindow):
         self.Task.currentTextChanged.connect(lambda task: setattr(self.behavior_session_model, 'experiment', task))
         self.Experimenter.textChanged.connect(lambda text: setattr(self.behavior_session_model, 'experimenter', [text]))
         self.ID.textChanged.connect(lambda subject: setattr(self.behavior_session_model, 'subject', subject))
-        self.ShowNotes.textChanged.connect(lambda notes: setattr(self.behavior_session_model, 'notes', notes))
+        self.ShowNotes.textChanged.connect(lambda: setattr(self.behavior_session_model, 'notes',
+                                                           self.ShowNotes.toPlainText()))
+
 
         # Set manual water volume to earned reward and trigger update if changed
         for side in ['Left', 'Right']:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -112,15 +112,14 @@ class Window(QMainWindow):
 
         # create AINDBehaviorSession model to be used and referenced for session info
         self.behavior_session_model = AindBehaviorSessionModel(
-            experiment=lambda: self.Task.currentText(),
-            experimenter=[lambda: self.Experimenter.text()],
+            experiment=self.Task.currentText(),
+            experimenter=[self.Experimenter.text()],
             date=datetime.now(),   # update when folders are created
             root_path='',         # update when created
-            session_name=lambda: f'{self.behavior_session_model.subject}_'
-                                 f'{ self.behavior_session_model.date.strftime("%Y-%m-%d_%H-%M-%S")}',
-            subject=lambda: self.ID.text(),
+            session_name= '',   # update when date and subject are filled in 
+            subject=self.ID.text(),
             experiment_version=foraging_gui.__version__,
-            notes=lambda:self.ShowNotes.toPlainText(),
+            notes=self.ShowNotes.toPlainText(),
             commit_hash= subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip(),
             allow_dirty_repo=subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip() != '',
             skip_hardware_validation=True
@@ -2788,8 +2787,9 @@ class Window(QMainWindow):
 
     def _get_folder_structure_old(self):
         '''get the folder structure for the old data format'''
-
-        session_name = self.behavior_session_model.session_name     # includes subject and date of session
+        # includes subject and date of session
+        session_name = self.behavior_session_model.session_name = f'behavior_{self.behavior_session_model.subject}_' \
+                                                     f'{self.behavior_session_model.date.strftime("%Y-%m-%d_%H-%M-%S")}'
         self.SessionFolder=os.path.join(self.default_saveFolder,
             self.current_box,self.behavior_session_model.subject, session_name)
         self.MetadataFolder=os.path.join(self.SessionFolder, 'metadata-dir')
@@ -2799,19 +2799,21 @@ class Window(QMainWindow):
         self.PhotometryFolder=os.path.join(self.SessionFolder, 'PhotometryFolder')
         self.SaveFileMat=os.path.join(self.behavior_session_model.root_path,f'{session_name}.mat')
         self.SaveFileJson=os.path.join(self.behavior_session_model.root_path,f'{session_name}.json')
-        self.SaveFileParJson=os.path.join(self.behavior_session_model.root_path,f'{session_name}_par.json')
+        self.SaveFileParJson=os.path.join(self.behavior_session_model.root_path,f'{session_name}.json')
 
     def _get_folder_structure_new(self):
         '''get the folder structure for the new data format'''
         # Determine folders
-        session_name = self.behavior_session_model.session_name # includes subject and date of session 
+        # session_name includes subject and date of session
+        session_name = self.behavior_session_model.session_name=f'behavior_{self.behavior_session_model.subject}_' \
+                                                     f'{self.behavior_session_model.date.strftime("%Y-%m-%d_%H-%M-%S")}'
         self.SessionFolder=os.path.join(self.default_saveFolder,
             self.current_box,self.behavior_session_model.subject, f'behavior_{session_name}')
         self.behavior_session_model.root_path=os.path.join(self.SessionFolder,'behavior')
         self.SaveFileMat=os.path.join(self.behavior_session_model.root_path,f'{session_name}.mat')
         self.SaveFileJson=os.path.join(self.behavior_session_model.root_path,f'{session_name}.json')
         self.SaveFileParJson=os.path.join(self.behavior_session_model.root_path,f'{session_name}_par.json')
-        self.behavior_session_modelJson = os.path.join(self.behavior_session_model.root_path,f'behavior_session_model_{session_name}_par.json')
+        self.behavior_session_modelJson = os.path.join(self.behavior_session_model.root_path,f'behavior_session_model_{session_name}.json')
         self.HarpFolder=os.path.join(self.behavior_session_model.root_path,'raw.harp')
         self.VideoFolder=os.path.join(self.SessionFolder,'behavior-videos')
         self.PhotometryFolder=os.path.join(self.SessionFolder,'fib')
@@ -4615,7 +4617,7 @@ class Window(QMainWindow):
             # Define contents of manifest file
             contents = {
                 'acquisition_datetime': self.behavior_session_model.date,
-                'name': self.session_name,
+                'name': self.behavior_session_model.session_name,
                 'platform': 'behavior',
                 'subject_id': int(self.behavior_session_model.subject),
                 'capsule_id': capsule_id,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -116,7 +116,7 @@ class Window(QMainWindow):
             experimenter=[self.Experimenter.text()],
             date=datetime.now(),   # update when folders are created
             root_path='',         # update when created
-            session_name= '',   # update when date and subject are filled in 
+            session_name= '',   # update when date and subject are filled in
             subject=self.ID.text(),
             experiment_version=foraging_gui.__version__,
             notes=self.ShowNotes.toPlainText(),
@@ -124,8 +124,6 @@ class Window(QMainWindow):
             allow_dirty_repo=subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip() != '',
             skip_hardware_validation=True
         )
-
-
 
         # add warning_widget to layout and set color
         self.warning_widget = WarningWidget(log_tag=self.warning_log_tag,
@@ -399,6 +397,12 @@ class Window(QMainWindow):
         self.Opto_dialog.laser_2_calibration_voltage.textChanged.connect(self._toggle_save_color)
         self.Opto_dialog.laser_1_calibration_power.textChanged.connect(self._toggle_save_color)
         self.Opto_dialog.laser_2_calibration_power.textChanged.connect(self._toggle_save_color)
+
+        # update parameters in behavior session model if widgets change
+        self.Task.currentTextChanged.connect(lambda task: setattr(self.behavior_session_model, 'experiment', task))
+        self.Experimenter.textChanged.connect(lambda text: setattr(self.behavior_session_model, 'experimenter', [text]))
+        self.ID.textChanged.connect(lambda subject: setattr(self.behavior_session_model, 'subject', subject))
+        self.ShowNotes.textChanged.connect(lambda notes: setattr(self.behavior_session_model, 'notes', notes))
 
         # Set manual water volume to earned reward and trigger update if changed
         for side in ['Left', 'Right']:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -121,10 +121,11 @@ class Window(QMainWindow):
             experiment_version=foraging_gui.__version__,
             notes=self.ShowNotes.toPlainText(),
             commit_hash= subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip(),
-            allow_dirty_repo=subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip() != '',
+            allow_dirty_repo=
+            subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip() != '',
             skip_hardware_validation=True
         )
-
+        print(self.behavior_session_model)
         # add warning_widget to layout and set color
         self.warning_widget = WarningWidget(log_tag=self.warning_log_tag,
                                             warning_color=self.default_warning_color)
@@ -2623,7 +2624,7 @@ class Window(QMainWindow):
             Obj['commit_ID']=self.behavior_session_model.commit_hash
             Obj['repo_url']=self.repo_url
             Obj['current_branch'] =self.current_branch
-            Obj['repo_dirty_flag'] =self.repo_dirty_flag
+            Obj['repo_dirty_flag'] =self.behavior_session_model.allow_dirty_repo
             Obj['dirty_files'] =self.dirty_files
             Obj['version'] = self.behavior_session_model.experiment_version
 
@@ -3845,7 +3846,7 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch))
 
             # Check for untracked local changes
-            if self.repo_dirty_flag & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
+            if self.behavior_session_model.allow_dirty_repo & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # prompt user over untracked local changes
                 reply = QMessageBox.critical(self,
                     'Box {}, Start'.format(self.box_letter),
@@ -3859,7 +3860,7 @@ class Window(QMainWindow):
                 else:
                     # Allow the session to continue, but log error
                     logging.error('Starting session with untracked local changes: {}'.format(self.dirty_files))
-            elif self.repo_dirty_flag is None:
+            elif self.behavior_session_model.allow_dirty_repo is None:
                 logging.error('Could not check for untracked local changes')
 
             if self.PhotometryB.currentText()=='on' and (not self.FIP_started):
@@ -4868,7 +4869,7 @@ if __name__ == "__main__":
     #win.behavior_session_model.commit_hash=commit_ID
     win.current_branch=current_branch
     win.repo_url=repo_url
-    win.repo_dirty_flag=repo_dirty_flag
+    #win.repo_dirty_flag=repo_dirty_flag
     win.dirty_files=dirty_files
     #win.behavior_session_model.experiment_version=version
     win.show()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -30,7 +30,7 @@ from PyQt5.QtCore import QThreadPool,Qt,QThread
 from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 
-from StageWidget.main import get_stage_widget
+#from StageWidget.main import get_stage_widget
 
 import foraging_gui
 import foraging_gui.rigcontrol as rigcontrol

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -125,7 +125,7 @@ class Window(QMainWindow):
             subprocess.check_output(['git','diff-index','--name-only', 'HEAD']).decode('ascii').strip() != '',
             skip_hardware_validation=True
         )
-        print(self.behavior_session_model)
+
         # add warning_widget to layout and set color
         self.warning_widget = WarningWidget(log_tag=self.warning_log_tag,
                                             warning_color=self.default_warning_color)
@@ -4866,12 +4866,9 @@ if __name__ == "__main__":
     # Start GUI window
     win = Window(box_number=box_number,start_bonsai_ide=start_bonsai_ide)
     # Get the commit hash of the current version of this Python file
-    #win.behavior_session_model.commit_hash=commit_ID
     win.current_branch=current_branch
     win.repo_url=repo_url
-    #win.repo_dirty_flag=repo_dirty_flag
     win.dirty_files=dirty_files
-    #win.behavior_session_model.experiment_version=version
     win.show()
 
     # Move creating AutoTrain here to catch any AWS errors

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -30,7 +30,7 @@ from PyQt5.QtCore import QThreadPool,Qt,QThread
 from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 
-#from StageWidget.main import get_stage_widget
+from StageWidget.main import get_stage_widget
 
 import foraging_gui
 import foraging_gui.rigcontrol as rigcontrol

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -928,7 +928,7 @@ class GenerateTrials():
                 self.win.same_side_lick_interval.setText(f'Percentage of same side lick intervals under 100 ms is '
                                                          f'over 10%: {same_side_frac * 100:.2f}%.')
                 logging.error(f'Percentage of same side lick intervals under 100 ms in Box {self.win.box_letter} '
-                              f'mouse {self.win.ID.text()} exceeded 10%')
+                              f'mouse {self.win.behavior_session_model.subject} exceeded 10%')
             else:
                 self.win.same_side_lick_interval.setText('')
 
@@ -955,7 +955,7 @@ class GenerateTrials():
                 self.win.cross_side_lick_interval.setText(f'Percentage of cross side lick intervals under 100 ms is '
                                                           f'over 10%: {cross_side_frac * 100:.2f}%.')
                 logging.error(f'Percentage of cross side lick intervals under 100 ms in Box {self.win.box_letter} '
-                              f'mouse {self.win.ID.text()} exceeded 10%')
+                              f'mouse {self.win.behavior_session_model.subject} exceeded 10%')
             else:
                 self.win.cross_side_lick_interval.setText('')
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"



### Describe changes:

AINDBehaviorSessionModel is created in the init of the UI with default values that will be updated as session information is created.  Attributes of the main window that are now nested in the data model are as follows:
       
            self.behavior_session_model.experiment = self.Task.currentText()
            self.behavior_session_model.experimenter = [self.Experimenter.text()]
            self.behavior_session_model.date = N/A
            self.behavior_session_model.root_path = self.TrainingFolder
            self.behavior_session_model.session_name = self.session_name
            self.behavior_session_model.subject = self.ID.text()
            self.behavior_session_model.experiment_version = self.version
            self.behavior_session_model.notes = self.ShowNotes.toPlainText(),
            self.behavior_session_model.commit_hash = self.commit_ID
            self.behavior_session_model.allow_dirty_repo = self.repo_dirty_flag
            
If the Task, Experimenter, ID, or ShowNotes widgets are edited by user, the behavior_session_model is updated with latest values. The model is validated and saved at the stopping of a session. If validation errors are raised, the errors are logged but the session model is still saved. The session model will be saved to the root_path (previously TrainingFolder) with the prefix `'behavior_session_model_{session_name}.json'`. Naming conventions of root_path and session names remain the same. The model's date is a datetime object, not a string and can be formatted to match currently used convention 

### What issues or discussions does this update address?
- resolves #799 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7




