### PR TITLE
Adding 5 second delay before stopping fip and remove extra pop up 

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -333,7 +333,7 @@ class Window(QMainWindow):
         self.Save.setCheckable(True)
         self.Save.clicked.connect(self._Save)
         self.Clear.clicked.connect(self._Clear)
-        self.Start.clicked.connect(self._Check)
+        self.Start.clicked.connect(self._CheckStartStop)
         self.GiveLeft.clicked.connect(self._GiveLeft)
         self.GiveRight.clicked.connect(self._GiveRight)
         self.NewSession.clicked.connect(self._NewSession)
@@ -3715,7 +3715,7 @@ class Window(QMainWindow):
             self.Metadata_dialog.ProjectName.addItems([project_name])
         return project_name
 
-    def _Checks(self):
+    def _CheckStartStop(self):
         """
         Check with user before starting or stopping a scan
         """

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3989,6 +3989,7 @@ class Window(QMainWindow):
             self.keyPressEvent(allow_reset=True)
 
         else:
+            logging.info('Stopping trials')
             # If the photometry timer is running, stop it
             if self.finish_Timer == 0:
                 self.ignore_timer = True
@@ -4007,10 +4008,19 @@ class Window(QMainWindow):
             # stop lick interval calculation
             self.GeneratedTrials.lick_interval_time.stop()  # stop lick interval calculation
 
+            # validate behavior session model and document validation errors if any
+            try:
+                AindBehaviorSessionModel(**self.behavior_session_model.model_dump())
+            except ValidationError as e:
+                logging.error(str(e), extra={'tags': [self.warning_log_tag]})
+            # save behavior session model
+            with open(self.behavior_session_modelJson, "w") as outfile:
+                outfile.write(self.behavior_session_model.model_dump_json())
+
         if (self.StartANewSession == 1) and (self.ANewTrial == 0):
             # If we are starting a new session, we should wait for the last trial to finish
             self._StopCurrentSession()
-        # to see if we should start a new session
+            # to see if we should start a new session
         if self.StartANewSession == 1 and self.ANewTrial == 1:
             # generate a new session id
             self.ManualWaterVolume = [0, 0]
@@ -4022,7 +4032,7 @@ class Window(QMainWindow):
                 not self.FIP_started):
                     # Turn off the camera recording
                     self.Camera_dialog.StartRecording.setChecked(False)
-                    # Turn off the preview if it is on and the autocontrol is on, which can make sure the trigger is off before starting the logging. 
+                    # Turn off the preview if it is on and the autocontrol is on, which can make sure the trigger is off before starting the logging.
                     if self.Camera_dialog.AutoControl.currentText() == 'Yes' and self.Camera_dialog.StartPreview.isChecked():
                         self.Camera_dialog.StartPreview.setChecked(False)
                         # sleep for 1 second to make sure the trigger is off
@@ -4128,7 +4138,7 @@ class Window(QMainWindow):
             workerStartTrialLoop1 = self.workerStartTrialLoop1
             worker_save = self.worker_save
 
-        # collecting the base signal for photometry. Only run once
+            # collecting the base signal for photometry. Only run once
         if self.Start.isChecked() and self.PhotometryB.currentText() == 'on' and self.PhotometryRun == 0:
             logging.info('Starting photometry baseline timer')
             self.finish_Timer = 0

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3731,7 +3731,7 @@ class Window(QMainWindow):
                 if reply == QMessageBox.No:
                     return
             # check if FIP setting match schedule
-            mouse_id = self.ID.text()
+            mouse_id = self.behavior_session_model.subject
             if hasattr(self, 'schedule') and mouse_id in self.schedule['Mouse ID'].values and mouse_id not in [
                 '0', '1',
                 '2', '3',
@@ -3796,7 +3796,6 @@ class Window(QMainWindow):
                     self.Start.setChecked(False)
                     logging.info('User declines continuation of session')
                     return
-                self.GeneratedTrials.lick_interval_time.start()  # restart lick interval calculation
 
             # check experimenter name
             reply = QMessageBox.critical(self,
@@ -3811,7 +3810,7 @@ class Window(QMainWindow):
 
             # check repo status
             if (self.current_branch not in ['main', 'production_testing']) & (
-                    self.ID.text() not in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']):
+                    self.behavior_session_model.subject not in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']):
                 # Prompt user over off-pipeline branch
                 reply = QMessageBox.critical(self,
                                              'Box {}, Start'.format(self.box_letter),
@@ -3828,8 +3827,8 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch))
 
             # Check for untracked local changes
-            if self.repo_dirty_flag & (
-                    self.ID.text() not in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']):
+            if self.behavior_session_model.allow_dirty_repo & (
+                    self.behavior_session_model.subject not in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']):
                 # prompt user over untracked local changes
                 reply = QMessageBox.critical(self,
                                              'Box {}, Start'.format(self.box_letter),
@@ -3843,7 +3842,7 @@ class Window(QMainWindow):
                 else:
                     # Allow the session to continue, but log error
                     logging.error('Starting session with untracked local changes: {}'.format(self.dirty_files))
-            elif self.repo_dirty_flag is None:
+            elif self.behavior_session_model.allow_dirty_repo is None:
                 logging.error('Could not check for untracked local changes')
 
             if self.PhotometryB.currentText() == 'on' and (not self.FIP_started):
@@ -3937,7 +3936,10 @@ class Window(QMainWindow):
             logging.info('Start button pressed: starting trial loop')
             self.keyPressEvent()
 
-            mouse_id = self.ID.text()
+            if self.StartANewSession == 0:
+                self.GeneratedTrials.lick_interval_time.start()  # restart lick interval calculation
+
+            mouse_id = self.behavior_session_model.subject
 
             # empty post weight after pass through checks in case user cancels run
             self.WeightAfter.setText('')

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1195,11 +1195,13 @@ class GenerateTrials():
             self.win.Start.setStyleSheet("background-color : none")
             self.win.Start.setChecked(False)
             reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
+            logging.info('Calling stop logic for session')
             self.win._Start()  # trigger stopping logic after window
             # stop FIB if running
             if self.win.StartExcitation.isChecked():
                 self.win.StartExcitation.setChecked(False)
                 # delay stopping fib for 5 seconds
+                logging.info('Starting timer to stop excitation')
                 fip_stop_timer = QtCore.QTimer(timeout=self.win._StartExcitation,interval=5000)
                 fip_stop_timer.setSingleShot(True)
                 fip_stop_timer.start()

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1195,7 +1195,7 @@ class GenerateTrials():
             self.win.Start.setStyleSheet("background-color : none")
             self.win.Start.setChecked(False)
             reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
-            self.win._Stop()  # trigger stopping logic after window
+            self.win._Start()  # trigger stopping logic after window
             # stop FIB if running
             if self.win.StartExcitation.isChecked():
                 self.win.StartExcitation.setChecked(False)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1195,12 +1195,14 @@ class GenerateTrials():
             self.win.Start.setStyleSheet("background-color : none")
             self.win.Start.setChecked(False)
             reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
-            self.win._Start()  # trigger stopping logic after window
+            self.win._Stop()  # trigger stopping logic after window
             # stop FIB if running
             if self.win.StartExcitation.isChecked():
                 self.win.StartExcitation.setChecked(False)
-                self.win._StartExcitation()
-    
+                # delay stopping fib for 5 seconds
+                fip_stop_timer = QtCore.QTimer(timeout=self.win._StartExcitation,interval=5000)
+                fip_stop_timer.setSingleShot(True)
+                fip_stop_timer.start()
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''
         if self.TP_AutoReward:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Stops redundant stop popup and delays fip on automatic stop
### What issues or discussions does this update address?
- resolves issues mentioned in #805 
### Describe the expected change in behavior from the perspective of the experimenter
- if automatic stop is triggered, fip will stop after 5 seconds and session will go through stopping logic
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [ ] 446/7



