### PR TITLE
pinning harp-python version to greater than 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "aind-behavior-services<0.9",
     "pynwb",
     "requests",
-    "harp-python",
+    "harp-python>=0.3.0",
     "openpyxl",
     "deepdiff",
     "aind-data-schema==1.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main
 aind-behavior-services<0.9
 pynwb
 requests
-harp-python
+harp-python>=0.3.0
 openpyxl
 deepdiff
 aind-data-schema==1.1.0


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- pins the requirement for harp-python to greater than 0.3.0

### What issues or discussions does this update address?
- resolves #1033 
- resolves #1009 
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/766
- https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/755

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
yes




