### PR TITLE
adding 30 minute random offset to upload time

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -14,7 +14,7 @@ import yaml
 import copy
 import shutil
 from pathlib import Path
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timezone, timedelta
 import csv
 from aind_slims_api import SlimsClient
 from aind_slims_api import models
@@ -4613,7 +4613,10 @@ class Window(QMainWindow):
             if not hasattr(self, 'project_name'):
                 self.project_name = 'Behavior Platform'
 
-            schedule = self.behavior_session_model.date.strftime("%Y-%m-%d_%H-%M-%S").split('_')[0]+'_20-30-00'
+            # Upload time is 8:30 tonight, plus a random offset over a 30 minute period
+            date_format = "%Y-%m-%d_%H-%M-%S"
+            schedule = self.behavior_session_model.date.strftime(date_format).split('_')[0]+'_20-30-00'
+            schedule_time = datetime.strptime(schedule,date_format) + timedelta(seconds=np.random.randint(30*60))
             capsule_id = 'c089614a-347e-4696-b17e-86980bb782c1'
             mount = 'FIP'
 
@@ -4626,7 +4629,6 @@ class Window(QMainWindow):
                 elif Modality.BEHAVIOR_VIDEOS in stream.stream_modalities:
                     modalities['behavior-videos'] = [self.VideoFolder.replace('\\', '/')]
 
-            date_format = "%Y-%m-%d_%H-%M-%S"
             # Define contents of manifest file
             contents = {
                 'acquisition_datetime': self.behavior_session_model.date,
@@ -4643,7 +4645,7 @@ class Window(QMainWindow):
                     os.path.join(self.MetadataFolder,'session.json').replace('\\','/'),
                     os.path.join(self.MetadataFolder,'rig.json').replace('\\','/'),
                     ],
-                'schedule_time':datetime.strptime(schedule,date_format),
+                'schedule_time':schedule_time,
                 'project_name':self.project_name,
                 'script': {}
                 }

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4614,6 +4614,7 @@ class Window(QMainWindow):
                 self.project_name = 'Behavior Platform'
 
             # Upload time is 8:30 tonight, plus a random offset over a 30 minute period
+            # Random offset reduces strain on downstream servers getting many requests at once
             date_format = "%Y-%m-%d_%H-%M-%S"
             schedule = self.behavior_session_model.date.strftime(date_format).split('_')[0]+'_20-30-00'
             schedule_time = datetime.strptime(schedule,date_format) + timedelta(seconds=np.random.randint(30*60))


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Changes the upload time from 8:30 to a random time between 8:30-9pm. 

### What issues or discussions does this update address?
- This was requested by @jtyoung84 to reduce pressure on aind servers

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested in 447




