### PR TITLE
Stopping Excitation after 5 second delay

### DIFF
--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1200,9 +1200,9 @@ class GenerateTrials():
                 self.win.StartExcitation.setChecked(False)
                 # delay stopping fib for 5 seconds
                 logging.info('Starting timer to stop excitation')
-                fip_stop_timer = QtCore.QTimer(timeout=self.win._StartExcitation, interval=5000)
-                fip_stop_timer.setSingleShot(True)
-                fip_stop_timer.start()
+                self.fip_stop_timer = QtCore.QTimer(timeout=self.win._StartExcitation, interval=5000)
+                self.fip_stop_timer.setSingleShot(True)
+                self.fip_stop_timer.start()
 
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1199,8 +1199,12 @@ class GenerateTrials():
             # stop FIB if running
             if self.win.StartExcitation.isChecked():
                 self.win.StartExcitation.setChecked(False)
-                self.win._StartExcitation()
-    
+                # delay stopping fib for 5 seconds
+                logging.info('Starting timer to stop excitation')
+                fip_stop_timer = QtCore.QTimer(timeout=self.win._StartExcitation, interval=5000)
+                fip_stop_timer.setSingleShot(True)
+                fip_stop_timer.start()
+
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''
         if self.TP_AutoReward:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1195,7 +1195,6 @@ class GenerateTrials():
             self.win.Start.setStyleSheet("background-color : none")
             self.win.Start.setChecked(False)
             reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
-            self.win._Start()  # trigger stopping logic after window
             # stop FIB if running
             if self.win.StartExcitation.isChecked():
                 self.win.StartExcitation.setChecked(False)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Stopping Excitation after 5 second delay
### What issues or discussions does this update address?
- resolves issues brough up in #805 
### Describe the expected change in behavior from the perspective of the experimenter
- fib excitation will end five seconds after a session is force quite
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 447




