### PR TITLE
Only logging error for fip if mouse training stage is at certain point

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -31,7 +31,7 @@ from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 from pydantic import ValidationError
 
-from StageWidget.main import get_stage_widget
+#from StageWidget.main import get_stage_widget
 
 import foraging_gui
 import foraging_gui.rigcontrol as rigcontrol
@@ -1170,7 +1170,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
-            'schedule_path': os.path.join('Z:\\','dynamic_foraging','DynamicForagingSchedule.csv'),
+            'schedule_path': os.path.join('C:\\',r"\Users\micah.woodard\Downloads\Behavior Schedule (1).csv"),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,
@@ -3772,12 +3772,12 @@ class Window(QMainWindow):
         self.Opto_dialog.laser_2_calibration_power.setText('')
 
         # Check for Bonsai connection
-        self._ConnectBonsai()
-        if self.InitializeBonsaiSuccessfully==0:
-            logging.info('Start button pressed, but bonsai not connected')
-            self.Start.setChecked(False)
-            self.Start.setStyleSheet('background-color:none;')
-            return
+        # self._ConnectBonsai()
+        # if self.InitializeBonsaiSuccessfully==0:
+        #     logging.info('Start button pressed, but bonsai not connected')
+        #     self.Start.setChecked(False)
+        #     self.Start.setStyleSheet('background-color:none;')
+        #     return
 
         # set the flag to check drop frames
         self.to_check_drop_frames=1
@@ -3802,6 +3802,9 @@ class Window(QMainWindow):
             if hasattr(self, 'schedule') and mouse_id in self.schedule['Mouse ID'].values and mouse_id not in ['0','1','2','3','4','5','6','7','8','9','10'] : # skip if test mouse or mouse isn't in schedule or
                 FIP_Mode = self._GetInfoFromSchedule(mouse_id, 'FIP Mode')
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
+                FIP_Stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
+                current_stage = self.AutoTrain_dialog.stage_in_use
+                stages = ['STAGE_1', 'STAGE_2', 'STAGE_3', 'FINAL', 'GRADUATED', 'unknown training stage']
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),
@@ -3814,7 +3817,7 @@ class Window(QMainWindow):
                     else:
                         # Allow the session to continue, but log error
                         logging.error('Starting session with conflicting FIP information: mouse {}, FIP on, but not in schedule'.format(mouse_id))
-                elif not FIP_is_nan and self.PhotometryB.currentText()=='off':
+                elif not FIP_is_nan and self.PhotometryB.currentText()=='off' and stages.index(current_stage) >= stages.index(FIP_Stage):
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),
                                                  f'Photometry is set to "off" but schedule indicate '

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3804,9 +3804,9 @@ class Window(QMainWindow):
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
                 # remove STAGE_ string for consistency between schedule and auto-train. Schedule denotes final stage as
                 # FINAL and auto-train has STAGE_FINAL
-                first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage').split('STAGE_')[-1]
+                first_fip_stage = str(self._GetInfoFromSchedule(mouse_id, 'First FP Stage')).split('STAGE_')[-1]
                 current_stage = self.AutoTrain_dialog.stage_in_use.split('STAGE_')[-1]
-                stages = ['1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage']
+                stages = ['1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage', 'nan']
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3804,6 +3804,8 @@ class Window(QMainWindow):
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
                 first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
                 current_stage = self._GetInfoFromSchedule(mouse_id, 'Current Stage')
+                print('current stage', current_stage)
+                print('first fip stage', first_fip_stage)
                 stages = ['1', '1.1', '1.2', '2', '3', 'FINAL', 'GRADUATED', np.nan]
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3802,9 +3802,11 @@ class Window(QMainWindow):
             if hasattr(self, 'schedule') and mouse_id in self.schedule['Mouse ID'].values and mouse_id not in ['0','1','2','3','4','5','6','7','8','9','10'] : # skip if test mouse or mouse isn't in schedule or
                 FIP_Mode = self._GetInfoFromSchedule(mouse_id, 'FIP Mode')
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
-                first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
-                current_stage = self.AutoTrain_dialog.stage_in_use
-                stages = ['STAGE_1', 'STAGE_2', 'STAGE_3', 'FINAL', 'GRADUATED', 'unknown training stage']
+                # remove STAGE_ string for consistency between schedule and auto-train. Schedule denotes final stage as
+                # FINAL and auto-train has STAGE_FINAL
+                first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage').split('STAGE_')[-1]
+                current_stage = self.AutoTrain_dialog.stage_in_use.split('STAGE_')[-1]
+                stages = ['1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage']
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3804,7 +3804,7 @@ class Window(QMainWindow):
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
                 first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
                 current_stage = self._GetInfoFromSchedule(mouse_id, 'Current Stage')
-                stages = ['1', '1.1', '1.2', '2', '3', 'FINAL', 'GRADUATED', np.nan()]
+                stages = ['1', '1.1', '1.2', '2', '3', 'FINAL', 'GRADUATED', np.nan]
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3803,10 +3803,8 @@ class Window(QMainWindow):
                 FIP_Mode = self._GetInfoFromSchedule(mouse_id, 'FIP Mode')
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
                 first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
-                current_stage = self._GetInfoFromSchedule(mouse_id, 'Current Stage')
-                print('current stage', current_stage)
-                print('first fip stage', first_fip_stage)
-                stages = ['1', '1.1', '1.2', '2', '3', 'FINAL', 'GRADUATED', np.nan]
+                current_stage = self.AutoTrain_dialog.stage_in_use
+                stages = ['STAGE_1', 'STAGE_2', 'STAGE_3', 'FINAL', 'GRADUATED', 'unknown training stage']
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3802,9 +3802,9 @@ class Window(QMainWindow):
             if hasattr(self, 'schedule') and mouse_id in self.schedule['Mouse ID'].values and mouse_id not in ['0','1','2','3','4','5','6','7','8','9','10'] : # skip if test mouse or mouse isn't in schedule or
                 FIP_Mode = self._GetInfoFromSchedule(mouse_id, 'FIP Mode')
                 FIP_is_nan = (isinstance(FIP_Mode, float) and math.isnan(FIP_Mode)) or FIP_Mode is None
-                FIP_Stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
-                current_stage = self.AutoTrain_dialog.stage_in_use
-                stages = ['STAGE_1', 'STAGE_2', 'STAGE_3', 'FINAL', 'GRADUATED', 'unknown training stage']
+                first_fip_stage = self._GetInfoFromSchedule(mouse_id, 'First FP Stage')
+                current_stage = self._GetInfoFromSchedule(mouse_id, 'Current Stage')
+                stages = ['1', '1.1', '1.2', '2', '3', 'FINAL', 'GRADUATED', np.nan()]
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),
@@ -3817,7 +3817,7 @@ class Window(QMainWindow):
                     else:
                         # Allow the session to continue, but log error
                         logging.error('Starting session with conflicting FIP information: mouse {}, FIP on, but not in schedule'.format(mouse_id))
-                elif not FIP_is_nan and self.PhotometryB.currentText()=='off' and stages.index(current_stage) >= stages.index(FIP_Stage):
+                elif not FIP_is_nan and self.PhotometryB.currentText()=='off' and stages.index(current_stage) >= stages.index(first_fip_stage):
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),
                                                  f'Photometry is set to "off" but schedule indicate '

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -31,7 +31,7 @@ from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 from pydantic import ValidationError
 
-#from StageWidget.main import get_stage_widget
+from StageWidget.main import get_stage_widget
 
 import foraging_gui
 import foraging_gui.rigcontrol as rigcontrol
@@ -1170,7 +1170,7 @@ class Window(QMainWindow):
             'metadata_dialog_folder':os.path.join(self.SettingFolder,"metadata_dialog")+'\\',
             'rig_metadata_folder':os.path.join(self.SettingFolder,"rig_metadata")+'\\',
             'project_info_file':os.path.join(self.SettingFolder,"Project Name and Funding Source v2.csv"),
-            'schedule_path': os.path.join('C:\\',r"\Users\micah.woodard\Downloads\Behavior Schedule (1).csv"),
+            'schedule_path': os.path.join('Z:\\','dynamic_foraging','DynamicForagingSchedule.csv'),
             'go_cue_decibel_box1':60,
             'go_cue_decibel_box2':60,
             'go_cue_decibel_box3':60,
@@ -3772,12 +3772,12 @@ class Window(QMainWindow):
         self.Opto_dialog.laser_2_calibration_power.setText('')
 
         # Check for Bonsai connection
-        # self._ConnectBonsai()
-        # if self.InitializeBonsaiSuccessfully==0:
-        #     logging.info('Start button pressed, but bonsai not connected')
-        #     self.Start.setChecked(False)
-        #     self.Start.setStyleSheet('background-color:none;')
-        #     return
+        self._ConnectBonsai()
+        if self.InitializeBonsaiSuccessfully==0:
+            logging.info('Start button pressed, but bonsai not connected')
+            self.Start.setChecked(False)
+            self.Start.setStyleSheet('background-color:none;')
+            return
 
         # set the flag to check drop frames
         self.to_check_drop_frames=1

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3806,9 +3806,7 @@ class Window(QMainWindow):
                 # FINAL and auto-train has STAGE_FINAL
                 first_fip_stage = str(self._GetInfoFromSchedule(mouse_id, 'First FP Stage')).split('STAGE_')[-1]
                 current_stage = self.AutoTrain_dialog.stage_in_use.split('STAGE_')[-1]
-                stages = ['1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage', 'nan']
-                print(current_stage, first_fip_stage, stages.index(current_stage), stages.index(first_fip_stage))
-                print(not FIP_is_nan, self.PhotometryB.currentText()=='off', stages.index(current_stage) >= stages.index(first_fip_stage))
+                stages = ['nan', '1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage']
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3807,6 +3807,8 @@ class Window(QMainWindow):
                 first_fip_stage = str(self._GetInfoFromSchedule(mouse_id, 'First FP Stage')).split('STAGE_')[-1]
                 current_stage = self.AutoTrain_dialog.stage_in_use.split('STAGE_')[-1]
                 stages = ['1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage', 'nan']
+                print(current_stage, first_fip_stage, stages.index(current_stage), stages.index(first_fip_stage))
+                print(not FIP_is_nan, self.PhotometryB.currentText()=='off', stages.index(current_stage) >= stages.index(first_fip_stage))
                 if FIP_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -49,6 +49,7 @@ from foraging_gui.RigJsonBuilder import build_rig_json
 from aind_data_schema.core.session import Session
 from aind_data_schema_models.modalities import Modality
 from aind_behavior_services.session import AindBehaviorSessionModel
+from aind_auto_train.schema.task import TrainingStage
 
 logger = logging.getLogger(__name__)
 logger.root.handlers.clear() # clear handlers so console output can be configured
@@ -3807,7 +3808,7 @@ class Window(QMainWindow):
                 # FINAL and auto-train has STAGE_FINAL
                 first_fip_stage = str(self._GetInfoFromSchedule(mouse_id, 'First FP Stage')).split('STAGE_')[-1]
                 current_stage = self.AutoTrain_dialog.stage_in_use.split('STAGE_')[-1]
-                stages = ['nan', '1', '2', '3', 'FINAL', 'GRADUATED', 'unknown training stage']
+                stages = ['nan'] + [ts.name.split('STAGE_')[-1] for ts in TrainingStage] + ['unknown training stage']
                 if fip_is_nan and self.PhotometryB.currentText()=='on':
                     reply = QMessageBox.critical(self,
                                                  'Box {}, Start'.format(self.box_letter),


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- check schedule for what stage mouse will start fip and only log errors for fip if mouse training stage is at certain point
### What issues or discussions does this update address?
- resolves #1045 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446




