### PR TITLE
Update ignore trials stopping logic

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2815,7 +2815,7 @@ class AutoTrainDialog(QDialog):
             for widget in self.widgets_locked_by_auto_train:
                 # Exclude some fields so that RAs can change them without going off-curriculum
                 # See https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/620
-                if widget.objectName() in ["StopIgnores", "MaxTrial", "MaxTime"]:
+                if widget.objectName() in ["auto_stop_ignore_win", "MaxTrial", "MaxTime"]:
                     continue
                 widget.setEnabled(False)
                 # set the border color to green

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -31,7 +31,7 @@ from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 from pydantic import ValidationError
 
-#from StageWidget.main import get_stage_widget
+from StageWidget.main import get_stage_widget
 
 import foraging_gui
 import foraging_gui.rigcontrol as rigcontrol

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -31,7 +31,7 @@ from pyOSC3.OSC3 import OSCStreamingClient
 import webbrowser
 from pydantic import ValidationError
 
-from StageWidget.main import get_stage_widget
+#from StageWidget.main import get_stage_widget
 
 import foraging_gui
 import foraging_gui.rigcontrol as rigcontrol

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -3567,7 +3567,7 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="12" column="5">
+                      <item row="12" column="13">
                        <widget class="QLabel" name="label_57">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -3982,7 +3982,7 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="12" column="6">
+                      <item row="12" column="14">
                        <widget class="QLineEdit" name="MaxTrial">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -4234,7 +4234,7 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="12" column="13">
+                      <item row="12" column="5">
                        <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4253,7 +4253,7 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="12" column="14">
+                      <item row="12" column="6">
                        <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -4197,6 +4197,44 @@ Double dipping:
                        </widget>
                       </item>
                       <item row="12" column="11">
+                       <widget class="QLabel" name="min_time_label">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>min time (min):</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="12" column="12">
+                       <widget class="QLineEdit" name="min_time">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>70</width>
+                          <height>16777215</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string>30</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="12" column="13">
                        <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -4215,7 +4253,7 @@ Double dipping:
                         </property>
                        </widget>
                       </item>
-                      <item row="12" column="12">
+                      <item row="12" column="14">
                        <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">

--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -3414,7 +3414,7 @@ Double dipping:
                        </widget>
                       </item>
                       <item row="12" column="3">
-                       <widget class="QLineEdit" name="StopIgnores">
+                       <widget class="QLineEdit" name="auto_stop_ignore_win">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                           <horstretch>0</horstretch>
@@ -3428,7 +3428,7 @@ Double dipping:
                          </size>
                         </property>
                         <property name="text">
-                         <string>20</string>
+                         <string>30</string>
                         </property>
                        </widget>
                       </item>
@@ -3904,7 +3904,7 @@ Double dipping:
                        </widget>
                       </item>
                       <item row="12" column="2">
-                       <widget class="QLabel" name="label_51">
+                       <widget class="QLabel" name="auto_stop_ignore_win_label">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                           <horstretch>0</horstretch>
@@ -3912,7 +3912,7 @@ Double dipping:
                          </sizepolicy>
                         </property>
                         <property name="text">
-                         <string>stop ignores&gt;</string>
+                         <string>auto stop ignore window:</string>
                         </property>
                         <property name="textFormat">
                          <enum>Qt::AutoText</enum>
@@ -4193,6 +4193,44 @@ Double dipping:
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="12" column="11">
+                       <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="text">
+                         <string>auto stop ignore ratio threshold:</string>
+                        </property>
+                        <property name="textFormat">
+                         <enum>Qt::AutoText</enum>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item row="12" column="12">
+                       <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
+                        <property name="sizePolicy">
+                         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                          <horstretch>0</horstretch>
+                          <verstretch>0</verstretch>
+                         </sizepolicy>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>70</width>
+                          <height>16777215</height>
+                         </size>
+                        </property>
+                        <property name="text">
+                         <string>.8</string>
                         </property>
                        </widget>
                       </item>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1170,50 +1170,6 @@
       <string>1</string>
      </property>
     </widget>
-    <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
-     <property name="geometry">
-      <rect>
-       <x>1080</x>
-       <y>232</y>
-       <width>67</width>
-       <height>16</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>auto stop ignore ratio threshold:</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
-     <property name="geometry">
-      <rect>
-       <x>1150</x>
-       <y>232</y>
-       <width>80</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>.8</string>
-     </property>
-    </widget>
     <widget class="QLabel" name="label_52">
      <property name="geometry">
       <rect>
@@ -2135,7 +2091,7 @@
     <widget class="QLabel" name="label_57">
      <property name="geometry">
       <rect>
-       <x>320</x>
+       <x>339</x>
        <y>315</y>
        <width>67</width>
        <height>16</height>
@@ -2160,7 +2116,7 @@
     <widget class="QLineEdit" name="MaxTrial">
      <property name="geometry">
       <rect>
-       <x>400</x>
+       <x>402</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>
@@ -2179,7 +2135,7 @@
     <widget class="QLineEdit" name="MaxTime">
      <property name="geometry">
       <rect>
-       <x>581</x>
+       <x>613</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>
@@ -2198,7 +2154,7 @@
     <widget class="QLabel" name="label_58">
      <property name="geometry">
       <rect>
-       <x>490</x>
+       <x>512</x>
        <y>315</y>
        <width>91</width>
        <height>20</height>
@@ -2223,7 +2179,7 @@
      <widget class="QLineEdit" name="min_time">
      <property name="geometry">
       <rect>
-       <x>772</x>
+       <x>863</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>
@@ -2242,7 +2198,7 @@
     <widget class="QLabel" name="min_time_label">
      <property name="geometry">
       <rect>
-       <x>681</x>
+       <x>762</x>
        <y>315</y>
        <width>91</width>
        <height>20</height>
@@ -2267,7 +2223,7 @@
     <widget class="QLabel" name="auto_stop_ignore_win_label">
      <property name="geometry">
       <rect>
-       <x>150</x>
+       <x>105</x>
        <y>315</y>
        <width>75</width>
        <height>16</height>
@@ -2292,7 +2248,7 @@
     <widget class="QLineEdit" name="auto_stop_ignore_win">
      <property name="geometry">
       <rect>
-       <x>230</x>
+       <x>190</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>
@@ -2324,7 +2280,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>auto stop ignore ratio threshold:</string>
+      <string>ignore ratio threshold:</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
@@ -2336,7 +2292,7 @@
     <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
      <property name="geometry">
       <rect>
-       <x>1072</x>
+       <x>1081</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1170,7 +1170,7 @@
       <string>1</string>
      </property>
     </widget>
-    <widget class="QLabel" name="label_51">
+    <widget class="QLabel" name="auto_stop_ignore_win_label">
      <property name="geometry">
       <rect>
        <x>542</x>
@@ -1186,7 +1186,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>stop ignores&gt;</string>
+      <string>auto stop ignore window:</string>
      </property>
      <property name="textFormat">
       <enum>Qt::AutoText</enum>
@@ -1195,7 +1195,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLineEdit" name="StopIgnores">
+    <widget class="QLineEdit" name="auto_stop_ignore_win">
      <property name="geometry">
       <rect>
        <x>614</x>
@@ -1211,7 +1211,51 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>20</string>
+      <string>30</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
+     <property name="geometry">
+      <rect>
+       <x>1080</x>
+       <y>232</y>
+       <width>67</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>auto stop ignore ratio threshold:</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
+     <property name="geometry">
+      <rect>
+       <x>1150</x>
+       <y>232</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>.8</string>
      </property>
     </widget>
     <widget class="QLabel" name="label_52">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -1170,50 +1170,6 @@
       <string>1</string>
      </property>
     </widget>
-    <widget class="QLabel" name="auto_stop_ignore_win_label">
-     <property name="geometry">
-      <rect>
-       <x>542</x>
-       <y>232</y>
-       <width>67</width>
-       <height>16</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>auto stop ignore window:</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="auto_stop_ignore_win">
-     <property name="geometry">
-      <rect>
-       <x>614</x>
-       <y>232</y>
-       <width>80</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>30</string>
-     </property>
-    </widget>
     <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
      <property name="geometry">
       <rect>
@@ -1669,94 +1625,6 @@
      </property>
      <property name="text">
       <string>0.1,0.3,0.7</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_57">
-     <property name="geometry">
-      <rect>
-       <x>790</x>
-       <y>232</y>
-       <width>67</width>
-       <height>16</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>max trial=</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="MaxTrial">
-     <property name="geometry">
-      <rect>
-       <x>863</x>
-       <y>232</y>
-       <width>80</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>1000</string>
-     </property>
-    </widget>
-    <widget class="QLineEdit" name="MaxTime">
-     <property name="geometry">
-      <rect>
-       <x>1080</x>
-       <y>232</y>
-       <width>80</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>120</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_58">
-     <property name="geometry">
-      <rect>
-       <x>983</x>
-       <y>232</y>
-       <width>91</width>
-       <height>20</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>max time (min)=</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::AutoText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
     <widget class="QComboBox" name="AutoWaterType">
@@ -2240,6 +2108,248 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="auto_stop_group">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>315</y>
+       <width>79</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Auto stop:</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_57">
+     <property name="geometry">
+      <rect>
+       <x>320</x>
+       <y>315</y>
+       <width>67</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>max trial=</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="MaxTrial">
+     <property name="geometry">
+      <rect>
+       <x>400</x>
+       <y>312</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>1000</string>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="MaxTime">
+     <property name="geometry">
+      <rect>
+       <x>581</x>
+       <y>312</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>120</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_58">
+     <property name="geometry">
+      <rect>
+       <x>490</x>
+       <y>315</y>
+       <width>91</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>max time (min)=</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+     <widget class="QLineEdit" name="min_time">
+     <property name="geometry">
+      <rect>
+       <x>772</x>
+       <y>312</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>30</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="min_time_label">
+     <property name="geometry">
+      <rect>
+       <x>681</x>
+       <y>315</y>
+       <width>91</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>min time (min)=</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="auto_stop_ignore_win_label">
+     <property name="geometry">
+      <rect>
+       <x>150</x>
+       <y>315</y>
+       <width>75</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>ignore window:</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="auto_stop_ignore_win">
+     <property name="geometry">
+      <rect>
+       <x>230</x>
+       <y>312</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>30</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
+     <property name="geometry">
+      <rect>
+       <x>882</x>
+       <y>315</y>
+       <width>180</width>
+       <height>16</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>auto stop ignore ratio threshold:</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::AutoText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+    <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
+     <property name="geometry">
+      <rect>
+       <x>1072</x>
+       <y>312</y>
+       <width>80</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>.8</string>
      </property>
     </widget>
     <widget class="QLabel" name="label_62">

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2091,7 +2091,7 @@
     <widget class="QLabel" name="label_57">
      <property name="geometry">
       <rect>
-       <x>339</x>
+       <x>1004</x>
        <y>315</y>
        <width>67</width>
        <height>16</height>
@@ -2116,7 +2116,7 @@
     <widget class="QLineEdit" name="MaxTrial">
      <property name="geometry">
       <rect>
-       <x>402</x>
+       <x>1081</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>
@@ -2267,7 +2267,7 @@
     <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
      <property name="geometry">
       <rect>
-       <x>882</x>
+       <x>212</x>
        <y>315</y>
        <width>180</width>
        <height>16</height>
@@ -2292,7 +2292,7 @@
     <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
      <property name="geometry">
       <rect>
-       <x>1081</x>
+       <x>402</x>
        <y>312</y>
        <width>80</width>
        <height>20</height>

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1170,7 +1170,8 @@ class GenerateTrials():
         # Check for reasons to stop early 
         non_auto_reward = self.B_AnimalResponseHistory[np.where(~self.TP_AutoReward)]   # isolate non-auto-reward trials
         win_sz = self.TP_auto_stop_ignore_win
-        if non_auto_reward.shape[0] > win_sz and non_auto_reward[-win_sz:][np.where(2)].shape[0] >= StopIgnore:
+        if self.BS_CurrentRunningTime >= 30 and \
+                non_auto_reward.shape[0] > win_sz and non_auto_reward[-win_sz:][np.where(2)].shape[0] >= StopIgnore:
             stop=True
             msg = f'Stopping the session because the mouse has ignored at least ' \
                   f'{self.TP_auto_stop_ignore_ratio_threshold*100}% of {self.TP_auto_stop_ignore_win} ' \

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1167,8 +1167,9 @@ class GenerateTrials():
         msg =''
         warning_label_text = ''
 
-        # Check for reasons to stop early 
-        non_auto_reward = self.B_AnimalResponseHistory[np.where(~self.TP_AutoReward)]   # isolate non-auto-reward trials
+        # Check for reasons to stop early
+        auto_rewards = np.array([any(x) for x in np.column_stack(self.B_AutoWaterTrial.astype(bool))])
+        non_auto_reward = self.B_AnimalResponseHistory[np.where(~auto_rewards)]   # isolate non-auto-reward trials
         win_sz = self.TP_auto_stop_ignore_win
         if self.BS_CurrentRunningTime >= 30 and \
                 non_auto_reward.shape[0] > win_sz and non_auto_reward[-win_sz:][np.where(2)].shape[0] >= StopIgnore:

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1172,7 +1172,7 @@ class GenerateTrials():
         non_auto_reward = self.B_AnimalResponseHistory[np.where(~auto_rewards.astype(bool))]   # isolate non-auto-reward
         win_sz = int(self.TP_auto_stop_ignore_win)
         min_time = int(self.TP_min_time)
-        if self.BS_CurrentRunningTime/60 >= 30 and len(np.where(non_auto_reward[-win_sz:] == 2)[0]) >= StopIgnore:
+        if self.BS_CurrentRunningTime/60 >= min_time and len(np.where(non_auto_reward[-win_sz:] == 2)[0]) >= StopIgnore:
             stop=True
             threshold = float(self.TP_auto_stop_ignore_ratio_threshold)*100
             msg = f'Stopping the session because the mouse has ignored at least ' \

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1171,8 +1171,8 @@ class GenerateTrials():
         auto_rewards = np.array([any(x) for x in np.column_stack(self.B_AutoWaterTrial.astype(bool))])
         non_auto_reward = self.B_AnimalResponseHistory[np.where(~auto_rewards.astype(bool))]   # isolate non-auto-reward
         win_sz = int(self.TP_auto_stop_ignore_win)
-
-        if self.BS_CurrentRunningTime >= 30 and len(np.where(non_auto_reward[-win_sz:] == 2)[0]) >= StopIgnore:
+        min_time = int(self.TP_min_time)
+        if self.BS_CurrentRunningTime/60 >= 30 and len(np.where(non_auto_reward[-win_sz:] == 2)[0]) >= StopIgnore:
             stop=True
             threshold = float(self.TP_auto_stop_ignore_ratio_threshold)*100
             msg = f'Stopping the session because the mouse has ignored at least ' \

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1154,10 +1154,10 @@ class GenerateTrials():
      
     def _CheckStop(self):
         '''Stop if there are many ingoral trials or if the maximam trial is exceeded MaxTrial'''
-        StopIgnore=round(self.TP_auto_stop_ignore_ratio_threshold*self.TP_auto_stop_ignore_win)
+        StopIgnore=round(float(self.TP_auto_stop_ignore_ratio_threshold)*int(self.TP_auto_stop_ignore_win))
         MaxTrial=int(self.TP_MaxTrial)-2 # trial number starts from 0
         MaxTime=float(self.TP_MaxTime)*60 # convert minutes to seconds
-        if hasattr(self, 'BS_CurrentRunningTime'): 
+        if hasattr(self, 'BS_CurrentRunningTime'):
             pass
         else:
             self.BS_CurrentRunningTime=0
@@ -1169,16 +1169,17 @@ class GenerateTrials():
 
         # Check for reasons to stop early
         auto_rewards = np.array([any(x) for x in np.column_stack(self.B_AutoWaterTrial.astype(bool))])
-        non_auto_reward = self.B_AnimalResponseHistory[np.where(~auto_rewards)]   # isolate non-auto-reward trials
-        win_sz = self.TP_auto_stop_ignore_win
-        if self.BS_CurrentRunningTime >= 30 and \
-                non_auto_reward.shape[0] > win_sz and non_auto_reward[-win_sz:][np.where(2)].shape[0] >= StopIgnore:
+        non_auto_reward = self.B_AnimalResponseHistory[np.where(~auto_rewards.astype(bool))]   # isolate non-auto-reward
+        win_sz = int(self.TP_auto_stop_ignore_win)
+
+        if self.BS_CurrentRunningTime >= 30 and len(np.where(non_auto_reward[-win_sz:] == 2)[0]) >= StopIgnore:
             stop=True
+            threshold = float(self.TP_auto_stop_ignore_ratio_threshold)*100
             msg = f'Stopping the session because the mouse has ignored at least ' \
-                  f'{self.TP_auto_stop_ignore_ratio_threshold*100}% of {self.TP_auto_stop_ignore_win} ' \
+                  f'{threshold}% of {self.TP_auto_stop_ignore_win} ' \
                   f'consecutive trials'
             warning_label_text = 'Stop because ignore trials exceed or equal: '+\
-                                 f'{self.TP_auto_stop_ignore_ratio_threshold*100}% of {self.TP_auto_stop_ignore_win}'
+                                 f'{threshold}% of {self.TP_auto_stop_ignore_win}'
         elif self.B_CurrentTrialN>MaxTrial: 
             stop=True
             msg = 'Stopping the session because the mouse has reached the maximum trial count: {}'.format(self.TP_MaxTrial)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- add two training parameters auto_stop_ignore_win (default = 30) and auto_stop_ignore_ratio_threshold (default = 0.8) 
- after each trial, if session_time > 30 min and if  percentage of ignored on-autowater trials exceeds auto_stop_ignore_ratio_threshold, automatically stop the session
### What issues or discussions does this update address?
- resolves [#680](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/680)
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446




