### PR TITLE
Adds a note to users about test IDs

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -52,7 +52,7 @@ class MouseSelectorDialog(QDialog):
         combo.setFont(font)
         self.combo = combo
         
-        msg = QLabel('Enter the Mouse ID: \n (use 0-9, single digit as test IDs)')
+        msg = QLabel('Enter the Mouse ID: \nuse 0-9, single digit as test ID')
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -52,7 +52,7 @@ class MouseSelectorDialog(QDialog):
         combo.setFont(font)
         self.combo = combo
         
-        msg = QLabel('Enter the Mouse ID: ')
+        msg = QLabel('Enter the Mouse ID: \n (use 0-9, single digit as test IDs)')
         font = msg.font()
         font.setPointSize(12)
         msg.setFont(font)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
When loading a mouse, I changed the prompt from `Enter the Mouse ID` to `Enter the Mouse ID: use 0-9, single digit as test ID`

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/778

### Describe the expected change in behavior from the perspective of the experimenter
Instructions for using a test ID

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested in 447




