### PR TITLE
Restore dependency that was accidentally removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "aind-auto-train@git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main",
     "aind-slims-api@git+https://github.com/AllenNeuralDynamics/aind-slims-api@main",
     "aind-dynamic-foraging-models@git+https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-models@main",
+    "aind-behavior-services >=0.8, <0.9",
     "pynwb",
     "requests",
     "harp-python",


### PR DESCRIPTION
### Describe changes:
Dependency `aind-behavior-services` was added in #1003 but was subsequently
removed by error.

This restores that dependency.

Fixes #1118

### What issues or discussions does this update address?
Closes #1118.

### Describe the expected change in behavior from the perspective of the experimenter
Experimenter can install the package.

### Describe any manual update steps for task computers
None

### Was this update tested in 446/447?
Yes




