### PR TITLE
Fix B_StagePositions keyerror

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3172,8 +3172,8 @@ class Window(QMainWindow):
 
             #Set stage position to last position
             try:
-                last_positions = Obj['B_StagePositions'][-1]
-                if 'B_StagePositions' in Obj:
+                if 'B_StagePositions' in Obj.keys():
+                    last_positions = Obj['B_StagePositions'][-1]
                     if hasattr(self,'current_stage'):   # newscale stage
                         self.current_stage.move_absolute_3d(float(last_positions['x']),
                                                             float(last_positions['y']),
@@ -3187,7 +3187,8 @@ class Window(QMainWindow):
                         self.stage_widget.movement_page_view.lineEdit_y2.setText(str(last_positions['y2']))
                         self.stage_widget.movement_page_view.lineEdit_z.setText(str(last_positions['z']))
                         threading.Thread(target=self.move_aind_stage).start()
-                elif 'B_NewscalePositions' in Obj:  # cross compatibility for mice run on older version of code.
+                elif 'B_NewscalePositions' in Obj.keys():  # cross compatibility for mice run on older version of code.
+                    last_positions = Obj['B_NewscalePositions'][-1]
                     self.current_stage.move_absolute_3d(float(last_positions[0]),
                                                         float(last_positions[1]),
                                                         float(last_positions[2]))

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3172,7 +3172,7 @@ class Window(QMainWindow):
 
             #Set stage position to last position
             try:
-                if 'B_StagePositions' in Obj.keys():
+                if 'B_StagePositions' in Obj.keys() and len(Obj['B_StagePositions']) != 0:
                     last_positions = Obj['B_StagePositions'][-1]
                     if hasattr(self,'current_stage'):   # newscale stage
                         self.current_stage.move_absolute_3d(float(last_positions['x']),
@@ -3187,7 +3187,7 @@ class Window(QMainWindow):
                         self.stage_widget.movement_page_view.lineEdit_y2.setText(str(last_positions['y2']))
                         self.stage_widget.movement_page_view.lineEdit_z.setText(str(last_positions['z']))
                         threading.Thread(target=self.move_aind_stage).start()
-                elif 'B_NewscalePositions' in Obj.keys():  # cross compatibility for mice run on older version of code.
+                elif 'B_NewscalePositions' in Obj.keys() and len(Obj['B_NewscalePositions']) != 0:  # cross compatibility for mice run on older version of code.
                     last_positions = Obj['B_NewscalePositions'][-1]
                     self.current_stage.move_absolute_3d(float(last_positions[0]),
                                                         float(last_positions[1]),


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- corrects logic to move stage to last position 
### What issues or discussions does this update address?
- resolves #1091 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7




