### PR TITLE
Incorrect Waterlog info fix

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1361,7 +1361,7 @@ class Window(QMainWindow):
 
         # extract software information
         logging.info('Extracting software information from first data stream')
-        software = session.data_streams[0].software[0]
+        software = session.stimulus_epochs[0].software[0]
 
         # create model
         logging.info('Creating SlimsWaterlogResult based on session information.')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1368,7 +1368,7 @@ class Window(QMainWindow):
         model = models.SlimsWaterlogResult(
             mouse_pk=mouse.pk,
             date=session.session_start_time,
-            weight_g=session.animal_weight_prior,
+            weight_g=session.animal_weight_post,
             water_earned_ml=water['water_in_session_foraging'],
             water_supplement_delivered_ml=water['water_after_session'],
             water_supplement_recommended_ml=None,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1369,6 +1369,7 @@ class Window(QMainWindow):
             mouse_pk=mouse.pk,
             date=session.session_start_time,
             weight_g=session.animal_weight_post,
+            operator=self.behavior_session_model.experimenter[0],
             water_earned_ml=water['water_in_session_foraging'],
             water_supplement_delivered_ml=water['water_after_session'],
             water_supplement_recommended_ml=None,

--- a/tash
+++ b/tash
@@ -1,0 +1,31 @@
+[1mdiff --git a/src/foraging_gui/Foraging.py b/src/foraging_gui/Foraging.py[m
+[1mindex 122706fe..b9a37510 100644[m
+[1m--- a/src/foraging_gui/Foraging.py[m
+[1m+++ b/src/foraging_gui/Foraging.py[m
+[36m@@ -9,7 +9,7 @@[m [mimport math[m
+ import logging[m
+ from hashlib import md5[m
+ [m
+[31m-import logging_loki[m
+[32m+[m[32m#import logging_loki[m
+ import socket[m
+ import harp[m
+ import threading[m
+[36m@@ -25,7 +25,7 @@[m [mfrom aind_slims_api import models[m
+ import serial[m
+ import numpy as np[m
+ import pandas as pd[m
+[31m-from pykeepass import PyKeePass[m
+[32m+[m[32m#from pykeepass import PyKeePass[m
+ from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar[m
+ from scipy.io import savemat, loadmat[m
+ from PyQt5.QtWidgets import QApplication, QMainWindow, QMessageBox, QSizePolicy[m
+[36m@@ -252,6 +252,8 @@[m [mclass Window(QMainWindow):[m
+     def _show_disk_space(self):[m
+         '''Show the disk space of the current computer'''[m
+         total, used, free = shutil.disk_usage(self.default_saveFolder)[m
+[32m+[m[32m        used = 450*1024**3[m
+[32m+[m[32m        free = total-used[m
+         self.diskspace.setText(f"Used space: {used/1024**3:.2f}GB    Free space: {free/1024**3:.2f}GB")[m
+         self.DiskSpaceProgreeBar.setValue(int(used/total*100))[m
+         if free/1024**3 < 100 or used/total > 0.9:[m


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- waterlog now record weight_g as animal_weight_post and records operator of session
### What issues or discussions does this update address?
- resolves #1155 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [ ] 446/7




