### PR TITLE
create nonmodal qmessage box so startloop can quit

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4242,6 +4242,7 @@ class Window(QMainWindow):
         stall_duration = 5*60
 
         while self.Start.isChecked():
+
             QApplication.processEvents()
             if self.ANewTrial==1 and self.Start.isChecked() and self.finish_Timer==1:
 

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -1197,7 +1197,15 @@ class GenerateTrials():
         if stop:           
             self.win.Start.setStyleSheet("background-color : none")
             self.win.Start.setChecked(False)
-            reply = QtWidgets.QMessageBox.question(self.win, 'Box {}'.format(self.win.box_letter), msg, QtWidgets.QMessageBox.Ok)
+            # create nonmodal message box so startloop can terminate
+            self.message_box = QtWidgets.QMessageBox()
+            self.message_box.setIcon(QtWidgets.QMessageBox.Warning)
+            self.message_box.setText(msg)
+            self.message_box.addButton(QtWidgets.QMessageBox.Ok)
+            self.message_box.setWindowTitle('Box {}'.format(self.win.box_letter))
+            self.message_box.setModal(False)
+            self.message_box.show()
+
             # stop FIB if running
             if self.win.StartExcitation.isChecked():
                 self.win.StartExcitation.setChecked(False)


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- if session is force quit, then QMessagebox will be nonmodal so other session logic can complete 
### What issues or discussions does this update address?
- resolves #717 and resolves #761 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7



