### PR TITLE
Feature/monument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "aind-data-schema==1.1.0",
     "aind-data-schema-models==0.5.6",
     "pydantic >=2.9.2, <3",
-    "stagewidget==1.0.4.dev4",
+    "stagewidget==1.0.4.dev5",
     "python-logging-loki >=0.3.1, <2",
     "pykeepass >=4.0.7, <5",
     "pyyaml >=6, <7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "aind-data-schema==1.1.0",
     "aind-data-schema-models==0.5.6",
     "pydantic >=2.9.2, <3",
-    "stagewidget==1.0.4.dev3",
+    "stagewidget==1.0.4.dev4",
     "python-logging-loki >=0.3.1, <2",
     "pykeepass >=4.0.7, <5",
     "pyyaml >=6, <7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "aind-data-schema==1.1.0",
     "aind-data-schema-models==0.5.6",
     "pydantic >=2.9.2, <3",
-    "stagewidget==1.0.4.dev1",
+    "stagewidget==1.0.4.dev3",
     "python-logging-loki >=0.3.1, <2",
     "pykeepass >=4.0.7, <5",
     "pyyaml >=6, <7",

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3208,7 +3208,7 @@ class Window(QMainWindow):
                             2: float(last_positions['y2']),
                             3: float(last_positions['z'])
                         }
-                        self.move_aind_stage(positions)
+                        self.stage_widget.stage_model.update_position(positions)
                         step_size = self.stage_widget.movement_page_view.lineEdit_step_size.returnPressed.emit()
                 elif 'B_NewscalePositions' in Obj.keys() and len(Obj['B_NewscalePositions']) != 0:  # cross compatibility for mice run on older version of code.
                     last_positions = Obj['B_NewscalePositions'][-1]
@@ -3249,14 +3249,6 @@ class Window(QMainWindow):
         self.keyPressEvent() # Accept all updates
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
-
-    def move_aind_stage(self, positions: dict):
-        """
-        Move all axis of stage in stage widget
-
-        :param positions: Dict where key = motor index, and value = the desired position to move the motor
-        """
-        self.stage_widget.stage_model.update_position(positions)
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -809,10 +809,12 @@ class Window(QMainWindow):
             self._UpdatePosition(current_position,(0,0,0))
             return {axis: float(pos) for axis, pos in zip(['x', 'y', 'z'], current_position) }
         elif self.stage_widget is not None:     # aind stage
-            return {'x': float(self.stage_widget.movement_page_view.lineEdit_x.text()),
-                    'y1': float(self.stage_widget.movement_page_view.lineEdit_y1.text()),
-                    'y2': float(self.stage_widget.movement_page_view.lineEdit_y2.text()),
-                    'z': float(self.stage_widget.movement_page_view.lineEdit_z.text())}
+            # Get absolute position of motors in AIND stage
+            positions = self.stage_widget.stage_model.get_current_positions_mm()
+            return {'x': positions[0],
+                    'y1': positions[1],
+                    'y2': positions[2],
+                    'z': positions[3]}
         else:   # no stage
             logging.info('GetPositions called, but no current stage')
             return None
@@ -3199,11 +3201,14 @@ class Window(QMainWindow):
                                               float(last_positions['y']),
                                               float(last_positions['z'])),(0,0,0))
                     elif self.stage_widget is not None:  # aind stage
-                        self.stage_widget.movement_page_view.lineEdit_x.setText(str(last_positions['x']))
-                        self.stage_widget.movement_page_view.lineEdit_y1.setText(str(last_positions['y1']))
-                        self.stage_widget.movement_page_view.lineEdit_y2.setText(str(last_positions['y2']))
-                        self.stage_widget.movement_page_view.lineEdit_z.setText(str(last_positions['z']))
-                        self.move_aind_stage()
+                        # Move AIND stage to the last session positions
+                        positions = {
+                            0: float(last_positions['x']),
+                            1: float(last_positions['y1']),
+                            2: float(last_positions['y2']),
+                            3: float(last_positions['z'])
+                        }
+                        self.move_aind_stage(positions)
                         step_size = self.stage_widget.movement_page_view.lineEdit_step_size.returnPressed.emit()
                 elif 'B_NewscalePositions' in Obj.keys() and len(Obj['B_NewscalePositions']) != 0:  # cross compatibility for mice run on older version of code.
                     last_positions = Obj['B_NewscalePositions'][-1]
@@ -3245,12 +3250,13 @@ class Window(QMainWindow):
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
 
-    def move_aind_stage(self):
+    def move_aind_stage(self, positions: dict):
         """
         Move all axis of stage in stage widget
+
+        :param positions: Dict where key = motor index, and value = the desired position to move the motor
         """
-        positions = self.stage_widget.movement_page_view.get_positions_from_line_edit()
-        self.stage_widget.movement_page_view.signal_position_change.emit(positions)
+        self.stage_widget.stage_model.update_position(positions)
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:

Added feature for users to set monument position (saved per rig). 
- Positions will be displayed relative to a monument position that is saved in zookeeper (ex. monument position of [1,2,2,1] will show [-1,-2,-2,-1] when stage is at origin)
- Users can save new monument positions through the widget. 

### What issues or discussions does this update address?
[SIPE Ticket](http://mpe-redirects/MPETracking/ItemID=3734)

### Describe the expected change in behavior from the perspective of the experimenter
Users now have a reference to where monument is.

### Describe any manual update steps for task computers
Normal deployment cycle. Just need to update stage widget package.

### Was this update tested in 446/447?

This was tested on FRG2A 



