### PR TITLE
Changing the lick interval errors to warnings

### DIFF
--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -927,7 +927,7 @@ class GenerateTrials():
             if same_side_frac >= threshold:
                 self.win.same_side_lick_interval.setText(f'Percentage of same side lick intervals under 100 ms is '
                                                          f'over 10%: {same_side_frac * 100:.2f}%.')
-                logging.error(f'Percentage of same side lick intervals under 100 ms in Box {self.win.box_number}'
+                logging.warning(f'Percentage of same side lick intervals under 100 ms in Box {self.win.box_number}'
                               f'{self.win.box_letter} mouse {self.win.behavior_session_model.subject} exceeded 10%')
             else:
                 self.win.same_side_lick_interval.setText('')
@@ -954,7 +954,7 @@ class GenerateTrials():
             if cross_side_frac >= threshold:
                 self.win.cross_side_lick_interval.setText(f'Percentage of cross side lick intervals under 100 ms is '
                                                           f'over 10%: {cross_side_frac * 100:.2f}%.')
-                logging.error(f'Percentage of cross side lick intervals under 100 ms in Box {self.win.box_number}'
+                logging.warning(f'Percentage of cross side lick intervals under 100 ms in Box {self.win.box_number}'
                               f'{self.win.box_letter} mouse {self.win.behavior_session_model.subject} exceeded 10%')
             else:
                 self.win.cross_side_lick_interval.setText('')
@@ -963,6 +963,7 @@ class GenerateTrials():
         '''get the number of double dipping. e.g. 0 1 0 will result in 2 double dipping''' 
         DoubleDipping=np.sum(np.diff(LicksIndex)!=0)
         return DoubleDipping
+
     def _ForagingEfficiency(self):
         pass
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Right now we generate errors when the same side, or cross side lick intervals less than a threshold are more than 10% of all lick intervals. The intent was this would notify scientists to look at their mice. That is simply not happening, and is resulting in too many issues being generated. The better solution is to use the AIND QC system to set up a automated logging system for QC evaluations. As a first step, I've changed these errors to warnings. Users will still be alerted in real time in the warning box, and the alerts will still be in the log, but no errors will be generated. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/1059

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested




