### PR TITLE
Changing dropped frame warning to error

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -710,7 +710,7 @@ class Window(QMainWindow):
                             self.drop_frames_warning_text+=f"Correct: {avi_file} has {num_frames} frames and {self.trigger_length} triggers\n"
                         self.frame_num[camera_name] = num_frames
             if self.drop_frames_tag:
-                logging.warning(self.drop_frames_warning_text, extra={'tags': [self.warning_log_tag]})
+                logging.error(self.drop_frames_warning_text, extra={'tags': [self.warning_log_tag]})
             else:
                 logging.info(self.drop_frames_warning_text, extra={'tags': [self.warning_log_tag]})
             # only check drop frames once each session


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
When we detect dropped frames, we currently generate a warning. This PR changes that to an error for easier tracking online

### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none
### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No


