### PR TITLE
fixing metadata typos

### DIFF
--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -780,7 +780,7 @@ class generate_metadata:
             trials_total= self.trials_total,
             trials_finished= self.trials_finished,
             trials_rewarded=self.trials_rewarded,
-            notes=f"The duration of go cue is 100ms. The frequency is 7500Hz. Decibel is {self.Obj['Other_go_cue_decibel']}dB. The total reward consumed in the session is {self.total_reward_consumed_in_session} microliter. The total reward indcluding consumed in the session and supplementary water is {self.Obj['TotalWater']} millimeters.",
+            notes=f"The duration of go cue is 100 ms. The frequency is 7500 Hz. Amplitude is {self.Obj['Other_go_cue_decibel']}dB. The total reward consumed in the session is {self.total_reward_consumed_in_session} microliters. The total reward including consumed in the session and supplementary water is {self.Obj['TotalWater']} milliliters.",
         ))
 
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Fixes several minor typos in the metadata
- adds a space between values and units
- corrects "millimeters" to "milliliters"
- fixes spelling of "including"
- makes units of "microliters" plural
- Changes "Decibel is 75 Db" to "Amplitude is 75 Db"

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/883
- Fixes metadata going forward, but does not retroactively fix older metadata

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- No


