### PR TITLE
logging errors on camera by camera basis

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -699,20 +699,21 @@ class Window(QMainWindow):
                     csv_file = avi_file.replace('.avi', '.csv')
                     camera_name = avi_file.replace('.avi','')
                     if csv_file not in csv_files:
-                        self.drop_frames_warning_text+=f'No csv file found for {avi_file}\n'
+                        self.drop_frames_warning_text+=f'No csv file found for {avi_file}'
                     else:
                         current_frames = pd.read_csv(os.path.join(video_folder, csv_file), header=None)
                         num_frames = len(current_frames)
                         if num_frames != self.trigger_length:
-                            self.drop_frames_warning_text+=f"Error: {avi_file} has {num_frames} frames, but {self.trigger_length} triggers\n"
+                            this_text = f"Error: {avi_file} has {num_frames} frames, but {self.trigger_length} triggers. "
+                            self.drop_frames_warning_text+= this_text
+                            logging.error(this_text, extra={'tags': [self.warning_log_tag]})
                             self.drop_frames_tag=1
                         else:
-                            self.drop_frames_warning_text+=f"Correct: {avi_file} has {num_frames} frames and {self.trigger_length} triggers\n"
+                            this_text = f"Correct: {avi_file} has {num_frames} frames and {self.trigger_length} triggers. "
+                            self.drop_frames_warning_text+= this_text
+                            logging.info(this_text, extra={'tags': [self.warning_log_tag]})
                         self.frame_num[camera_name] = num_frames
-            if self.drop_frames_tag:
-                logging.error(self.drop_frames_warning_text, extra={'tags': [self.warning_log_tag]})
-            else:
-                logging.info(self.drop_frames_warning_text, extra={'tags': [self.warning_log_tag]})
+
             # only check drop frames once each session
             self.to_check_drop_frames=0
 


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Right now, the logging errors combine all cameras into one error message. This is hard to parse, because if the first camera has no dropped frames, then the error message starts with "correct"

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/1334

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no



