### PR TITLE
Making FIP workflow restart non-blocking

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3540,18 +3540,12 @@ class Window(QMainWindow):
             self.FIP_started=False
 
         if (FIP_was_running)&(not closing):
-            #reply = QMessageBox.critical(self,
-            #    'Box {}, New Session:'.format(self.box_letter),
-            #    'Please restart the FIP workflow',
-            #    QMessageBox.Ok)
-            logging.info('DEBUG TEST')
             self.FIP_msgbox = QMessageBox()
             self.FIP_msgbox.setWindowTitle('Box {}, New Session:'.format(self.box_letter))
             self.FIP_msgbox.setText('Please restart the FIP workflow')
             self.FIP_msgbox.setStandardButtons(QMessageBox.Ok)
             self.FIP_msgbox.setModal(False)
             self.FIP_msgbox.show()
-            logging.info('DEBUG TEST 2 ')
 
     def _AutoReward(self):
         if self.AutoReward.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3545,12 +3545,12 @@ class Window(QMainWindow):
             #    'Please restart the FIP workflow',
             #    QMessageBox.Ok)
             logging.info('DEBUG TEST')
-            msgbox = QMessageBox()
-            msgbox.setWindowTitle('Box {}, New Session:'.format(self.box_letter))
-            msgbox.setText('Please restart the FIP workflow')
-            msgbox.setStandardButtons(QMessageBox.Ok)
-            msgbox.setModal(False)
-            msgbox.show()
+            self.FIP_msgbox = QMessageBox()
+            self.FIP_msgbox.setWindowTitle('Box {}, New Session:'.format(self.box_letter))
+            self.FIP_msgbox.setText('Please restart the FIP workflow')
+            self.FIP_msgbox.setStandardButtons(QMessageBox.Ok)
+            self.FIP_msgbox.setModal(False)
+            self.FIP_msgbox.show()
             logging.info('DEBUG TEST 2 ')
 
     def _AutoReward(self):

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3540,10 +3540,16 @@ class Window(QMainWindow):
             self.FIP_started=False
 
         if (FIP_was_running)&(not closing):
-            reply = QMessageBox.critical(self,
-                'Box {}, New Session:'.format(self.box_letter),
-                'Please restart the FIP workflow',
-                QMessageBox.Ok)
+            #reply = QMessageBox.critical(self,
+            #    'Box {}, New Session:'.format(self.box_letter),
+            #    'Please restart the FIP workflow',
+            #    QMessageBox.Ok)
+            msgbox = QMessageBox()
+            msgbox.setWindowTitle('Box {}, New Session:'.format(self.box_letter))
+            msgbox.setText('Please restart the FIP workflow')
+            msgbox.setStandardButtons(QMessageBox.Ok)
+            msgbox.setModal(False)
+            msgbox.show()
 
     def _AutoReward(self):
         if self.AutoReward.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3544,12 +3544,14 @@ class Window(QMainWindow):
             #    'Box {}, New Session:'.format(self.box_letter),
             #    'Please restart the FIP workflow',
             #    QMessageBox.Ok)
+            logging.info('DEBUG TEST')
             msgbox = QMessageBox()
             msgbox.setWindowTitle('Box {}, New Session:'.format(self.box_letter))
             msgbox.setText('Please restart the FIP workflow')
             msgbox.setStandardButtons(QMessageBox.Ok)
             msgbox.setModal(False)
             msgbox.show()
+            logging.info('DEBUG TEST 2 ')
 
     def _AutoReward(self):
         if self.AutoReward.isChecked():


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
FIP workflow restart reminder is non-blocking

### What issues or discussions does this update address?
- resolves [#888](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/888)

### Describe the expected change in behavior from the perspective of the experimenter
- When an FIP session saves, you will still be prompted to close the FIP workflow. But the GUI will not wait for you to hit OK before saving the session.

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested in 447

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- No


