### PR TITLE
removing Go Cue Decibel from metadata dialog

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1835,7 +1835,6 @@ class MetadataDialog(QDialog):
         self.meta_data['rig_metadata'] = {}
         self.meta_data['session_metadata'] = {}
         self.meta_data['rig_metadata_file'] = ''
-        self.GoCueDecibel.setText(str(self.MainWindow.Other_go_cue_decibel))
         self.LickSpoutDistance.setText(str(self.MainWindow.Other_lick_spout_distance))
         self._get_basics()
         self._show_project_names()
@@ -1874,7 +1873,6 @@ class MetadataDialog(QDialog):
         self.Stick_ModuleAngle.textChanged.connect(self._save_configuration)
         self.Stick_RotationAngle.textChanged.connect(self._save_configuration)
         self.ProjectName.currentIndexChanged.connect(self._show_project_info)
-        self.GoCueDecibel.textChanged.connect(self._save_go_cue_decibel)
         self.LickSpoutDistance.textChanged.connect(self._save_lick_spout_distance)
 
     def _set_reference(self, reference: dict):
@@ -1903,10 +1901,6 @@ class MetadataDialog(QDialog):
     def _save_lick_spout_distance(self):
         '''save the lick spout distance'''
         self.MainWindow.Other_lick_spout_distance=self.LickSpoutDistance.text()
-
-    def _save_go_cue_decibel(self):
-        '''save the go cue decibel'''
-        self.MainWindow.Other_go_cue_decibel=self.GoCueDecibel.text()
 
     def _show_project_names(self):
         '''show the project names from the project spreadsheet'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1928,7 +1928,7 @@ class Window(QMainWindow):
                         if Correct ==0: # incorrect format; don't change
                             child.setText(getattr(Parameters, 'TP_'+child.objectName()))
                         continue
-                    if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight','','GoCueDecibel','ConditionP_5','ConditionP_6','Duration_5','Duration_6','OffsetEnd_5','OffsetEnd_6','OffsetStart_5','OffsetStart_6','Probability_5','Probability_6','PulseDur_5','PulseDur_6','RD_5','RD_6']) and
+                    if ((child.objectName() in ['PositionX','PositionY','PositionZ','SuggestedWater','BaseWeight','TargetWeight','','ConditionP_5','ConditionP_6','Duration_5','Duration_6','OffsetEnd_5','OffsetEnd_6','OffsetStart_5','OffsetStart_6','Probability_5','Probability_6','PulseDur_5','PulseDur_6','RD_5','RD_6']) and
                         (child.text() == '')):
                         # These attributes can have the empty string, but we can't set the value as the empty string, unless we allow resets
                         if allow_reset:

--- a/src/foraging_gui/MetaData.ui
+++ b/src/foraging_gui/MetaData.ui
@@ -1279,7 +1279,6 @@ p, li { white-space: pre-wrap; }
   <zorder>DataDescription</zorder>
   <zorder>LoadMeta</zorder>
   <zorder>label_83</zorder>
-  <zorder>GoCueDecibel</zorder>
   <zorder>groupBox</zorder>
  </widget>
  <tabstops>
@@ -1308,7 +1307,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>ManipulatorX</tabstop>
   <tabstop>ManipulatorZ</tabstop>
   <tabstop>ManipulatorY</tabstop>
-  <tabstop>GoCueDecibel</tabstop>
   <tabstop>Fundee</tabstop>
   <tabstop>LickSpoutReferenceArea</tabstop>
  </tabstops>

--- a/src/foraging_gui/MetaData.ui
+++ b/src/foraging_gui/MetaData.ui
@@ -1162,50 +1162,6 @@ p, li { white-space: pre-wrap; }
     </property>
    </widget>
   </widget>
-  <widget class="QLabel" name="label_83">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>280</y>
-     <width>90</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="text">
-    <string>Go cue (db):</string>
-   </property>
-   <property name="textFormat">
-    <enum>Qt::AutoText</enum>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLineEdit" name="GoCueDecibel">
-   <property name="geometry">
-    <rect>
-     <x>120</x>
-     <y>280</y>
-     <width>70</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="text">
-    <string/>
-   </property>
-  </widget>
   <widget class="QGroupBox" name="groupBox">
    <property name="geometry">
     <rect>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Right now, the go cue amplitude is saved in Settings_box.csv, and also can be manually entered on the Metadata dialog. This means there are two sources of truth, and the metadata dialog can accidently be modified. I removed the metadata dialog version, since this has to be calibrated and set in the settings file. 

### What issues or discussions does this update address?
- resolves #1345 
- I think this is also why we are getting pydantic validation errors from the empty string

### Describe the expected change in behavior from the perspective of the experimenter
- You cannot modify the go cue amplitude in the metadata dialog

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


