### PR TITLE
Adding valve name to error logging

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1096,7 +1096,7 @@ class WaterCalibrationDialog(QDialog):
             if reply == QMessageBox.Cancel:
                 logging.warning('Spot check discarded due to type', extra={'tags': self.MainWindow.warning_log_tag})
             else:
-                logging.error('Water calibration spot check exceeds tolerance: {}'.format(error))
+                logging.error('Water calibration spot check, {}, exceeds tolerance: {}'.format(valve,error))
                 save.setStyleSheet("color: white;background-color : mediumorchid;")
                 self.Warning.setText(
                     f'Measuring {valve.lower()} valve: {volume}uL' + \
@@ -1106,8 +1106,8 @@ class WaterCalibrationDialog(QDialog):
                 )
                 self._SaveValve(valve)
                 if self.check_spot_failures(valve) >= 2:
-                    msg = 'Two or more spot checks have failed in the last 30 days. Please create a SIPE ticket to ' \
-                          'check rig.'
+                    msg = 'Two or more spot checks, {}, have failed in the last 30 days. Please create a SIPE ticket to ' \
+                          'check rig.'.format(valve)
                     logging.error(msg, extra={'tags': self.MainWindow.warning_log_tag})
                     QMessageBox.critical(self, f'Spot check {valve}', msg, QMessageBox.Ok)
         else:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Adds the name of the valve (left/right) to error messages about spot check failures

### What issues or discussions does this update address?
resolves https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/113#issuecomment-2648957376

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


