### PR TITLE
Fix ephys rig naming convention

### DIFF
--- a/src/foraging_gui/settings_model.py
+++ b/src/foraging_gui/settings_model.py
@@ -37,8 +37,8 @@ class BonsaiSettingsModel(BaseModel):
         description="Calibration parameter for the left channel sound stimulus"
     )
     current_box: str = Field(
-        pattern=r"^[0-9][0-9][0-9]-[0-9]+-[ABCD]$",
-        description="Box name in ROOM-TOWER-BOX format",
+        pattern=r"^[0-9][0-9][0-9](-[0-9]+-[ABCD]|_EPHYS[0-9]+|_Ephys[0-9]+)$",
+        description="Box name in ROOM-TOWER-BOX format, or ROOM-EphysNUM",
     )
     RunningWheel: Literal["0", "1"] = Field(
         default=0, description="Using AIND running wheel"


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Updates the pydantic model for the box name to allow for <ROOM>_Ephys<NUM>, or <ROOM>_EPHYS<Num>

### What issues or discussions does this update address?
 - https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/1364
 
### Describe the expected change in behavior from the perspective of the experimenter
none

### Describe any manual update steps for task computers
none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
none



