### PR TITLE
high-speed camera recording window direction fix

### DIFF
--- a/src/workflows/foraging.bonsai.layout
+++ b/src/workflows/foraging.bonsai.layout
@@ -68,8 +68,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>1506</Width>
-        <Height>895</Height>
+        <Width>550</Width>
+        <Height>644</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -586,8 +586,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>632</Width>
-        <Height>654</Height>
+        <Width>550</Width>
+        <Height>644</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -610,8 +610,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>632</Width>
-            <Height>654</Height>
+            <Width>550</Width>
+            <Height>644</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -2990,8 +2990,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>632</Width>
-        <Height>654</Height>
+        <Width>550</Width>
+        <Height>644</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -3134,8 +3134,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>632</Width>
-            <Height>654</Height>
+            <Width>550</Width>
+            <Height>644</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -3616,8 +3616,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>632</Width>
-            <Height>654</Height>
+            <Width>550</Width>
+            <Height>644</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -4148,8 +4148,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>632</Width>
-        <Height>654</Height>
+        <Width>550</Width>
+        <Height>644</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -4172,8 +4172,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>632</Width>
-            <Height>654</Height>
+            <Width>550</Width>
+            <Height>644</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -6022,8 +6022,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>632</Width>
-            <Height>654</Height>
+            <Width>550</Width>
+            <Height>644</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>
@@ -7534,12 +7534,12 @@
     <EditorDialogSettings>
       <Visible>true</Visible>
       <Location>
-        <X>909</X>
-        <Y>647</Y>
+        <X>182</X>
+        <Y>182</Y>
       </Location>
       <Size>
-        <Width>266</Width>
-        <Height>164</Height>
+        <Width>316</Width>
+        <Height>239</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -8271,7 +8271,7 @@
               <VisualizerTypeName>IplImageRotateVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <IplImageRotateVisualizer>
-                  <InvertHorizontal>false</InvertHorizontal>
+                  <InvertHorizontal>true</InvertHorizontal>
                   <InvertVertical>false</InvertVertical>
                   <RotateAngle>0</RotateAngle>
                 </IplImageRotateVisualizer>
@@ -8419,8 +8419,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>632</Width>
-        <Height>654</Height>
+        <Width>550</Width>
+        <Height>644</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -8618,8 +8618,8 @@
         <Y>3</Y>
       </Location>
       <Size>
-        <Width>632</Width>
-        <Height>654</Height>
+        <Width>550</Width>
+        <Height>644</Height>
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
@@ -8642,8 +8642,8 @@
             <Y>3</Y>
           </Location>
           <Size>
-            <Width>632</Width>
-            <Height>654</Height>
+            <Width>550</Width>
+            <Height>644</Height>
           </Size>
           <WindowState>Normal</WindowState>
         </EditorDialogSettings>


### PR DESCRIPTION
A patch to flip camera recording window to match the preview window. Originally those windows were designed to be consistent, but at one point, an inadvertently flipped local change (likely in a ephys rig) was merged. This is to revert it back.
  
### Describe changes:
Horizontal direction of the camera recording is flipped so it would match preview and the "intuitive" direction.

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/889

### Describe the expected change in behavior from the perspective of the experimenter
NA
### Describe any manual update steps for task computers
NA
### Was this update tested in 446/447?
in 447 2D
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No. Pure change in visualization.


