### PR TITLE
Use most recent experimenter name when loading mice

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2998,13 +2998,13 @@ class Window(QMainWindow):
         filepath = os.path.join(self.default_saveFolder,self.current_box)
         now = datetime.now()
         mouse_dirs = os.listdir(filepath)
-        mouse_dirs.sort(reverse=True, key=lambda x: os.path.getmtime(os.path.join(filepath, x)))   # in order of date modified
+        mouse_dirs.sort(reverse=True)
         mice = []
         experimenters = []
         for m in mouse_dirs:
             session_dir = os.path.join(self.default_saveFolder, self.current_box, str(m))
             sessions = os.listdir(session_dir)
-            sessions.sort(reverse=True, key=lambda x: os.path.getmtime(os.path.join(session_dir,x)))
+            sessions.sort(reverse=True)
             for s in sessions:
                 if 'behavior_' in s:
                     json_file = os.path.join(self.default_saveFolder,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2998,7 +2998,7 @@ class Window(QMainWindow):
         filepath = os.path.join(self.default_saveFolder,self.current_box)
         now = datetime.now()
         mouse_dirs = os.listdir(filepath)
-        mouse_dirs.sort(reverse=True)
+        mouse_dirs.sort(reverse=True, key=lambda x: os.path.getmtime(os.path.join(filepath,x))) # in order of date modified
         mice = []
         experimenters = []
         for m in mouse_dirs:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3004,6 +3004,7 @@ class Window(QMainWindow):
         for m in mouse_dirs:
             session_dir = os.path.join(self.default_saveFolder, self.current_box, str(m))
             sessions = os.listdir(session_dir)
+            sessions.sort(reverse=True, key=lambda x: os.path.getmtime(os.path.join(session_dir,x)))
             for s in sessions:
                 if 'behavior_' in s:
                     json_file = os.path.join(self.default_saveFolder,


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
When loading a mouse, the pop up currently displays the FIRST experimenter to run a mouse, rather than the most recent. This is confusing to users because inconsistent information is displayed in the loading selection box, the verification box, the GUI window, and the confirmation before starting a session. 

This PR will make this more consistent. The loading selection box, verification box, and GUI window will also show the most recent experimenter. If the user then changes the experimenter name, that new name will be used when starting the session. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/905

### Describe the expected change in behavior from the perspective of the experimenter
More consistent information about experimenter names

### Describe any manual update steps for task computers
none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
no


