### PR TITLE
changing error to info when project name is None

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1160,7 +1160,10 @@ class Window(QMainWindow):
     
         # Check if this is a valid project name
         if project_name not in self._GetApprovedAINDProjectNames():
-            logging.error('Project name {} is not valid, using default, please correct schedule'.format(project_name))
+            if project_name is not None:
+                logging.error('Project name {} is not valid, using default, please correct schedule'.format(project_name))
+            else:
+                logging.info('Project name {} is not valid, using default, please correct schedule'.format(project_name))
             project_name = None
 
         # If we have a valid name update the metadata dialog


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- We log an error when the project name on the schedule is not valid. However if the mouse is not on the schedule, or the mouse is on habituation the project name will return None. In this case we shouldn't log an error. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/125

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


