### PR TITLE
Make GenerateMetadata robust to sessions without trials

### DIFF
--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -497,6 +497,7 @@ class generate_metadata:
         self._get_water_calibration()
         self._get_opto_calibration()
         self.calibration=self.water_calibration+self.opto_calibration
+        self._get_behavior_software()
         self._get_behavior_stream()
         self._get_ephys_stream()
         self._get_ophys_stream()
@@ -1077,7 +1078,6 @@ class generate_metadata:
             daq_names=self.name_mapper['rig_daq_names_janelia_lick_detector']
 
         self.behavior_streams=[]
-        self._get_behavior_software()
         self.behavior_streams.append(Stream(
                 stream_modalities=[Modality.BEHAVIOR],
                 stream_start_time=datetime.strptime(self.Obj['Other_SessionStartTime'], '%Y-%m-%d %H:%M:%S.%f'),


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- GenerateMetadata generates an error during habituation sessions. This is because the attribute `self.behavior_software` isn't created unless trials were generated. This doesn't make sense since the software is being used regardless. I moved the function that creates this attribute outside of the behavior_stream function. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/9

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- No. The upload manifest won't be generated unless a trial is performed, so habituation sessions will not be uploaded. 


