### PR TITLE
adding experimenter name from schedule if available

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2998,13 +2998,15 @@ class Window(QMainWindow):
         logging.info('User input mouse id {}, which had no sessions on this computer'.format(mouse_id))
         return False, ''
 
-    def _OpenNewMouse(self, mouse_id):
+    def _OpenNewMouse(self, mouse_id,experimenter):
         '''
             Queries the user to start a new mouse
         '''
         reply = QMessageBox.question(self,
             'Box {}, Load mouse'.format(self.box_letter),
-            'No data for mouse <span style="color:purple;font-weight:bold">{}</span>, start new mouse?'.format(mouse_id),
+            'No data for mouse <span style="color:purple;font-weight:bold">{}</span>'.format(mouse_id) +\
+            '<br>Experimenter: {}<br>'.format(experimenter) +\
+            'start new mouse?',
             QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes)
         if reply == QMessageBox.No:
             logging.info('User declines to start new mouse: {}'.format(mouse_id))
@@ -3013,6 +3015,7 @@ class Window(QMainWindow):
         # Set ID, clear weight information
         logging.info('User starting a new mouse: {}'.format(mouse_id))
         self.ID.setText(mouse_id)
+        self.Experimenter.setText(experimenter)
         self.ID.returnPressed.emit()
         self.TargetRatio.setText('0.85')
         self.keyPressEvent(allow_reset=True)
@@ -3070,7 +3073,10 @@ class Window(QMainWindow):
                 if mouse_id not in mice:
                     # figureout out new Mouse
                     logging.info('User entered the ID for a mouse with no data: {}'.format(mouse_id))
-                    reply = self._OpenNewMouse(mouse_id)
+                    experimenter = self._GetInfoFromSchedule(mouse_id, 'Trainer')
+                    if experimenter is None:
+                        experimenter = self.behavior_session_model.experimenter[0]
+                    reply = self._OpenNewMouse(mouse_id,experimenter)
                     if reply != QMessageBox.No:     # user pressed yes
                         self.NewSession.setChecked(True)
                         self._NewSession()


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Experimenter name will automatically be set from the schedule, if available, when starting a new mouse

### What issues or discussions does this update address?
- resolves #294 

### Describe the expected change in behavior from the perspective of the experimenter
- You will not need to enter your name when starting a new mouse, if the mouse is on the schedule

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


