### PR TITLE
[hot fix, skip email] adding force check for photometry end time

### DIFF
--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -631,6 +631,8 @@ class generate_metadata:
         if self.Obj['fiber_photometry_start_time']=='':
             logging.info('No photometry data stream detected!')
             return
+        if self.Obj['fiber_photometry_end_time'] == '':
+            self.Obj['fiber_photometry_end_time'] = str(datetime.now())
         self._get_photometry_light_sources_config()
         self._get_photometry_detectors()
         self._get_fiber_connections()


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Ensuring that fiber_photometry_end_time is set to a valid string, rather than the empty string when saving 

### What issues or discussions does this update address?
- attempting to resolve https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/926

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
none

### Was this update tested in 446/447?
- tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
no


