### PR TITLE
only allow integers as auto_stop_ignore_win

### DIFF
--- a/src/foraging_gui/ForagingGUI.ui
+++ b/src/foraging_gui/ForagingGUI.ui
@@ -3414,7 +3414,7 @@ Double dipping:
                        </widget>
                       </item>
                       <item row="12" column="3">
-                       <widget class="QLineEdit" name="auto_stop_ignore_win">
+                       <widget class="QSpinBox" name="auto_stop_ignore_win">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                           <horstretch>0</horstretch>
@@ -3427,8 +3427,8 @@ Double dipping:
                           <height>16777215</height>
                          </size>
                         </property>
-                        <property name="text">
-                         <string>30</string>
+                        <property name="value">
+                         <number>30</number>
                         </property>
                        </widget>
                       </item>
@@ -4254,7 +4254,7 @@ Double dipping:
                        </widget>
                       </item>
                       <item row="12" column="6">
-                       <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
+                       <widget class="QDoubleSpinBox" name="auto_stop_ignore_ratio_threshold">
                         <property name="sizePolicy">
                          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                           <horstretch>0</horstretch>
@@ -4267,8 +4267,8 @@ Double dipping:
                           <height>16777215</height>
                          </size>
                         </property>
-                        <property name="text">
-                         <string>.8</string>
+                        <property name="value">
+                         <double>.8</double>
                         </property>
                        </widget>
                       </item>

--- a/src/foraging_gui/ForagingGUI_Ephys.ui
+++ b/src/foraging_gui/ForagingGUI_Ephys.ui
@@ -2245,7 +2245,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLineEdit" name="auto_stop_ignore_win">
+    <widget class="QSpinBox" name="auto_stop_ignore_win">
      <property name="geometry">
       <rect>
        <x>190</x>
@@ -2260,8 +2260,8 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="text">
-      <string>30</string>
+     <property name="value">
+      <number>30</number>
      </property>
     </widget>
     <widget class="QLabel" name="auto_stop_ignore_ratio_threshold_label">
@@ -2289,7 +2289,7 @@
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
-    <widget class="QLineEdit" name="auto_stop_ignore_ratio_threshold">
+    <widget class="QDoubleSpinBox" name="auto_stop_ignore_ratio_threshold">
      <property name="geometry">
       <rect>
        <x>402</x>
@@ -2304,8 +2304,8 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="text">
-      <string>.8</string>
+     <property name="value">
+      <double>.8</double>
      </property>
     </widget>
     <widget class="QLabel" name="label_62">


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- change auto_stop_ignore_win and auto_stop_ignore_win_threshold to QSpinBoxes to only allow correct type input
### What issues or discussions does this update address?
- resolves [#208](https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/208)
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- No 



