### PR TITLE
save bias confidence intervals

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4265,7 +4265,8 @@ class Window(QMainWindow):
         last_ci = self.GeneratedTrials.B_Bias_CI[-1]
         b_ci_len = len(self.GeneratedTrials.B_Bias_CI)
         ci_filler = [last_ci] * ((self.GeneratedTrials.B_CurrentTrialN + 1) - b_ci_len)
-        self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, ci_filler), axis=0)
+        if ci_filler != []:
+            self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, ci_filler), axis=0)
 
         # stop lick interval calculation
         self.GeneratedTrials.lick_interval_time.stop()  # stop lick interval calculation
@@ -4499,9 +4500,10 @@ class Window(QMainWindow):
         # back-fill bias confidence interval list with previous bias CI
         last_ci_filler = [self.GeneratedTrials.B_Bias_CI[-1]] * (
                     self.GeneratedTrials.B_CurrentTrialN - len(self.GeneratedTrials.B_Bias_CI))
-        self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, last_ci_filler), axis=0)
-        self.GeneratedTrials.B_Bias_CI[trial_number - 1:] = confidence_interval # set last value to newest bias CI
-    
+        if last_ci_filler !=  []:
+            self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, last_ci_filler), axis=0)
+            self.GeneratedTrials.B_Bias_CI[trial_number - 1:] = confidence_interval # set last value to newest bias CI
+
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):
         logging.info('starting trial loop 1')
         while self.Start.isChecked():

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4263,7 +4263,7 @@ class Window(QMainWindow):
 
         # fill out GenerateTrials B_Bias_CI
         last_ci = self.GeneratedTrials.B_Bias_CI[-1]
-        b_ci_len = len(self.GeneratedTrials.B_Bias)
+        b_ci_len = len(self.GeneratedTrials.B_Bias_CI)
         ci_filler = [last_ci] * ((self.GeneratedTrials.B_CurrentTrialN + 1) - b_ci_len)
         self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, ci_filler), axis=0)
 
@@ -4501,7 +4501,7 @@ class Window(QMainWindow):
                     self.GeneratedTrials.B_CurrentTrialN - len(self.GeneratedTrials.B_Bias_CI))
         self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, last_ci_filler), axis=0)
         self.GeneratedTrials.B_Bias_CI[trial_number - 1:] = confidence_interval # set last value to newest bias CI
-
+    
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):
         logging.info('starting trial loop 1')
         while self.Start.isChecked():

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -28,7 +28,8 @@ class GenerateTrials():
         self.B_LeftLickIntervalPercent = None      # percentage of left lick intervals under 100ms
         self.B_RightLickIntervalPercent = None     # percentage of right lick intervals under 100ms
         self.B_CrossSideIntervalPercent = None     # percentage of cross side lick intervals under 100ms
-        self.B_Bias =np.array([0], dtype=np.float64)  # lick bias
+        self.B_Bias = np.array([0], dtype=np.float64)  # lick bias
+        self.B_Bias_CI = np.array([[0, 0]], dtype=np.float64)  # lick bias confidence intervals
         self.B_RewardFamilies=self.win.RewardFamilies
         self.B_CurrentTrialN=-1 # trial number starts from 0; Update when trial starts
         self.B_LickPortN=2
@@ -1216,6 +1217,8 @@ class GenerateTrials():
                 self.fip_stop_timer = QtCore.QTimer(timeout=self.win._StartExcitation, interval=5000)
                 self.fip_stop_timer.setSingleShot(True)
                 self.fip_stop_timer.start()
+
+            self.win.session_end_tasks()
 
     def _CheckAutoWater(self):
         '''Check if it should be an auto water trial'''


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- bias confidence intervals are saved and appended when trial ends. Session model is also saved when session end either by clicking button or autostop. 
### What issues or discussions does this update address?
- resolves #1387 and resolves #1372 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [ ] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No


