### PR TITLE
Add data_lock to calculate bias thread

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4388,12 +4388,10 @@ class Window(QMainWindow):
                     # add data to bias_indicator
                     if not self.bias_thread.is_alive():
                         logger.debug('Starting bias thread.')
-                        self.bias_thread = threading.Thread(target=self.bias_indicator.calculate_bias,
+                        self.bias_thread = threading.Thread(target=self.calculate_bias,
                                                        kwargs={'trial_num': len(formatted_history),
                                                                'choice_history': choice_history,
-                                                               'reward_history': np.array(any_reward).astype(int),
-                                                               'n_trial_back': 5,
-                                                               'cv': 1})
+                                                               'reward_history': np.array(any_reward).astype(int)})
                         self.bias_thread.start()
                     else:
                         logger.debug('Skipping bias calculation as previous is still in progress. ')
@@ -4478,7 +4476,23 @@ class Window(QMainWindow):
         last_bias_filler = [self.GeneratedTrials.B_Bias[-1]]*(self.GeneratedTrials.B_CurrentTrialN-len(self.GeneratedTrials.B_Bias))
         self.GeneratedTrials.B_Bias = np.concatenate((self.GeneratedTrials.B_Bias, last_bias_filler), axis=0)
         self.GeneratedTrials.B_Bias[trial_number-1:] = bias
-    
+
+    def calculate_bias(self, trial_num: int, choice_history: np.ndarray, reward_history:np.ndarray):
+        """
+        Calculate bias based on lick data
+        :param trial_num: Trial number of currently at
+        :param choice_history: Choice history (0 = left choice, 1 = right choice).
+        :param reward_history: Reward history (0 = unrewarded, 1 = rewarded).
+        """
+
+        with self.data_lock:
+            self.bias_indicator.calculate_bias(trial_num= trial_num,
+                                               choice_history= choice_history,
+                                               reward_history= np.array(reward_history).astype(int),
+                                               n_trial_back= 5,
+                                               cv=1)
+
+
     def _StartTrialLoop1(self,GeneratedTrials,worker1,workerPlot,workerGenerateAtrial):
         logging.info('starting trial loop 1')
         while self.Start.isChecked():


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- adding data_lock to bias calculation to try and stop threading errors
### What issues or discussions does this update address?
- resolves #1394 
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [ ] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- No


