### PR TITLE
downgrading spot check error to warning unless two have failed

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1096,7 +1096,7 @@ class WaterCalibrationDialog(QDialog):
             if reply == QMessageBox.Cancel:
                 logging.warning('Spot check discarded due to type', extra={'tags': self.MainWindow.warning_log_tag})
             else:
-                logging.error('Water calibration spot check, {}, exceeds tolerance: {}'.format(valve,error))
+                logging.warning('Water calibration spot check, {}, exceeds tolerance: {}'.format(valve,error))
                 save.setStyleSheet("color: white;background-color : mediumorchid;")
                 self.Warning.setText(
                     f'Measuring {valve.lower()} valve: {volume}uL' + \


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Changes the logging level for spot check failures from error to warning. 
- Errors will be generated only when two spot checks fail in 30 days.

### What issues or discussions does this update address?
https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/317#issuecomment-2711913577

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- no

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- none


