### PR TITLE
Updating Project Name information

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2016,7 +2016,7 @@ class MetadataDialog(QDialog):
         '''get the widgets used for saving/loading metadata'''
         exclude_widgets=self._get_children_keys(self.Probes)
         exclude_widgets+=self._get_children_keys(self.Microscopes)
-        exclude_widgets+=['EphysProbes','RigMetadataFile','StickMicroscopes']
+        exclude_widgets+=['EphysProbes','RigMetadataFile','StickMicroscopes', 'ProjectName']
         widget_dict = {w.objectName(): w for w in self.findChildren(
             (QtWidgets.QLineEdit, QtWidgets.QTextEdit, QtWidgets.QComboBox))
             if w.objectName() not in exclude_widgets}

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1889,27 +1889,15 @@ class MetadataDialog(QDialog):
         '''show the project information based on current project name'''
         current_project_index = self.ProjectName.currentIndex()
         self.current_project_name=self.ProjectName.currentText()
-        self.funding_institution=self.project_info['Funding Institution'][current_project_index]
-        self.grant_number=self.project_info['Grant Number'][current_project_index]
-        self.investigators=self.project_info['Investigators'][current_project_index]
-        self.fundee=self.project_info['Fundee'][current_project_index]
-        self.FundingSource.setText(str(self.funding_institution))
-        self.Investigators.setText(str(self.investigators))
-        self.GrantNumber.setText(str(self.grant_number))
-        self.Fundee.setText(str(self.fundee))
 
     def _save_lick_spout_distance(self):
         '''save the lick spout distance'''
         self.MainWindow.Other_lick_spout_distance=self.LickSpoutDistance.text()
 
     def _show_project_names(self):
-        '''show the project names from the project spreadsheet'''
-        # load the project spreadsheet
-        project_info_file = self.MainWindow.project_info_file
-        if not os.path.exists(project_info_file):
-            return
-        self.project_info = pd.read_excel(project_info_file)
-        project_names = self.project_info['Project Name'].tolist()
+        '''show the project names'''
+        project_names = self.MainWindow._GetApprovedAINDProjectNames()
+
         # show the project information
         # adding project names to the project combobox
         self._manage_signals(enable=False,keys=['ProjectName'],action=self._show_project_info)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3363,7 +3363,7 @@ class Window(QMainWindow):
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
         self._GetProjectName(mouse_id)
-        logging.info(self.Metadata_dialog.ProjectName.currentText())
+        logging.info(self.Metadata_dialog.ProjectName.currentText()) ## DEBUG
     
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''
@@ -3916,7 +3916,7 @@ class Window(QMainWindow):
 
         # set the load tag to zero
         self.load_tag=0
-
+        logging.info(self.Metadata_dialog.ProjectName.currentText()+' 1') ## DEBUG
         # post weight not entered and session ran
         if self.WeightAfter.text() == '' and self.session_run and not self.unsaved_data:
             reply = QMessageBox.critical(self,
@@ -3941,7 +3941,7 @@ class Window(QMainWindow):
         self._connect_Sessionlist(connect=True)
         self.SessionlistSpin.setEnabled(False)
         self.Sessionlist.setEnabled(False)
-
+        logging.info(self.Metadata_dialog.ProjectName.currentText()+' 2') ## DEBUG
         # Clear warnings
         self.NewSession.setDisabled(False)
         # Toggle button colors
@@ -4003,6 +4003,7 @@ class Window(QMainWindow):
                         # Allow the session to continue, but log error
                         logging.error('Starting session with conflicting FIP information: mouse {}, FIP mode {}, schedule lists {}'.format(mouse_id, self.FIPMode.currentText(), fip_mode),extra={'tags': [self.warning_log_tag]})
 
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 3') ## DEBUG
             if self.StartANewSession == 0 :
                 reply = QMessageBox.question(self,
                     'Box {}, Start'.format(self.box_letter),
@@ -4025,7 +4026,7 @@ class Window(QMainWindow):
                 logging.info('User declines using default name')
                 return
             logging.info('Starting session, with experimenter: {}'.format(self.behavior_session_model.experimenter[0]))
-
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 4') ## DEBUG
             # check repo status
             if (self.current_branch not in ['main','production_testing']) & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # Prompt user over off-pipeline branch
@@ -4043,6 +4044,7 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch),extra={'tags': [self.warning_log_tag]})
 
             # Check for untracked local changes
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 5') ## DEBUG
             if self.behavior_session_model.allow_dirty_repo & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # prompt user over untracked local changes
                 reply = QMessageBox.critical(self,
@@ -4069,6 +4071,7 @@ class Window(QMainWindow):
                 logging.info('Cannot start session without starting FIP workflow')
                 return
 
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 6') ## DEBUG
             # Check if photometry excitation is running or not
             if self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
                 logging.warning('photometry is set to "on", but excitation is not running')
@@ -4096,7 +4099,7 @@ class Window(QMainWindow):
 
             # disable sound button
             self.action_Sound.setEnabled(False)
-
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 7') ## DEBUG
             # empty post weight after pass through checks in case user cancels run
             self.WeightAfter.setText('')
 
@@ -4105,8 +4108,9 @@ class Window(QMainWindow):
             self.NewSession.setStyleSheet("background-color : none")
             self.NewSession.setChecked(False)
             # disable metadata fields
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 8') ## DEBUG
             self._set_metadata_enabled(False)
-
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 9') ## DEBUG
             # Set IACUC protocol in metadata based on schedule
             protocol = self._GetInfoFromSchedule(mouse_id, 'Protocol')
             if protocol is not None:
@@ -4116,7 +4120,7 @@ class Window(QMainWindow):
                     update_session_metadata=True
                 )
                 logging.info('Setting IACUC Protocol: {}'.format(protocol))
-
+            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 10') ## DEBUG
             self.session_run = True   # session has been started
 
             self.keyPressEvent(allow_reset=True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3915,6 +3915,7 @@ class Window(QMainWindow):
 
         # set the load tag to zero
         self.load_tag=0
+
         # post weight not entered and session ran
         if self.WeightAfter.text() == '' and self.session_run and not self.unsaved_data:
             reply = QMessageBox.critical(self,
@@ -3939,6 +3940,7 @@ class Window(QMainWindow):
         self._connect_Sessionlist(connect=True)
         self.SessionlistSpin.setEnabled(False)
         self.Sessionlist.setEnabled(False)
+
         # Clear warnings
         self.NewSession.setDisabled(False)
         # Toggle button colors
@@ -4022,6 +4024,7 @@ class Window(QMainWindow):
                 logging.info('User declines using default name')
                 return
             logging.info('Starting session, with experimenter: {}'.format(self.behavior_session_model.experimenter[0]))
+
             # check repo status
             if (self.current_branch not in ['main','production_testing']) & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # Prompt user over off-pipeline branch
@@ -4092,6 +4095,7 @@ class Window(QMainWindow):
 
             # disable sound button
             self.action_Sound.setEnabled(False)
+
             # empty post weight after pass through checks in case user cancels run
             self.WeightAfter.setText('')
 
@@ -4099,8 +4103,10 @@ class Window(QMainWindow):
             self.Start.setStyleSheet("background-color : green;")
             self.NewSession.setStyleSheet("background-color : none")
             self.NewSession.setChecked(False)
+
             # disable metadata fields
             self._set_metadata_enabled(False)
+
             # Set IACUC protocol in metadata based on schedule
             protocol = self._GetInfoFromSchedule(mouse_id, 'Protocol')
             if protocol is not None:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3363,7 +3363,6 @@ class Window(QMainWindow):
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
         self._GetProjectName(mouse_id)
-        logging.info(self.Metadata_dialog.ProjectName.currentText()) ## DEBUG
     
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''
@@ -3916,7 +3915,6 @@ class Window(QMainWindow):
 
         # set the load tag to zero
         self.load_tag=0
-        logging.info(self.Metadata_dialog.ProjectName.currentText()+' 1') ## DEBUG
         # post weight not entered and session ran
         if self.WeightAfter.text() == '' and self.session_run and not self.unsaved_data:
             reply = QMessageBox.critical(self,
@@ -3941,7 +3939,6 @@ class Window(QMainWindow):
         self._connect_Sessionlist(connect=True)
         self.SessionlistSpin.setEnabled(False)
         self.Sessionlist.setEnabled(False)
-        logging.info(self.Metadata_dialog.ProjectName.currentText()+' 2') ## DEBUG
         # Clear warnings
         self.NewSession.setDisabled(False)
         # Toggle button colors
@@ -4003,7 +4000,6 @@ class Window(QMainWindow):
                         # Allow the session to continue, but log error
                         logging.error('Starting session with conflicting FIP information: mouse {}, FIP mode {}, schedule lists {}'.format(mouse_id, self.FIPMode.currentText(), fip_mode),extra={'tags': [self.warning_log_tag]})
 
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 3') ## DEBUG
             if self.StartANewSession == 0 :
                 reply = QMessageBox.question(self,
                     'Box {}, Start'.format(self.box_letter),
@@ -4026,7 +4022,6 @@ class Window(QMainWindow):
                 logging.info('User declines using default name')
                 return
             logging.info('Starting session, with experimenter: {}'.format(self.behavior_session_model.experimenter[0]))
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 4') ## DEBUG
             # check repo status
             if (self.current_branch not in ['main','production_testing']) & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # Prompt user over off-pipeline branch
@@ -4044,7 +4039,6 @@ class Window(QMainWindow):
                     logging.error('Starting session on branch: {}'.format(self.current_branch),extra={'tags': [self.warning_log_tag]})
 
             # Check for untracked local changes
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 5') ## DEBUG
             if self.behavior_session_model.allow_dirty_repo & (self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']):
                 # prompt user over untracked local changes
                 reply = QMessageBox.critical(self,
@@ -4071,7 +4065,6 @@ class Window(QMainWindow):
                 logging.info('Cannot start session without starting FIP workflow')
                 return
 
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 6') ## DEBUG
             # Check if photometry excitation is running or not
             if self.PhotometryB.currentText()=='on' and (not self.StartExcitation.isChecked()):
                 logging.warning('photometry is set to "on", but excitation is not running')
@@ -4099,7 +4092,6 @@ class Window(QMainWindow):
 
             # disable sound button
             self.action_Sound.setEnabled(False)
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 7') ## DEBUG
             # empty post weight after pass through checks in case user cancels run
             self.WeightAfter.setText('')
 
@@ -4108,9 +4100,7 @@ class Window(QMainWindow):
             self.NewSession.setStyleSheet("background-color : none")
             self.NewSession.setChecked(False)
             # disable metadata fields
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 8') ## DEBUG
             self._set_metadata_enabled(False)
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 9') ## DEBUG
             # Set IACUC protocol in metadata based on schedule
             protocol = self._GetInfoFromSchedule(mouse_id, 'Protocol')
             if protocol is not None:
@@ -4120,7 +4110,6 @@ class Window(QMainWindow):
                     update_session_metadata=True
                 )
                 logging.info('Setting IACUC Protocol: {}'.format(protocol))
-            logging.info(self.Metadata_dialog.ProjectName.currentText()+' 10') ## DEBUG
             self.session_run = True   # session has been started
 
             self.keyPressEvent(allow_reset=True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1995,7 +1995,7 @@ class Window(QMainWindow):
                         child.setStyleSheet('background-color: white;')
                         self._Task()
 
-                    if child.objectName() in {'WeightAfter','LickSpoutDistance','ModuleAngle','ArcAngle','ProtocolID','Stick_RotationAngle','LickSpoutReferenceX','LickSpoutReferenceY','LickSpoutReferenceZ','LickSpoutReferenceArea','Fundee','ProjectCode','GrantNumber','FundingSource','Investigators','Stick_ArcAngle','Stick_ModuleAngle','RotationAngle','ManipulatorX','ManipulatorY','ManipulatorZ','ProbeTarget','RigMetadataFile','IACUCProtocol','Experimenter','TotalWater','ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
+                    if child.objectName() in {'WeightAfter','LickSpoutDistance','ModuleAngle','ArcAngle','ProtocolID','Stick_RotationAngle','LickSpoutReferenceX','LickSpoutReferenceY','LickSpoutReferenceZ','LickSpoutReferenceArea','ProjectCode','Stick_ArcAngle','Stick_ModuleAngle','RotationAngle','ManipulatorX','ManipulatorY','ManipulatorZ','ProbeTarget','RigMetadataFile','IACUCProtocol','Experimenter','TotalWater','ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
                         continue
                     if child.objectName()=='UncoupledReward':
                         Correct=self._CheckFormat(child)
@@ -2064,7 +2064,7 @@ class Window(QMainWindow):
                             self.UpdateParameters = 0
 
                         self.Continue=0
-                        if child.objectName() in {'LickSpoutReferenceArea','Fundee','ProjectCode','GrantNumber','FundingSource','Investigators','ProbeTarget','RigMetadataFile','Experimenter', 'UncoupledReward', 'ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
+                        if child.objectName() in {'LickSpoutReferenceArea','ProjectCode','ProbeTarget','RigMetadataFile','Experimenter', 'UncoupledReward', 'ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
                             child.setStyleSheet(f'color: {self.default_text_color};')
                             self.Continue=1
                         if child.text()=='': # If empty, change background color and wait for confirmation
@@ -3870,13 +3870,6 @@ class Window(QMainWindow):
             self.Metadata_dialog.ProjectName.setCurrentIndex(index)
             self.Metadata_dialog._show_project_info()
         else:
-            project_info = {
-                'Funding Institution': ['Allen Institute'],
-                'Grant Number': ['nan'],
-                'Investigators': ['Jeremiah Cohen'],
-                'Fundee': ['nan'],
-            }
-            self.Metadata_dialog.project_info = project_info
             self.Metadata_dialog.ProjectName.addItems([project_name])
         return project_name
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1168,7 +1168,7 @@ class Window(QMainWindow):
 
         # Check if this is a valid project name
         if project_name is None:
-            logging.info('Project name {} is not valid, using default, please correct schedule'.format(project_name))
+            logging.info('Project name not on schedule, using default')
         elif project_name not in self._GetApprovedAINDProjectNames():
             logging.error('Project name {} is not valid, using default, please correct schedule'.format(project_name))
             project_name = None

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1995,7 +1995,7 @@ class Window(QMainWindow):
                         child.setStyleSheet('background-color: white;')
                         self._Task()
 
-                    if child.objectName() in {'WeightAfter','LickSpoutDistance','ModuleAngle','ArcAngle','ProtocolID','Stick_RotationAngle','LickSpoutReferenceX','LickSpoutReferenceY','LickSpoutReferenceZ','LickSpoutReferenceArea','ProjectCode','Stick_ArcAngle','Stick_ModuleAngle','RotationAngle','ManipulatorX','ManipulatorY','ManipulatorZ','ProbeTarget','RigMetadataFile','IACUCProtocol','Experimenter','TotalWater','ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
+                    if child.objectName() in {'WeightAfter','LickSpoutDistance','ModuleAngle','ArcAngle','ProtocolID','Stick_RotationAngle','LickSpoutReferenceX','LickSpoutReferenceY','LickSpoutReferenceZ','LickSpoutReferenceArea','Stick_ArcAngle','Stick_ModuleAngle','RotationAngle','ManipulatorX','ManipulatorY','ManipulatorZ','ProbeTarget','RigMetadataFile','IACUCProtocol','Experimenter','TotalWater','ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
                         continue
                     if child.objectName()=='UncoupledReward':
                         Correct=self._CheckFormat(child)
@@ -2064,7 +2064,7 @@ class Window(QMainWindow):
                             self.UpdateParameters = 0
 
                         self.Continue=0
-                        if child.objectName() in {'LickSpoutReferenceArea','ProjectCode','ProbeTarget','RigMetadataFile','Experimenter', 'UncoupledReward', 'ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
+                        if child.objectName() in {'LickSpoutReferenceArea','ProbeTarget','RigMetadataFile','Experimenter', 'UncoupledReward', 'ExtraWater','laser_1_target','laser_2_target','laser_1_calibration_power','laser_2_calibration_power','laser_1_calibration_voltage','laser_2_calibration_voltage'}:
                             child.setStyleSheet(f'color: {self.default_text_color};')
                             self.Continue=1
                         if child.text()=='': # If empty, change background color and wait for confirmation

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3052,6 +3052,7 @@ class Window(QMainWindow):
         self.ID.setText(mouse_id)
         self.Experimenter.setText(experimenter)
         self.ID.returnPressed.emit()
+        self._GetProjectName(mouse_id)
         self.TargetRatio.setText('0.85')
         self.keyPressEvent(allow_reset=True)
 
@@ -3364,6 +3365,7 @@ class Window(QMainWindow):
         self.keyPressEvent() # Accept all updates
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
+        self._GetProjectName(mouse_id)
 
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''
@@ -4117,9 +4119,6 @@ class Window(QMainWindow):
                 )
                 logging.info('Setting IACUC Protocol: {}'.format(protocol))
 
-            # Set Project Name in metadata based on schedule
-            self._GetProjectName(mouse_id)
-            
             self.session_run = True   # session has been started
 
             self.keyPressEvent(allow_reset=True)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1188,11 +1188,8 @@ class Window(QMainWindow):
         # Users can opt out of setting the default project name
         # In this case they must set the project name manually
         if self.Settings['add_default_project_name'] and add_default:
-            project_name=self._set_default_project()
+            project_name=self._set_default_project()   
 
-        # Set attribute
-        self.project_name = project_name
-    
     def _GetApprovedAINDProjectNames(self):
         end_point = "http://aind-metadata-service/project_names"
         timeout = 5
@@ -4839,13 +4836,6 @@ class Window(QMainWindow):
 
         logging.info('Generating upload manifest')
         try:
-            if not hasattr(self, 'project_name'):
-                self.project_name = 'Behavior Platform'
-                logging.error('No project name attribute, using default')
-            if self.project_name==None:
-                self.project_name = 'Behavior Platform'
-                logging.error('project name was None, using default')
-
             # Upload time is 8:30 tonight, plus a random offset over a 30 minute period
             # Random offset reduces strain on downstream servers getting many requests at once
             date_format = "%Y-%m-%d_%H-%M-%S"
@@ -4879,7 +4869,7 @@ class Window(QMainWindow):
                     os.path.join(self.MetadataFolder,'rig.json').replace('\\','/'),
                     ],
                 'schedule_time':schedule_time,
-                'project_name':self.project_name,
+                'project_name':self.Metadata_dialog.ProjectName.currentText(),
                 'script': {}
                 }
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3363,7 +3363,8 @@ class Window(QMainWindow):
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
         self._GetProjectName(mouse_id)
-
+        logging.info(self.Metadata_dialog.ProjectName.currentText())
+    
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''
         self.ToInitializeVisual=1

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -14,7 +14,6 @@ from aind_data_schema.components.stimulus import AuditoryStimulation
 from aind_data_schema.components.devices import SpoutSide,Calibration
 from aind_data_schema_models.units import SizeUnit,FrequencyUnit,SoundIntensityUnit,PowerUnit
 
-from aind_data_schema.core.data_description import Funding
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.platforms import Platform
@@ -242,16 +241,6 @@ class generate_metadata:
             self.box_type = 'Ephys'
         else:
             self.box_type = 'Behavior'
-
-    def _get_funding_source(self):
-        '''
-        Get the funding source
-        '''
-        self.funding_source=[Funding(
-            funder=getattr(Organization,self.name_mapper['institute'][self.Obj['meta_data_dialog']['session_metadata']['FundingSource']]),
-            grant_number=self.Obj['meta_data_dialog']['session_metadata']['GrantNumber'],
-            fundee=self.Obj['meta_data_dialog']['session_metadata']['Fundee'],
-        )]
                 
     def _get_platform(self):
         '''
@@ -294,16 +283,6 @@ class generate_metadata:
             self.session_start_time = ''
             self.session_end_time = ''
         
-    def _get_investigators(self):
-        '''
-        Get investigators
-        '''
-        self.investigators=[]
-        investigators=self.Obj['meta_data_dialog']['session_metadata']['Investigators'].split(',')
-        for investigator in investigators:
-            if investigator != '':
-                self.investigators.append(PIDName(name=investigator, registry=self.orcid))
-
     def _save_rig_metadata(self):
         '''
         Save the rig metadata to the MetadataFolder

--- a/src/foraging_gui/MetaData.ui
+++ b/src/foraging_gui/MetaData.ui
@@ -904,31 +904,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
     </property>
    </widget>
-   <widget class="QLabel" name="label_81">
-    <property name="geometry">
-     <rect>
-      <x>6</x>
-      <y>50</y>
-      <width>91</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>Investigators:</string>
-    </property>
-    <property name="textFormat">
-     <enum>Qt::AutoText</enum>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-    </property>
-   </widget>
    <widget class="QLabel" name="label_85">
     <property name="geometry">
      <rect>
@@ -957,9 +932,9 @@ p, li { white-space: pre-wrap; }
    <widget class="QComboBox" name="ProjectName">
     <property name="geometry">
      <rect>
-      <x>100</x>
+      <x>20</x>
       <y>20</y>
-      <width>141</width>
+      <width>221</width>
       <height>20</height>
      </rect>
     </property>

--- a/src/foraging_gui/MetaData.ui
+++ b/src/foraging_gui/MetaData.ui
@@ -904,50 +904,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
     </property>
    </widget>
-   <widget class="QLineEdit" name="FundingSource">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>80</y>
-      <width>141</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_82">
-    <property name="geometry">
-     <rect>
-      <x>6</x>
-      <y>80</y>
-      <width>91</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>Funding source:</string>
-    </property>
-    <property name="textFormat">
-     <enum>Qt::AutoText</enum>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-    </property>
-   </widget>
    <widget class="QLabel" name="label_81">
     <property name="geometry">
      <rect>
@@ -998,50 +954,6 @@ p, li { white-space: pre-wrap; }
      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
     </property>
    </widget>
-   <widget class="QLineEdit" name="Investigators">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>50</y>
-      <width>141</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_84">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>20</y>
-      <width>91</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>Project name:</string>
-    </property>
-    <property name="textFormat">
-     <enum>Qt::AutoText</enum>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-    </property>
-   </widget>
    <widget class="QComboBox" name="ProjectName">
     <property name="geometry">
      <rect>
@@ -1071,94 +983,6 @@ p, li { white-space: pre-wrap; }
     </property>
     <property name="sizeAdjustPolicy">
      <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="GrantNumber">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>110</y>
-      <width>141</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_86">
-    <property name="geometry">
-     <rect>
-      <x>6</x>
-      <y>110</y>
-      <width>91</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>Grant number:</string>
-    </property>
-    <property name="textFormat">
-     <enum>Qt::AutoText</enum>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="Fundee">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>140</y>
-      <width>141</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string/>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_91">
-    <property name="geometry">
-     <rect>
-      <x>6</x>
-      <y>140</y>
-      <width>91</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>Fundee:</string>
-    </property>
-    <property name="textFormat">
-     <enum>Qt::AutoText</enum>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
     </property>
    </widget>
   </widget>
@@ -1300,14 +1124,10 @@ p, li { white-space: pre-wrap; }
   <tabstop>Stick_ArcAngle</tabstop>
   <tabstop>Stick_RotationAngle</tabstop>
   <tabstop>DataSummary</tabstop>
-  <tabstop>FundingSource</tabstop>
-  <tabstop>Investigators</tabstop>
   <tabstop>ProjectName</tabstop>
-  <tabstop>GrantNumber</tabstop>
   <tabstop>ManipulatorX</tabstop>
   <tabstop>ManipulatorZ</tabstop>
   <tabstop>ManipulatorY</tabstop>
-  <tabstop>Fundee</tabstop>
   <tabstop>LickSpoutReferenceArea</tabstop>
  </tabstops>
  <resources/>

--- a/src/foraging_gui/settings_model.py
+++ b/src/foraging_gui/settings_model.py
@@ -119,7 +119,6 @@ class DFTSettingsModel(BaseModel):
     open_ephys_machine_ip_address: str
     metadata_dialog_folder: str
     rig_metadata_folder: str
-    project_info_file: str
     schedule_path: str
     go_cue_decibel_box1: float
     go_cue_decibel_box2: float


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Previously, the list of project names was gathered from a static CSV file. 
- Recently, aind-metadata-service has provided a list of project names that are strictly enforced
- Because the schedule was using the aind-metadata-service project names, but the UI was using the static CSV list, it was causing a mis-match, and all sessions were being uploaded with "Behavior Platform" which is the default. 
- This PR updates the UI to use the AIND-metadata-service list of project names, instead of the static csv file on an institute server. 
- Removes unused metadata labels for funding source, fundee, grant number. These are tracked via project names, so we don't need to set them
- Users can still manually set project names using a combo-box
- Removes unused functions in GenerateMetadata.py

### What issues or discussions does this update address?
- resolves #1427 

### Describe the expected change in behavior from the perspective of the experimenter
- The metadata dialog box has some fields removed, and the project list will be up to date
![Capture](https://github.com/user-attachments/assets/d00f6416-6b6b-4601-b724-0c320c14df1f)

### Describe any manual update steps for task computers
- The setting `project_info_file` in `ForagingSettings.json` is being depreciated. Remove it if you have set it. I don't think any rigs have set this manually. 

### Was this update tested in 446/447?
- tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


