### PR TITLE
Checking for no generated trials when ending session

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4315,28 +4315,31 @@ class Window(QMainWindow):
         """
         Data cleanup and saving that needs to be done at end of session.
         """
+        if hasattr(self, 'GeneratedTrials'):
+            # If the session never generated any trials, then we don't need to perform these tasks
 
-        # fill out GenerateTrials B_Bias
-        last_bias = self.GeneratedTrials.B_Bias[-1]
-        b_bias_len = len(self.GeneratedTrials.B_Bias)
-        bias_filler = [last_bias] * ((self.GeneratedTrials.B_CurrentTrialN + 1) - b_bias_len)
-        self.GeneratedTrials.B_Bias = np.concatenate((self.GeneratedTrials.B_Bias, bias_filler), axis=0)
+            # fill out GenerateTrials B_Bias
+            last_bias = self.GeneratedTrials.B_Bias[-1]
+            b_bias_len = len(self.GeneratedTrials.B_Bias)
+            bias_filler = [last_bias] * ((self.GeneratedTrials.B_CurrentTrialN + 1) - b_bias_len)
+            self.GeneratedTrials.B_Bias = np.concatenate((self.GeneratedTrials.B_Bias, bias_filler), axis=0)
 
-        # fill out GenerateTrials B_Bias_CI
-        last_ci = self.GeneratedTrials.B_Bias_CI[-1]
-        b_ci_len = len(self.GeneratedTrials.B_Bias_CI)
-        ci_filler = [last_ci] * ((self.GeneratedTrials.B_CurrentTrialN + 1) - b_ci_len)
-        if ci_filler != []:
-            self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, ci_filler), axis=0)
+            # fill out GenerateTrials B_Bias_CI
+            last_ci = self.GeneratedTrials.B_Bias_CI[-1]
+            b_ci_len = len(self.GeneratedTrials.B_Bias_CI)
+            ci_filler = [last_ci] * ((self.GeneratedTrials.B_CurrentTrialN + 1) - b_ci_len)
+            if ci_filler != []:
+                self.GeneratedTrials.B_Bias_CI = np.concatenate((self.GeneratedTrials.B_Bias_CI, ci_filler), axis=0)
 
-        # stop lick interval calculation
-        self.GeneratedTrials.lick_interval_time.stop()  # stop lick interval calculation
+            # stop lick interval calculation
+            self.GeneratedTrials.lick_interval_time.stop()
 
         # validate behavior session model and document validation errors if any
         try:
             AindBehaviorSessionModel(**self.behavior_session_model.model_dump())
         except ValidationError as e:
             logging.error(str(e), extra={'tags': [self.warning_log_tag]})
+
         # save behavior session model
         with open(self.behavior_session_modelJson, "w") as outfile:
             outfile.write(self.behavior_session_model.model_dump_json())


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
I believe this error (https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/266) is caused when an error happens during the photometry baseline period that doesn't crash the session, but prevents the normal generation of trials. Then the user stops the session, but the session end tasks can't run because the normal generation of trials didn't happen. This PR just checks for the existence of the GeneratedTrials before trying to access them. I tested this doesn't interfere with normal operations. 

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/266

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


