### PR TITLE
Delaying upload time for sessions that start after 5:30pm

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4871,11 +4871,17 @@ class Window(QMainWindow):
 
         logging.info('Generating upload manifest')
         try:
-            # Upload time is 8:30 tonight, plus a random offset over a 30 minute period
-            # Random offset reduces strain on downstream servers getting many requests at once
             date_format = "%Y-%m-%d_%H-%M-%S"
-            schedule = self.behavior_session_model.date.strftime(date_format).split('_')[0]+'_20-30-00'
-            schedule_time = datetime.strptime(schedule,date_format) + timedelta(seconds=np.random.randint(30*60))
+            if self.behavior_session_model.date.strftime('%H-%M-%S') < '18-30-00':
+                # Session started before 6:30
+                # Upload time is 8:30 tonight, plus a random offset over a 30 minute period
+                # Random offset reduces strain on downstream servers getting many requests at once
+                schedule = self.behavior_session_model.date.strftime(date_format).split('_')[0]+'_20-30-00'
+                schedule_time = datetime.strptime(schedule,date_format) + timedelta(seconds=np.random.randint(30*60))
+            else:
+                # Session started after 6:30
+                # upload time is current time plus 3 hours plus a random offset
+                schedule_time = self.behavior_session_model.date + timedelta(hours=3,seconds =np.random.randin(30*60))
             capsule_id = '0ae9703f-9012-4d0b-ad8d-b6a00858b80d'
             mount = 'FIP'
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4872,14 +4872,14 @@ class Window(QMainWindow):
         logging.info('Generating upload manifest')
         try:
             date_format = "%Y-%m-%d_%H-%M-%S"
-            if self.behavior_session_model.date.strftime('%H-%M-%S') < '18-30-00':
-                # Session started before 6:30
+            if self.behavior_session_model.date.strftime('%H-%M-%S') < '17-30-00':
+                # Session started before 5:30
                 # Upload time is 8:30 tonight, plus a random offset over a 30 minute period
                 # Random offset reduces strain on downstream servers getting many requests at once
                 schedule = self.behavior_session_model.date.strftime(date_format).split('_')[0]+'_20-30-00'
                 schedule_time = datetime.strptime(schedule,date_format) + timedelta(seconds=np.random.randint(30*60))
             else:
-                # Session started after 6:30
+                # Session started after 5:30
                 # upload time is current time plus 3 hours plus a random offset
                 schedule_time = self.behavior_session_model.date + timedelta(hours=3,seconds =np.random.randin(30*60))
             capsule_id = '0ae9703f-9012-4d0b-ad8d-b6a00858b80d'


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Previously session upload time was always 8:30 plus a random offset. However, sessions that run late will not upload until the next day.
- now upload time for sessions that start after 5:30pm will be delayed to 3 hours after the start time (plus random offset)

### What issues or discussions does this update address?
- resolves #1450 

### Describe the expected change in behavior from the perspective of the experimenter
- Data should always upload the day it was run

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


