### PR TITLE
Makes setting the protocol robust

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1969,6 +1969,7 @@ class MetadataDialog(QDialog):
     def _set_widgets_value(self, widget_dict, metadata):
         '''set the widgets value'''
         for key, value in widget_dict.items():
+            print(str(key) + ' ' + str(value)) ## TODO DEBUG
             if key in metadata:
                 if isinstance(value, QtWidgets.QLineEdit):
                     value.setText(metadata[key])

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -2020,7 +2020,7 @@ class MetadataDialog(QDialog):
         '''get the widgets used for saving/loading metadata'''
         exclude_widgets=self._get_children_keys(self.Probes)
         exclude_widgets+=self._get_children_keys(self.Microscopes)
-        exclude_widgets+=['EphysProbes','RigMetadataFile','StickMicroscopes', 'ProjectName']
+        exclude_widgets+=['EphysProbes','RigMetadataFile','StickMicroscopes']
         widget_dict = {w.objectName(): w for w in self.findChildren(
             (QtWidgets.QLineEdit, QtWidgets.QTextEdit, QtWidgets.QComboBox))
             if w.objectName() not in exclude_widgets}

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -1969,7 +1969,6 @@ class MetadataDialog(QDialog):
     def _set_widgets_value(self, widget_dict, metadata):
         '''set the widgets value'''
         for key, value in widget_dict.items():
-            print(str(key) + ' ' + str(value)) ## TODO DEBUG
             if key in metadata:
                 if isinstance(value, QtWidgets.QLineEdit):
                     value.setText(metadata[key])

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1207,7 +1207,7 @@ class Window(QMainWindow):
 
 
     def _GetProjectName(self, mouse_id):
-        if not self.Settings['check_schedule']
+        if not self.Settings['check_schedule']:
             logging.info('not setting project name because check_schedule=False')
             return
         logging.info('Getting Project name')

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3420,8 +3420,10 @@ class Window(QMainWindow):
             # load metadata to the metadata dialog
             if 'meta_data_dialog' in Obj:
                 if 'session_metadata' in Obj['meta_data_dialog']:
+                    print(Obj['meta_data_dialog']['session_metadata']) ## TODO DEBUG
                     self.Metadata_dialog.meta_data['session_metadata'] = Obj['meta_data_dialog']['session_metadata']
                 self.Metadata_dialog._update_metadata()
+                print(self.Metadata_dialog ) ## TODO DEBUG
 
             # show session list related to that animal
             tag=self._show_sessions()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1185,13 +1185,17 @@ class Window(QMainWindow):
         return self.schedule.query('`Mouse ID` == @mouse_id').iloc[0][column]
     
     def _GetProtocol(self, mouse_id):
+        if not self.Settings['check_schedule']:
+            logging.info('not setting protocol because check_schedule=False')
+            return
         logging.info('Getting protocol')
         protocol = self._GetInfoFromSchedule(mouse_id, 'Protocol')
         if (protocol is None) or (protocol == '') or (np.isnan(protocol)):
-            logging.info('Protocol not on schedule, using default: 2414')
             if not self.Settings['add_default_project_name']:
+                logging.info('Protocol not on schedule, not using default because add_default_project_name=False')
                 return
             else:
+                logging.info('Protocol not on schedule, using default: 2414')
                 protocol = 2414
  
         self.Metadata_dialog.meta_data['session_metadata']['IACUCProtocol'] = str(int(protocol))
@@ -1203,6 +1207,9 @@ class Window(QMainWindow):
 
 
     def _GetProjectName(self, mouse_id):
+        if not self.Settings['check_schedule']
+            logging.info('not setting project name because check_schedule=False')
+            return
         logging.info('Getting Project name')
         project_name = self._GetInfoFromSchedule(mouse_id, 'Project Name')
         add_default = True 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3423,7 +3423,7 @@ class Window(QMainWindow):
                     print(Obj['meta_data_dialog']['session_metadata']) ## TODO DEBUG
                     self.Metadata_dialog.meta_data['session_metadata'] = Obj['meta_data_dialog']['session_metadata']
                 self.Metadata_dialog._update_metadata()
-                print(self.Metadata_dialog ) ## TODO DEBUG
+                print(self.Metadata_dialog.meta_data['session_metadata'] ) ## TODO DEBUG
 
             # show session list related to that animal
             tag=self._show_sessions()

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3239,7 +3239,7 @@ class Window(QMainWindow):
             self.Obj = Obj
 
             widget_dict={}
-            dialogs = ['LaserCalibration_dialog', 'Opto_dialog', 'Camera_dialog','centralwidget','Metadata_dialog','TrainingParameters']
+            dialogs = ['LaserCalibration_dialog', 'Opto_dialog', 'Camera_dialog','centralwidget','TrainingParameters']
             for dialog_name in dialogs:
                 if hasattr(self, dialog_name):
                     widget_types = (QtWidgets.QPushButton, QtWidgets.QLineEdit, QtWidgets.QTextEdit,
@@ -3262,7 +3262,6 @@ class Window(QMainWindow):
                             CurrentObj=Obj['LaserCalibration_dialog']
                         elif widget.parent().objectName()=='MetaData':
                             CurrentObj=Obj['Metadata_dialog']
-                            logging.info('DEBUG DEBUG here') ## TODO
                         else:
                             CurrentObj=Obj.copy()
                     except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3420,10 +3420,8 @@ class Window(QMainWindow):
             # load metadata to the metadata dialog
             if 'meta_data_dialog' in Obj:
                 if 'session_metadata' in Obj['meta_data_dialog']:
-                    print(Obj['meta_data_dialog']['session_metadata']) ## TODO DEBUG
                     self.Metadata_dialog.meta_data['session_metadata'] = Obj['meta_data_dialog']['session_metadata']
                 self.Metadata_dialog._update_metadata()
-                print(self.Metadata_dialog.meta_data['session_metadata'] ) ## TODO DEBUG
 
             # show session list related to that animal
             tag=self._show_sessions()
@@ -3443,8 +3441,8 @@ class Window(QMainWindow):
         self.keyPressEvent() # Accept all updates
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
-        #self._GetProjectName(self.behavior_session_model.subject) ## TODO DEBUG
-        #self._GetProtocol(self.behavior_session_model.subject) ## TODO DEBUG
+        self._GetProjectName(self.behavior_session_model.subject)
+        self._GetProtocol(self.behavior_session_model.subject) 
     
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3443,8 +3443,8 @@ class Window(QMainWindow):
         self.keyPressEvent() # Accept all updates
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
-        self._GetProjectName(self.behavior_session_model.subject)
-        self._GetProtocol(self.behavior_session_model.subject)
+        #self._GetProjectName(self.behavior_session_model.subject) ## TODO DEBUG
+        #self._GetProtocol(self.behavior_session_model.subject) ## TODO DEBUG
     
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3442,7 +3442,7 @@ class Window(QMainWindow):
         self.load_tag=1
         self.ID.returnPressed.emit() # Mimic the return press event to auto-engage AutoTrain
         self._GetProjectName(self.behavior_session_model.subject)
-        self._GetProject(self.behavior_session_model.subject)
+        self._GetProtocol(self.behavior_session_model.subject)
     
     def _LoadVisualization(self):
         '''To visulize the training when loading a session'''

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3239,7 +3239,7 @@ class Window(QMainWindow):
             self.Obj = Obj
 
             widget_dict={}
-            dialogs = ['LaserCalibration_dialog', 'Opto_dialog', 'Camera_dialog','centralwidget','TrainingParameters']
+            dialogs = ['LaserCalibration_dialog', 'Opto_dialog', 'Camera_dialog','centralwidget','Metadata_dialog','TrainingParameters']
             for dialog_name in dialogs:
                 if hasattr(self, dialog_name):
                     widget_types = (QtWidgets.QPushButton, QtWidgets.QLineEdit, QtWidgets.QTextEdit,

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3262,6 +3262,7 @@ class Window(QMainWindow):
                             CurrentObj=Obj['LaserCalibration_dialog']
                         elif widget.parent().objectName()=='MetaData':
                             CurrentObj=Obj['Metadata_dialog']
+                            logging.info('DEBUG DEBUG here') ## TODO
                         else:
                             CurrentObj=Obj.copy()
                     except Exception as e:

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1187,7 +1187,7 @@ class Window(QMainWindow):
     def _GetProtocol(self, mouse_id):
         logging.info('Getting protocol')
         protocol = self._GetInfoFromSchedule(mouse_id, 'Protocol')
-        if (protocol is None) or (protocol == ''):
+        if (protocol is None) or (protocol == '') or (np.isnan(protocol)):
             logging.info('Protocol not on schedule, using default: 2414')
             if not self.Settings['add_default_project_name']:
                 return


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- If protocol information was not in the schedule, it would generate an error
- I moved this check to when we load the mouse
- I only set the default protocol if add_default_project_name is set to true
- Correctly sets the ProjectName from the behavior JSON

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/1027
- resolves https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/1463

### Describe the expected change in behavior from the perspective of the experimenter
- robust to missing schedule info

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- none


