### PR TITLE
Checking for missing stage position

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4800,6 +4800,8 @@ class Window(QMainWindow):
                     and len(Obj["B_StagePositions"]) != 0
                 ):
                     last_positions = Obj["B_StagePositions"][-1]
+                    if last_positions is None:
+                        pass
                     if hasattr(self, "current_stage"):  # newscale stage
                         self.current_stage.move_absolute_3d(
                             float(last_positions["x"]),
@@ -4833,6 +4835,8 @@ class Window(QMainWindow):
                     and len(Obj["B_NewscalePositions"]) != 0
                 ):  # cross compatibility for mice run on older version of code.
                     last_positions = Obj["B_NewscalePositions"][-1]
+                    if last_positions is None:
+                        pass
                     self.current_stage.move_absolute_3d(
                         float(last_positions[0]),
                         float(last_positions[1]),


### PR DESCRIPTION
…ession

### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
If we loose the stage controller mid-session (happens with both AIND Stage Controller and Newscale), then the last known stage position will be None. Currently this throws an error that is caught, this PR handles that case.

### What issues or discussions does this update address?
- resolves https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/522

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- no


