### PR TITLE
Remove call that changes widget state in save worker thread

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2835,7 +2835,6 @@ class Window(QMainWindow):
             if save_clicked:    # create water log result if weight after filled and uncheck save
                 if self.BaseWeight.text() != '' and self.WeightAfter.text() != '' and self.behavior_session_model.subject not in ['0','1','2','3','4','5','6','7','8','9','10']:
                     self._AddWaterLogResult(session)
-                self.bias_indicator.clear()  # prepare for new session
 
 
         except Exception as e:


### PR DESCRIPTION
@xx-yin found the cause of #1394, documented in PR #1472. I am recreating that fix off of main to implement a 'hotfix' of this week's main

Fixes #1394


