### PR TITLE
Manually reverting ruff changes

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -786,7 +786,7 @@ class WaterCalibrationDialog(QDialog):
                     "All measurements have been completed. Either press Repeat, or Finished"
                 )
                 return
-            next_index = np.where(self.left_measurements == False)[0][0]
+            next_index = np.where(self.left_measurements != True)[0][0]
             self.LeftOpenTime.setCurrentIndex(next_index)
         else:
             next_index = self.LeftOpenTime.currentIndex()
@@ -973,7 +973,7 @@ class WaterCalibrationDialog(QDialog):
                     "All measurements have been completed. Either press Repeat, or Finished"
                 )
                 return
-            next_index = np.where(self.right_measurements == False)[0][0]
+            next_index = np.where(self.right_measurements != True)[0][0]
             self.RightOpenTime.setCurrentIndex(next_index)
         else:
             next_index = self.RightOpenTime.currentIndex()
@@ -1454,7 +1454,7 @@ class WaterCalibrationDialog(QDialog):
         if np.abs(error) > TOLERANCE:
             reply = QMessageBox.critical(
                 self,
-                f"Spot check {valve}",
+                f"Spot check {valve}".format(np.round(result, 2)),
                 "Measurement is outside expected tolerance.<br><br>"
                 "If this is a typo, please press cancel."
                 '<br><br><span style="color:purple;font-weight:bold">IMPORTANT</span>: '

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -786,7 +786,7 @@ class WaterCalibrationDialog(QDialog):
                     "All measurements have been completed. Either press Repeat, or Finished"
                 )
                 return
-            next_index = np.where(self.left_measurements is False)[0][0]
+            next_index = np.where(self.left_measurements == False)[0][0]
             self.LeftOpenTime.setCurrentIndex(next_index)
         else:
             next_index = self.LeftOpenTime.currentIndex()
@@ -973,7 +973,7 @@ class WaterCalibrationDialog(QDialog):
                     "All measurements have been completed. Either press Repeat, or Finished"
                 )
                 return
-            next_index = np.where(self.right_measurements is False)[0][0]
+            next_index = np.where(self.right_measurements == False)[0][0]
             self.RightOpenTime.setCurrentIndex(next_index)
         else:
             next_index = self.RightOpenTime.currentIndex()
@@ -2589,7 +2589,7 @@ class LaserCalibrationDialog(QDialog):
                 if self.SleepStart == 1:  # only run once
                     self.SleepStart = 0
                     self.threadpool2.start(self.worker2)
-                if self.Open.isChecked() is False or self.SleepComplete2 == 1:
+                if self.Open.isChecked() == False or self.SleepComplete2 == 1:
                     break
             self.Open.setStyleSheet("background-color : none")
             self.Open.setChecked(False)
@@ -2619,7 +2619,7 @@ class LaserCalibrationDialog(QDialog):
                     self.SleepComplete = 0
                     self._InitiateATrial()
                     self.threadpool1.start(self.worker1)
-                if self.KeepOpen.isChecked() is False:
+                if self.KeepOpen.isChecked() == False:
                     break
             self.KeepOpen.setStyleSheet("background-color : none")
             self.KeepOpen.setChecked(False)
@@ -2773,7 +2773,7 @@ class MetadataDialog(QDialog):
                 != self.RigMetadataFile.text()
                 and self.RigMetadataFile.text() != ""
             ):
-                if dont_clear is False:
+                if dont_clear == False:
                     # clear probe angles if the rig metadata file is changed
                     self.meta_data["session_metadata"]["probes"] = {}
                     self.meta_data["session_metadata"]["microscopes"] = {}

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -2660,7 +2660,7 @@ class Window(QMainWindow):
         allow_reset (bool) allows the Baseweight etc. parameters to be reset to the empty string
         """
         try:
-            if self.actionTime_distribution.isChecked() is True:
+            if self.actionTime_distribution.isChecked() == True:
                 self.PlotTime._Update(self)
         except Exception:
             logging.error(traceback.format_exc())
@@ -2889,7 +2889,7 @@ class Window(QMainWindow):
             ):
                 if (
                     child.objectName() in ["qt_spinbox_lineedit", None, ""]
-                    or child.isEnabled() is False
+                    or child.isEnabled() == False
                 ):  # I don't understand where the qt_spinbox_lineedit comes from.
                     continue
                 if (
@@ -3447,7 +3447,7 @@ class Window(QMainWindow):
         if self.OpenOptogenetics == 0:
             self.Opto_dialog = OptogeneticsDialog(MainWindow=self)
             self.OpenOptogenetics = 1
-        if self.action_Optogenetics.isChecked() is True:
+        if self.action_Optogenetics.isChecked() == True:
             self.Opto_dialog.show()
         else:
             self.Opto_dialog.hide()
@@ -3457,7 +3457,7 @@ class Window(QMainWindow):
         if self.OpenCamera == 0:
             self.Camera_dialog = CameraDialog(MainWindow=self)
             self.OpenCamera = 1
-        if self.action_Camera.isChecked() is True:
+        if self.action_Camera.isChecked() == True:
             self.Camera_dialog.show()
         else:
             self.Camera_dialog.hide()
@@ -3505,7 +3505,7 @@ class Window(QMainWindow):
         if self.OpenMetadata == 0:
             self.Metadata_dialog = MetadataDialog(MainWindow=self)
             self.OpenMetadata = 1
-        if self.actionMeta_Data.isChecked() is True:
+        if self.actionMeta_Data.isChecked() == True:
             self.Metadata_dialog.show()
         else:
             self.Metadata_dialog.hide()
@@ -3516,7 +3516,7 @@ class Window(QMainWindow):
                 MainWindow=self
             )
             self.OpenWaterCalibration = 1
-        if self.action_Calibration.isChecked() is True:
+        if self.action_Calibration.isChecked() == True:
             self.WaterCalibration_dialog.show()
         else:
             self.WaterCalibration_dialog.hide()
@@ -3527,7 +3527,7 @@ class Window(QMainWindow):
                 MainWindow=self
             )
             self.OpenLaserCalibration = 1
-        if self.actionLaser_Calibration.isChecked() is True:
+        if self.actionLaser_Calibration.isChecked() == True:
             self.LaserCalibration_dialog.show()
         else:
             self.LaserCalibration_dialog.hide()
@@ -3542,7 +3542,7 @@ class Window(QMainWindow):
             self.TimeDistribution_dialog.setWindowTitle(
                 "Simulated time distribution"
             )
-        if self.actionTime_distribution.isChecked() is True:
+        if self.actionTime_distribution.isChecked() == True:
             self.TimeDistribution_dialog.show()
         else:
             self.TimeDistribution_dialog.hide()
@@ -3575,7 +3575,7 @@ class Window(QMainWindow):
             self.LickSta_dialog = LickStaDialog(MainWindow=self)
             self.LickSta = 1
             self.LickSta_dialog.setWindowTitle("Licks statistics")
-        if self.actionLicks_sta.isChecked() is True:
+        if self.actionLicks_sta.isChecked() == True:
             self.LickSta_dialog.show()
         else:
             self.LickSta_dialog.hide()
@@ -3999,7 +3999,6 @@ class Window(QMainWindow):
                     ]
                 ):
                     self._AddWaterLogResult(session)
-
 
         except Exception as e:
             logging.warning(
@@ -6166,7 +6165,7 @@ class Window(QMainWindow):
 
         self._StartTrialLoop(GeneratedTrials, worker1, worker_save)
 
-        if self.actionDrawing_after_stopping.isChecked() is True:
+        if self.actionDrawing_after_stopping.isChecked() == True:
             try:
                 self.PlotM._Update(
                     GeneratedTrials=GeneratedTrials, Channel=self.Channel2
@@ -6347,7 +6346,7 @@ class Window(QMainWindow):
                         self.Start.setStyleSheet("background-color : none")
                         break
                 # receive licks and update figures
-                if self.actionDrawing_after_stopping.isChecked() is False:
+                if self.actionDrawing_after_stopping.isChecked() == False:
                     self.PlotM._Update(
                         GeneratedTrials=GeneratedTrials, Channel=self.Channel2
                     )
@@ -6411,7 +6410,7 @@ class Window(QMainWindow):
                         )
 
                 # save the data everytrial
-                if GeneratedTrials.CurrentSimulation is True:
+                if GeneratedTrials.CurrentSimulation == True:
                     GeneratedTrials._GetAnimalResponse(
                         self.Channel, self.Channel3, self.data_lock
                     )
@@ -6429,7 +6428,7 @@ class Window(QMainWindow):
                     GeneratedTrials.B_CurrentTrialN > 0
                     and self.previous_backup_completed == 1
                     and self.save_each_trial
-                    and GeneratedTrials.CurrentSimulation is False
+                    and GeneratedTrials.CurrentSimulation == False
                 ):
                     self.previous_backup_completed = 0
                     self.threadpool6.start(worker_save)

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -945,7 +945,7 @@ class generate_metadata:
         Make the audio stimulus metadata
         """
         self.behavior_stimulus = []
-        if self.has_behavior_data is False:
+        if self.has_behavior_data == False:
             logging.info("No behavior data stream detected!")
             return
 
@@ -1376,7 +1376,7 @@ class generate_metadata:
         Make the behavior stream metadata
         """
 
-        if self.has_behavior_data is False:
+        if self.has_behavior_data == False:
             self.behavior_streams = []
             logging.info("No behavior data detected!")
             return
@@ -1408,9 +1408,7 @@ class generate_metadata:
         self.behavior_software = []
         try:
             # Get information about task repository
-            commit_ID = (
-                self.session_model.commit_hash
-            )
+            commit_ID = self.session_model.commit_hash
             current_branch = (
                 subprocess.check_output(["git", "branch", "--show-current"])
                 .decode("ascii")

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -407,7 +407,7 @@ class GenerateTrials:
                 self.BaitPermitted = False
         else:
             self.BaitPermitted = True
-        if self.BaitPermitted is False:
+        if self.BaitPermitted == False:
             logging.warning(
                 "The active side has no reward due to consecutive \nselections("
                 + str(MaxCLen)
@@ -2497,7 +2497,7 @@ class GenerateTrials:
         if self.TP_Task in ["Coupled Baiting", "Uncoupled Baiting"]:
             self.CurrentBait = self.CurrentBait | self.B_Baited
         # For task rewardN, if this is the "initial N trials" of the active side, no bait will be be given.
-        if self.BaitPermitted is False:
+        if self.BaitPermitted == False:
             # no reward in the active side
             max_index = np.argmax(self.B_CurrentRewardProb)
             self.CurrentBait[max_index] = False
@@ -2599,8 +2599,8 @@ class GenerateTrials:
     def _CheckSimulationSession(self):
         """To check if this is a simulation session"""
         if (
-            self.win.actionWin_stay_lose_switch.isChecked() is True
-            or self.win.actionRandom_choice.isChecked() is True
+            self.win.actionWin_stay_lose_switch.isChecked() == True
+            or self.win.actionRandom_choice.isChecked() == True
         ):
             self.CurrentSimulation = True
             self.B_SimulationSession.append(True)

--- a/src/foraging_gui/MyFunctions.py
+++ b/src/foraging_gui/MyFunctions.py
@@ -807,10 +807,10 @@ class GenerateTrials:
             self.BS_CurrentBlockTrialN[i] = length[-1]
             index[i] = indexN[-1]
         self.BS_RewardedTrialN_CurrentLeftBlock = np.sum(
-            B_RewardedHistory[0][index[0][0] : index[0][1] + 1] is True
+            B_RewardedHistory[0][index[0][0] : index[0][1] + 1] == True
         )
         self.BS_RewardedTrialN_CurrentRightBlock = np.sum(
-            B_RewardedHistory[1][index[1][0] : index[1][1] + 1] is True
+            B_RewardedHistory[1][index[1][0] : index[1][1] + 1] == True
         )
         self.AllRewardThisBlock = (
             self.BS_RewardedTrialN_CurrentLeftBlock
@@ -845,7 +845,7 @@ class GenerateTrials:
             self.BS_RespondedRate = np.nan
         else:
             self.BS_RespondedRate = self.BS_FinisheTrialN / self.BS_AllTrialN
-        self.BS_RewardTrialN = np.sum(self.B_RewardedHistory is True)
+        self.BS_RewardTrialN = np.sum(self.B_RewardedHistory == True)
         B_RewardedHistory = self.B_RewardedHistory.copy()
         # auto reward is considered as reward
         Ind = range(len(self.B_RewardedHistory[0]))
@@ -853,8 +853,8 @@ class GenerateTrials:
             B_RewardedHistory[i] = np.logical_or(
                 self.B_RewardedHistory[i], self.B_AutoWaterTrial[i][Ind]
             )
-        self.BS_RewardN = np.sum(B_RewardedHistory[0] is True) + np.sum(
-            B_RewardedHistory[1] is True
+        self.BS_RewardN = np.sum(B_RewardedHistory[0] == True) + np.sum(
+            B_RewardedHistory[1] == True
         )
 
         (
@@ -893,8 +893,8 @@ class GenerateTrials:
             + BS_auto_water_left
             + BS_auto_water_right
         )
-        self.BS_LeftRewardTrialN = np.sum(self.B_RewardedHistory[0] is True)
-        self.BS_RightRewardTrialN = np.sum(self.B_RewardedHistory[1] is True)
+        self.BS_LeftRewardTrialN = np.sum(self.B_RewardedHistory[0] == True)
+        self.BS_RightRewardTrialN = np.sum(self.B_RewardedHistory[1] == True)
         self.BS_LeftChoiceN = np.sum(self.B_AnimalResponseHistory == 0)
         self.BS_RightChoiceN = np.sum(self.B_AnimalResponseHistory == 1)
         self.BS_OverallRewardRate = self.BS_RewardTrialN / (
@@ -2153,9 +2153,9 @@ class GenerateTrials:
                             extra={"tags": [self.win.warning_log_tag]},
                         )
                     elif (
-                        np.all(B_RewardedHistory[0][-UnrewardedN:] is False)
+                        np.all(B_RewardedHistory[0][-UnrewardedN:] == False)
                         and np.all(
-                            B_RewardedHistory[1][-UnrewardedN:] is False
+                            B_RewardedHistory[1][-UnrewardedN:] == False
                         )
                         and np.shape(B_RewardedHistory[0])[0] >= UnrewardedN
                     ):
@@ -2652,7 +2652,7 @@ class GenerateTrials:
             self.B_CurrentRewarded[1] = False
             self.B_CurrentRewarded[0] = True
         elif (
-            self.B_AnimalCurrentResponse == 0 and self.CurrentBait[0] is False
+            self.B_AnimalCurrentResponse == 0 and self.CurrentBait[0] == False
         ):
             self.B_Baited[0] = False
             self.B_CurrentRewarded[0] = False
@@ -2662,7 +2662,7 @@ class GenerateTrials:
             self.B_CurrentRewarded[0] = False
             self.B_CurrentRewarded[1] = True
         elif (
-            self.B_AnimalCurrentResponse == 1 and self.CurrentBait[1] is False
+            self.B_AnimalCurrentResponse == 1 and self.CurrentBait[1] == False
         ):
             self.B_Baited[1] = False
             self.B_CurrentRewarded[0] = False

--- a/src/foraging_gui/Visualization.py
+++ b/src/foraging_gui/Visualization.py
@@ -200,25 +200,25 @@ class PlotV(FigureCanvas):
         LeftChoice_Rewarded = np.where(
             np.logical_and(
                 self.B_AnimalResponseHistory == 0,
-                self.B_RewardedHistory[0] is True,
+                self.B_RewardedHistory[0] == True,
             )
         )
         np.where(
             np.logical_and(
                 self.B_AnimalResponseHistory == 0,
-                self.B_RewardedHistory[0] is False,
+                self.B_RewardedHistory[0] == False,
             )
         )
         RightChoice_Rewarded = np.where(
             np.logical_and(
                 self.B_AnimalResponseHistory == 1,
-                self.B_RewardedHistory[1] is True,
+                self.B_RewardedHistory[1] == True,
             )
         )
         np.where(
             np.logical_and(
                 self.B_AnimalResponseHistory == 1,
-                self.B_RewardedHistory[1] is False,
+                self.B_RewardedHistory[1] == False,
             )
         )
 
@@ -277,8 +277,8 @@ class PlotV(FigureCanvas):
         NoResponse = np.where(self.B_AnimalResponseHistory == 2)
 
         if self.B_BaitHistory.shape[1] > self.B_AnimalResponseHistory.shape[0]:
-            LeftBait = np.where(self.B_BaitHistory[0][:-1])
-            RightBait = np.where(self.B_BaitHistory[1][:-1])
+            LeftBait = np.where(self.B_BaitHistory[0][:-1]==True)
+            RightBait = np.where(self.B_BaitHistory[1][:-1]==True)
             # plot the upcoming trial start time
             if self.B_CurrentTrialN > 0:
                 NewTrialStart = np.array(self.B_BTime[-1])
@@ -305,7 +305,7 @@ class PlotV(FigureCanvas):
                 color="k",
                 alpha=0.3,
             )
-            if self.B_BaitHistory[0][-1]:
+            if self.B_BaitHistory[0][-1] == True:
                 self.ax1.plot(
                     NewTrialStart2,
                     -0.2,
@@ -314,7 +314,7 @@ class PlotV(FigureCanvas):
                     markersize=self.MarkerSize,
                     alpha=0.4,
                 )
-            if self.B_BaitHistory[1][-1]:
+            if self.B_BaitHistory[1][-1] == True:
                 self.ax1.plot(
                     NewTrialStart2,
                     1.2,


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- #1468 used ruff to fix linter complaints. This introduced bugs. 
-  I could not revert the commit since other commits had already been merged, and I didn't want to revert everything
- I believe the issues are caused by the following mistake
    - `1 == True` evaluates to True
    - `1 is True` evaluates to False
    - `1` evaluates to True
- I went through the commits in #1468 and corrected the instances where I believe this was causing a problem

### What issues or discussions does this update address?
- resolves #1492 
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/1051

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- none


