### PR TITLE
changing FIP metadata detector exposure time unit

### DIFF
--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -907,7 +907,7 @@ class generate_metadata:
                         name=current_detector["name"],
                         exposure_time=exposure_time,
                         exposure_time_unit=TimeUnit.US,
-                        trigger_type=TriggerType.INTERNAL,
+                        trigger_type=TriggerType.EXTERNAL,
                     )
                 )
 

--- a/src/foraging_gui/GenerateMetadata.py
+++ b/src/foraging_gui/GenerateMetadata.py
@@ -42,6 +42,7 @@ from aind_data_schema_models.units import (
     PowerUnit,
     SizeUnit,
     SoundIntensityUnit,
+    TimeUnit
 )
 
 import foraging_gui
@@ -905,6 +906,7 @@ class generate_metadata:
                     DetectorConfig(
                         name=current_detector["name"],
                         exposure_time=exposure_time,
+                        exposure_time_unit=TimeUnit.US,
                         trigger_type=TriggerType.INTERNAL,
                     )
                 )


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- changes FIP detector exposure time unit from ms to us

### What issues or discussions does this update address?
- resolves #1495

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [x] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- corrects metadata


