### PR TITLE
drops down waterlog log level

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4006,11 +4006,11 @@ class Window(QMainWindow):
                 ):
                     self._AddWaterLogResult(session)
                 elif self.BaseWeight.text() == "" or self.WeightAfter.text() == "":
-                    logging.error(f"Waterlog for mouse {self.behavior_session_model.subject} cannot be added to slims "
-                                  f"due do unrecorded weight information.")
+                    logging.warning(f"Waterlog for mouse {self.behavior_session_model.subject} cannot be added to slims"
+                                   f" due do unrecorded weight information.")
                 elif session is None:
-                    logging.error(f"Waterlog for mouse {self.behavior_session_model.subject} cannot be added to slims "
-                                 f"due do metadata generation failure.")
+                    logging.warning(f"Waterlog for mouse {self.behavior_session_model.subject} cannot be added to slims"
+                                  f" due do metadata generation failure.")
         except Exception as e:
             logging.warning(
                 "Meta data is not saved!",


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- drops down waterlog logging level if weight not saved or metadata generation failed 
### What issues or discussions does this update address?
- resolves [#709](https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/709)
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No


