### PR TITLE
Feat 1106 baseline load in bug

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4758,7 +4758,8 @@ class Window(QMainWindow):
                         elif isinstance(widget, QtWidgets.QDoubleSpinBox):
                             widget.setValue(float(final_value))
                         elif isinstance(widget, QtWidgets.QSpinBox):
-                            widget.setValue(int(final_value))
+                            if final_value.isnumeric(): # check in case QSpinBox has suffix or prefix
+                                widget.setValue(int(final_value))
                         elif isinstance(widget, QtWidgets.QTextEdit):
                             widget.setText(final_value)
                         elif isinstance(widget, QtWidgets.QPushButton):


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- skips loading in baseline timer value since the prefix and suffix make it not an int. I tried to change it so it saves as a int using the .value() call but can't find where in the code to change. This timer will ultimately be set from somewhere in the new curriculum so I didn't want to spec to much time digging. Jsons can now be loaded in without error
### What issues or discussions does this update address?
- resolves [#1106](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/1106)
### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
None
### Was this update tested in 446/447?
- [ ] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- Adds TP_hab_time_box but should effect pipeline