### PR TITLE
remove filter for schedule without assigned box

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1561,7 +1561,7 @@ class Window(QMainWindow):
                 for x in schedule["Mouse ID"].unique()
                 if isinstance(x, str) and (len(x) > 3) and ("/" not in x)
             ]
-            self.schedule = schedule.dropna(subset=["Mouse ID", "Box"]).copy()
+            self.schedule = schedule.dropna(subset=["Mouse ID"]).copy()
             logging.info("Loaded behavior schedule")
         else:
             self.schedule_mice = None


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Does not filter out schedule rows without a box assignment

### What issues or discussions does this update address?
- https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/609#issuecomment-2845356968

### Describe the expected change in behavior from the perspective of the experimenter
Box assignments are not required for `check_schedule` functionality to run

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- [ ] tested

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- none


