### PR TITLE
deindents return for checking photometery

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -6207,7 +6207,7 @@ class Window(QMainWindow):
                 self.Start.setChecked(False)
                 return False
 
-            return True
+        return True
 
     def session_end_tasks(self):
         """


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- de indents return true when checking if photometery is set up correctly 
### What issues or discussions does this update address?
- resolves [#1120](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/1120#issuecomment-2852577537)
### Describe the expected change in behavior from the perspective of the experimenter
- running fip in any order should now work 
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [x] 446/7

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?

- No

