### PR TITLE
Queries relative pos from aind stage

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1163,7 +1163,7 @@ class Window(QMainWindow):
         elif self.stage_widget is not None:  # aind stage
             # Get absolute position of motors in AIND stage
             positions = (
-                self.stage_widget.stage_model.get_current_positions_mm()
+                self.stage_widget.stage_model.get_current_positions_mm(rel_to_monument=True)
             )
             return {
                 "x": positions[0],


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Queries relative pos from aind stage instead of absolute 
### What issues or discussions does this update address?
Per @nathan-mars 

> We found a bug in the DF GUI where the lickspout coordinates are saved for the next session. Absolute coordinates are saved (referenced to stage limits) but when they are opened the next day they are read as monument coordinates (referenced to the monument that we use to correct rig to rig variance). Stage widget adds the monument offset (to convert monument coordinate → absolute coordinate) to determine the absolute coordinate to send to the controller, except it is a large number past limits. Monument coordinates are what the users see in the stage widget text boxes. 

### Describe the expected change in behavior from the perspective of the experimenter
 - No
### Describe any manual update steps for task computers
- None
### Was this update tested in 446/447?
- [ ] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- No

