### PR TITLE
Safer Ephys saving.

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4067,8 +4067,17 @@ class Window(QMainWindow):
                     with open(self.SaveFile, "w") as outfile:
                         json.dump(Obj2, outfile, indent=4, cls=NumpyEncoder)
                 elif self.SaveFile.endswith(".json"):
-                    with open(self.SaveFile, "w") as outfile:
+                    # Crashses during save can corupt a json file.
+                    # Make tmp file to save to
+                    tmp_file_name = self.SaveFile.split('.json')[0]
+                    tmp_file_name = tmp_file_name + '_tmp.json'
+                    with open(tmp_file_name, "w") as outfile:
                         json.dump(Obj, outfile, indent=4, cls=NumpyEncoder)
+                    # After file is safely saved, remove the old save file
+                    # and rewrite the new one.
+                    if os.path.isfile(self.SaveFile):
+                        os.remove(self.SaveFile)
+                    os.rename(tmp_file_name,self.SaveFile)
 
         # Toggle unsaved data to False
         if BackupSave == 0:


### PR DESCRIPTION
We have, in cases of high computer load, had the gui crash during ephys recordings. If the crash happens while the file is saving (which it seems to do more often than not), the result is a corrupt JSON that seems to be unrecoverable. This bug has caused us to lose valuable segments of ephys+behavior data.

Here, I have modified the save function to (1) save a new file each trial called "tmp" (2) once tmp is safely saved, delete the old log and (3) rename tmp to the name of the desired json log file. This way only the last trial of the task will be lost if something gets corrupted during the saving process. This does not increase the saving load on any trial, it simply avoids directly overwriting data to prevent loss.

I been running this solution since May on on rig 2 and it seems to be stable. Because it is hard to get the task to crash in a controlled way it is difficult to confirm that it is totally ephys safe, but it should be much more robust. In the event of a crash, what should (theoretically) happen is that the "tmp" file should be corrupted leaving a health json file from the last trial.

A couple of notes
(1) A better way to do this would be to save only information for the last trial each trial, but this solution was vetoed in the past due to fears about extra effort to maintain. The proposed fix here achieves a similar goal, albeit with higher "save" load on each trial.

(2) I accidently committed these changes on a computer with Galen's github logged on.


Thanks!

