### PR TITLE
Add "transfer_service_job_type" to Settings and watchdog manifest

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1814,6 +1814,7 @@ class Window(QMainWindow):
                 "aind_watchdog_service",
                 "manifest",
             ),
+            "transfer_service_job_type": "dynamic_foraging",
             "auto_engage": True,
             "clear_figure_after_save": True,
             "add_default_project_name": True,
@@ -7079,6 +7080,7 @@ class Window(QMainWindow):
             contents = {
                 "acquisition_datetime": self.behavior_session_model.date,
                 "name": self.behavior_session_model.session_name,
+                "transfer_service_job_type": self.Settings.get("transfer_service_job_type"),
                 "platform": "behavior",
                 "subject_id": int(self.behavior_session_model.subject),
                 "capsule_id": capsule_id,


### PR DESCRIPTION
### Describe changes:
Adds `transfer_service_job_type` to Settings and watchdog manifest to trigger a predefined job to run on the VAST before upload to s3. This should be deployed alongside aind-watchdog-service 0.1.6, and supports switching to aind-data-transfer-service V2 endpoints.

### What issues or discussions does this update address?
#1586 

### Describe the expected change in behavior from the perspective of the experimenter
No change

### Describe any manual update steps for task computers
No change, unless the job_type changes (coordinate with Jon). It defaults to "dynamic_foraging", but can be changed in the Settings file

### Was this update tested in 446/447?
No

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
Adds a key to the watchdog manifest, per the new features added in 0.1.6 (https://github.com/AllenNeuralDynamics/aind-watchdog-service/pull/135)



