### PR TITLE
Implement FFMPEG logger

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -5,7 +5,7 @@
     <Package id="AForge.Video" version="2.2.5" />
     <Package id="AForge.Video.DirectShow" version="2.2.5" />
     <Package id="AllenNeuralDynamics.AindBehaviorServices" version="0.8.0" />
-    <Package id="AllenNeuralDynamics.Core" version="0.4.0" />
+    <Package id="AllenNeuralDynamics.Core" version="0.4.1" />
     <Package id="AllenNeuralDynamics.EnvironmentSensor" version="0.3.0" />
     <Package id="AllenNeuralDynamics.LicketySplitLickDetector" version="0.1.0-preview2024020101" />
     <Package id="AssimpNet" version="4.1.0" />
@@ -21,7 +21,7 @@
     <Package id="Bonsai.Editor" version="2.8.0" />
     <Package id="Bonsai.FFmpeg" version="0.1.0" />
     <Package id="Bonsai.Gui" version="0.1.0" />
-    <Package id="Bonsai.Harp" version="3.5.2" />
+    <Package id="Bonsai.Harp" version="3.6.0" />
     <Package id="Bonsai.Harp.Design" version="3.5.0" />
     <Package id="Bonsai.Numerics" version="0.7.0" />
     <Package id="Bonsai.Osc" version="2.7.0" />
@@ -114,7 +114,7 @@
     <AssemblyLocation assemblyName="AForge.Video" processorArchitecture="MSIL" location="Packages\AForge.Video.2.2.5\lib\AForge.Video.dll" />
     <AssemblyLocation assemblyName="AForge.Video.DirectShow" processorArchitecture="MSIL" location="Packages\AForge.Video.DirectShow.2.2.5\lib\AForge.Video.DirectShow.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.AindBehaviorServices" processorArchitecture="MSIL" location="Packages\AllenNeuralDynamics.AindBehaviorServices.0.8.0\lib\net472\AllenNeuralDynamics.AindBehaviorServices.dll" />
-    <AssemblyLocation assemblyName="AllenNeuralDynamics.Core" processorArchitecture="MSIL" location="Packages\AllenNeuralDynamics.Core.0.4.0\lib\net472\AllenNeuralDynamics.Core.dll" />
+    <AssemblyLocation assemblyName="AllenNeuralDynamics.Core" processorArchitecture="MSIL" location="Packages\AllenNeuralDynamics.Core.0.4.1\lib\net472\AllenNeuralDynamics.Core.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.EnvironmentSensor" processorArchitecture="MSIL" location="Packages\AllenNeuralDynamics.EnvironmentSensor.0.3.0\lib\net462\AllenNeuralDynamics.EnvironmentSensor.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.LicketySplitLickDetector" processorArchitecture="MSIL" location="Packages\AllenNeuralDynamics.LicketySplitLickDetector.0.1.0-preview2024020101\lib\net462\AllenNeuralDynamics.LicketySplitLickDetector.dll" />
     <AssemblyLocation assemblyName="AssimpNet" processorArchitecture="MSIL" location="Packages\AssimpNet.4.1.0\lib\net40\AssimpNet.dll" />
@@ -130,7 +130,7 @@
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.FFmpeg" processorArchitecture="MSIL" location="Packages\Bonsai.FFmpeg.0.1.0\lib\net462\Bonsai.FFmpeg.dll" />
     <AssemblyLocation assemblyName="Bonsai.Gui" processorArchitecture="MSIL" location="Packages\Bonsai.Gui.0.1.0\lib\net472\Bonsai.Gui.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.2\lib\net462\Bonsai.Harp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.6.0\lib\net462\Bonsai.Harp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.Design.3.5.0\lib\net462\Bonsai.Harp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.7.0\lib\net462\Bonsai.Numerics.dll" />
     <AssemblyLocation assemblyName="Bonsai.Osc" processorArchitecture="MSIL" location="Packages\Bonsai.Osc.2.7.0\lib\net462\Bonsai.Osc.dll" />

--- a/src/workflows/foraging.bonsai
+++ b/src/workflows/foraging.bonsai
@@ -21,7 +21,6 @@
                  xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
                  xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
                  xmlns:spk="clr-namespace:Bonsai.Spinnaker;assembly=Bonsai.Spinnaker"
-                 xmlns:ffmpeg="clr-namespace:Bonsai.FFmpeg;assembly=Bonsai.FFmpeg"
                  xmlns:p6="clr-namespace:;assembly=Extensions"
                  xmlns:gui="clr-namespace:Bonsai.Gui;assembly=Bonsai.Gui"
                  xmlns="https://bonsai-rx.org/2018/workflow">
@@ -4791,421 +4790,423 @@
           <Edges />
         </Workflow>
       </Expression>
-      <Expression xsi:type="GroupWorkflow">
-        <Name>Optogenetics2</Name>
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>WaveForm1_1</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>WaveForm1_2</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Zip" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="dsp:Concat">
-                <dsp:Axis>0</dsp:Axis>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Location1Size</Name>
-            </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="BufferSize" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>TriggerSource</Name>
-            </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="TriggerSource" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="rx:SelectMany">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="ExternalizedMapping">
-                    <Property Name="BufferSize" />
-                    <Property Name="TriggerSource" />
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="p5:TriggeredAnalogOutput">
-                      <p5:SignalSource />
-                      <p5:TriggerSource>/Dev1/PFI0</p5:TriggerSource>
-                      <p5:SampleRate>5000</p5:SampleRate>
-                      <p5:ActiveEdge>Rising</p5:ActiveEdge>
-                      <p5:SampleMode>FiniteSamples</p5:SampleMode>
-                      <p5:BufferSize>50002</p5:BufferSize>
-                      <p5:Channels>
-                        <p5:AnalogOutputChannelConfiguration>
-                          <p5:ChannelName />
-                          <p5:MinimumValue>-10</p5:MinimumValue>
-                          <p5:MaximumValue>10</p5:MaximumValue>
-                          <p5:PhysicalChannel>Dev1/ao0</p5:PhysicalChannel>
-                          <p5:VoltageUnits>Volts</p5:VoltageUnits>
-                        </p5:AnalogOutputChannelConfiguration>
-                        <p5:AnalogOutputChannelConfiguration>
-                          <p5:ChannelName />
-                          <p5:MinimumValue>-10</p5:MinimumValue>
-                          <p5:MaximumValue>10</p5:MaximumValue>
-                          <p5:PhysicalChannel>Dev1/ao1</p5:PhysicalChannel>
-                          <p5:VoltageUnits>Volts</p5:VoltageUnits>
-                        </p5:AnalogOutputChannelConfiguration>
-                      </p5:Channels>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="Combinator">
-                    <Combinator xsi:type="IntProperty">
-                      <Value>1</Value>
-                    </Combinator>
-                  </Expression>
-                  <Expression xsi:type="osc:Format">
-                    <osc:Address>/FinishOfWave1_1</osc:Address>
-                  </Expression>
-                  <Expression xsi:type="MulticastSubject">
-                    <Name>ToBonsaiOSC4</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="2" Label="Source2" />
-                  <Edge From="1" To="2" Label="Source2" />
-                  <Edge From="2" To="3" Label="Source1" />
-                  <Edge From="3" To="4" Label="Source1" />
-                  <Edge From="4" To="5" Label="Source1" />
-                  <Edge From="5" To="6" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>OptogeneticsCalibration</Name>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreatePulseDO0Payload">
-                <beh:PulseDO0>1</beh:PulseDO0>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
-                <beh:OutputToggle>DO0</beh:OutputToggle>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>DO0</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Equal">
-              <Operand xsi:type="IntProperty">
-                <Value>1</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreatePulseDO0Payload">
-                <beh:PulseDO0>10</beh:PulseDO0>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Delay">
-                <rx:DueTime>PT1S</rx:DueTime>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
-                <beh:OutputToggle>DO0</beh:OutputToggle>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Repeat" />
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>DO1</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Equal">
-              <Operand xsi:type="IntProperty">
-                <Value>1</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreatePulseDO1Payload">
-                <beh:PulseDO1>10</beh:PulseDO1>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Delay">
-                <rx:DueTime>PT1S</rx:DueTime>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
-                <beh:OutputToggle>DO1</beh:OutputToggle>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Repeat" />
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>DO2</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Equal">
-              <Operand xsi:type="IntProperty">
-                <Value>1</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreatePulseDO2Payload">
-                <beh:PulseDO2>10</beh:PulseDO2>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Delay">
-                <rx:DueTime>PT1S</rx:DueTime>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
-                <beh:OutputToggle>DO2</beh:OutputToggle>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Repeat" />
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>DO3</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Equal">
-              <Operand xsi:type="IntProperty">
-                <Value>1</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreatePulseDO3Payload">
-                <beh:PulseDO3>1</beh:PulseDO3>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Delay">
-                <rx:DueTime>PT1S</rx:DueTime>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
-                <beh:OutputToggle>DO3</beh:OutputToggle>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Repeat" />
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Port2</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Equal">
-              <Operand xsi:type="IntProperty">
-                <Value>1</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreatePulseDOPort2Payload">
-                <beh:PulseDOPort2>1</beh:PulseDOPort2>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Delay">
-                <rx:DueTime>PT1S</rx:DueTime>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="beh:CreateMessage">
-              <harp:MessageType>Write</harp:MessageType>
-              <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
-                <beh:OutputToggle>DOPort2</beh:OutputToggle>
-              </harp:Payload>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>BehaviorCommands</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Repeat" />
-            </Expression>
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="2" Label="Source1" />
-            <Edge From="1" To="2" Label="Source2" />
-            <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="8" Label="Source1" />
-            <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="8" Label="Source2" />
-            <Edge From="6" To="7" Label="Source1" />
-            <Edge From="7" To="8" Label="Source3" />
-            <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
-            <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source1" />
-            <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="20" Label="Source1" />
-            <Edge From="20" To="21" Label="Source1" />
-            <Edge From="21" To="22" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
-            <Edge From="24" To="25" Label="Source1" />
-            <Edge From="25" To="26" Label="Source1" />
-            <Edge From="26" To="27" Label="Source1" />
-            <Edge From="27" To="28" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
-            <Edge From="29" To="30" Label="Source1" />
-            <Edge From="30" To="31" Label="Source1" />
-            <Edge From="32" To="33" Label="Source1" />
-            <Edge From="33" To="34" Label="Source1" />
-            <Edge From="34" To="35" Label="Source1" />
-            <Edge From="35" To="36" Label="Source1" />
-            <Edge From="36" To="37" Label="Source1" />
-            <Edge From="37" To="38" Label="Source1" />
-            <Edge From="38" To="39" Label="Source1" />
-            <Edge From="39" To="40" Label="Source1" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="42" To="43" Label="Source1" />
-            <Edge From="43" To="44" Label="Source1" />
-            <Edge From="44" To="45" Label="Source1" />
-            <Edge From="45" To="46" Label="Source1" />
-            <Edge From="46" To="47" Label="Source1" />
-            <Edge From="47" To="48" Label="Source1" />
-            <Edge From="48" To="49" Label="Source1" />
-            <Edge From="50" To="51" Label="Source1" />
-            <Edge From="51" To="52" Label="Source1" />
-            <Edge From="52" To="53" Label="Source1" />
-            <Edge From="53" To="54" Label="Source1" />
-            <Edge From="54" To="55" Label="Source1" />
-            <Edge From="55" To="56" Label="Source1" />
-            <Edge From="56" To="57" Label="Source1" />
-            <Edge From="57" To="58" Label="Source1" />
-          </Edges>
-        </Workflow>
+      <Expression xsi:type="Disable">
+        <Builder xsi:type="GroupWorkflow">
+          <Name>Optogenetics2</Name>
+          <Workflow>
+            <Nodes>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>WaveForm1_1</Name>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>WaveForm1_2</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Zip" />
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="dsp:Concat">
+                  <dsp:Axis>0</dsp:Axis>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>Location1Size</Name>
+              </Expression>
+              <Expression xsi:type="PropertyMapping">
+                <PropertyMappings>
+                  <Property Name="BufferSize" />
+                </PropertyMappings>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>TriggerSource</Name>
+              </Expression>
+              <Expression xsi:type="PropertyMapping">
+                <PropertyMappings>
+                  <Property Name="TriggerSource" />
+                </PropertyMappings>
+              </Expression>
+              <Expression xsi:type="rx:SelectMany">
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="ExternalizedMapping">
+                      <Property Name="BufferSize" />
+                      <Property Name="TriggerSource" />
+                    </Expression>
+                    <Expression xsi:type="Combinator">
+                      <Combinator xsi:type="p5:TriggeredAnalogOutput">
+                        <p5:SignalSource />
+                        <p5:TriggerSource>/Dev1/PFI0</p5:TriggerSource>
+                        <p5:SampleRate>5000</p5:SampleRate>
+                        <p5:ActiveEdge>Rising</p5:ActiveEdge>
+                        <p5:SampleMode>FiniteSamples</p5:SampleMode>
+                        <p5:BufferSize>50002</p5:BufferSize>
+                        <p5:Channels>
+                          <p5:AnalogOutputChannelConfiguration>
+                            <p5:ChannelName />
+                            <p5:MinimumValue>-10</p5:MinimumValue>
+                            <p5:MaximumValue>10</p5:MaximumValue>
+                            <p5:PhysicalChannel>Dev1/ao0</p5:PhysicalChannel>
+                            <p5:VoltageUnits>Volts</p5:VoltageUnits>
+                          </p5:AnalogOutputChannelConfiguration>
+                          <p5:AnalogOutputChannelConfiguration>
+                            <p5:ChannelName />
+                            <p5:MinimumValue>-10</p5:MinimumValue>
+                            <p5:MaximumValue>10</p5:MaximumValue>
+                            <p5:PhysicalChannel>Dev1/ao1</p5:PhysicalChannel>
+                            <p5:VoltageUnits>Volts</p5:VoltageUnits>
+                          </p5:AnalogOutputChannelConfiguration>
+                        </p5:Channels>
+                      </Combinator>
+                    </Expression>
+                    <Expression xsi:type="Combinator">
+                      <Combinator xsi:type="IntProperty">
+                        <Value>1</Value>
+                      </Combinator>
+                    </Expression>
+                    <Expression xsi:type="osc:Format">
+                      <osc:Address>/FinishOfWave1_1</osc:Address>
+                    </Expression>
+                    <Expression xsi:type="MulticastSubject">
+                      <Name>ToBonsaiOSC4</Name>
+                    </Expression>
+                    <Expression xsi:type="WorkflowOutput" />
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="2" Label="Source2" />
+                    <Edge From="1" To="2" Label="Source2" />
+                    <Edge From="2" To="3" Label="Source1" />
+                    <Edge From="3" To="4" Label="Source1" />
+                    <Edge From="4" To="5" Label="Source1" />
+                    <Edge From="5" To="6" Label="Source1" />
+                  </Edges>
+                </Workflow>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>OptogeneticsCalibration</Name>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreatePulseDO0Payload">
+                  <beh:PulseDO0>1</beh:PulseDO0>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
+                  <beh:OutputToggle>DO0</beh:OutputToggle>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>DO0</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Take">
+                  <rx:Count>1</rx:Count>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="Equal">
+                <Operand xsi:type="IntProperty">
+                  <Value>1</Value>
+                </Operand>
+              </Expression>
+              <Expression xsi:type="rx:Condition">
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="WorkflowOutput" />
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="1" Label="Source1" />
+                  </Edges>
+                </Workflow>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreatePulseDO0Payload">
+                  <beh:PulseDO0>10</beh:PulseDO0>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Delay">
+                  <rx:DueTime>PT1S</rx:DueTime>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
+                  <beh:OutputToggle>DO0</beh:OutputToggle>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Repeat" />
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>DO1</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Take">
+                  <rx:Count>1</rx:Count>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="Equal">
+                <Operand xsi:type="IntProperty">
+                  <Value>1</Value>
+                </Operand>
+              </Expression>
+              <Expression xsi:type="rx:Condition">
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="WorkflowOutput" />
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="1" Label="Source1" />
+                  </Edges>
+                </Workflow>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreatePulseDO1Payload">
+                  <beh:PulseDO1>10</beh:PulseDO1>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Delay">
+                  <rx:DueTime>PT1S</rx:DueTime>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
+                  <beh:OutputToggle>DO1</beh:OutputToggle>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Repeat" />
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>DO2</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Take">
+                  <rx:Count>1</rx:Count>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="Equal">
+                <Operand xsi:type="IntProperty">
+                  <Value>1</Value>
+                </Operand>
+              </Expression>
+              <Expression xsi:type="rx:Condition">
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="WorkflowOutput" />
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="1" Label="Source1" />
+                  </Edges>
+                </Workflow>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreatePulseDO2Payload">
+                  <beh:PulseDO2>10</beh:PulseDO2>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Delay">
+                  <rx:DueTime>PT1S</rx:DueTime>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
+                  <beh:OutputToggle>DO2</beh:OutputToggle>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Repeat" />
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>DO3</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Take">
+                  <rx:Count>1</rx:Count>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="Equal">
+                <Operand xsi:type="IntProperty">
+                  <Value>1</Value>
+                </Operand>
+              </Expression>
+              <Expression xsi:type="rx:Condition">
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="WorkflowOutput" />
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="1" Label="Source1" />
+                  </Edges>
+                </Workflow>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreatePulseDO3Payload">
+                  <beh:PulseDO3>1</beh:PulseDO3>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Delay">
+                  <rx:DueTime>PT1S</rx:DueTime>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
+                  <beh:OutputToggle>DO3</beh:OutputToggle>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Repeat" />
+              </Expression>
+              <Expression xsi:type="SubscribeSubject">
+                <Name>Port2</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Take">
+                  <rx:Count>1</rx:Count>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="Equal">
+                <Operand xsi:type="IntProperty">
+                  <Value>1</Value>
+                </Operand>
+              </Expression>
+              <Expression xsi:type="rx:Condition">
+                <Workflow>
+                  <Nodes>
+                    <Expression xsi:type="WorkflowInput">
+                      <Name>Source1</Name>
+                    </Expression>
+                    <Expression xsi:type="WorkflowOutput" />
+                  </Nodes>
+                  <Edges>
+                    <Edge From="0" To="1" Label="Source1" />
+                  </Edges>
+                </Workflow>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreatePulseDOPort2Payload">
+                  <beh:PulseDOPort2>1</beh:PulseDOPort2>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Delay">
+                  <rx:DueTime>PT1S</rx:DueTime>
+                </Combinator>
+              </Expression>
+              <Expression xsi:type="beh:CreateMessage">
+                <harp:MessageType>Write</harp:MessageType>
+                <harp:Payload xsi:type="beh:CreateOutputTogglePayload">
+                  <beh:OutputToggle>DOPort2</beh:OutputToggle>
+                </harp:Payload>
+              </Expression>
+              <Expression xsi:type="MulticastSubject">
+                <Name>BehaviorCommands</Name>
+              </Expression>
+              <Expression xsi:type="Combinator">
+                <Combinator xsi:type="rx:Repeat" />
+              </Expression>
+            </Nodes>
+            <Edges>
+              <Edge From="0" To="2" Label="Source1" />
+              <Edge From="1" To="2" Label="Source2" />
+              <Edge From="2" To="3" Label="Source1" />
+              <Edge From="3" To="8" Label="Source1" />
+              <Edge From="4" To="5" Label="Source1" />
+              <Edge From="5" To="8" Label="Source2" />
+              <Edge From="6" To="7" Label="Source1" />
+              <Edge From="7" To="8" Label="Source3" />
+              <Edge From="9" To="10" Label="Source1" />
+              <Edge From="10" To="11" Label="Source1" />
+              <Edge From="11" To="12" Label="Source1" />
+              <Edge From="12" To="13" Label="Source1" />
+              <Edge From="14" To="15" Label="Source1" />
+              <Edge From="15" To="16" Label="Source1" />
+              <Edge From="16" To="17" Label="Source1" />
+              <Edge From="17" To="18" Label="Source1" />
+              <Edge From="18" To="19" Label="Source1" />
+              <Edge From="19" To="20" Label="Source1" />
+              <Edge From="20" To="21" Label="Source1" />
+              <Edge From="21" To="22" Label="Source1" />
+              <Edge From="23" To="24" Label="Source1" />
+              <Edge From="24" To="25" Label="Source1" />
+              <Edge From="25" To="26" Label="Source1" />
+              <Edge From="26" To="27" Label="Source1" />
+              <Edge From="27" To="28" Label="Source1" />
+              <Edge From="28" To="29" Label="Source1" />
+              <Edge From="29" To="30" Label="Source1" />
+              <Edge From="30" To="31" Label="Source1" />
+              <Edge From="32" To="33" Label="Source1" />
+              <Edge From="33" To="34" Label="Source1" />
+              <Edge From="34" To="35" Label="Source1" />
+              <Edge From="35" To="36" Label="Source1" />
+              <Edge From="36" To="37" Label="Source1" />
+              <Edge From="37" To="38" Label="Source1" />
+              <Edge From="38" To="39" Label="Source1" />
+              <Edge From="39" To="40" Label="Source1" />
+              <Edge From="41" To="42" Label="Source1" />
+              <Edge From="42" To="43" Label="Source1" />
+              <Edge From="43" To="44" Label="Source1" />
+              <Edge From="44" To="45" Label="Source1" />
+              <Edge From="45" To="46" Label="Source1" />
+              <Edge From="46" To="47" Label="Source1" />
+              <Edge From="47" To="48" Label="Source1" />
+              <Edge From="48" To="49" Label="Source1" />
+              <Edge From="50" To="51" Label="Source1" />
+              <Edge From="51" To="52" Label="Source1" />
+              <Edge From="52" To="53" Label="Source1" />
+              <Edge From="53" To="54" Label="Source1" />
+              <Edge From="54" To="55" Label="Source1" />
+              <Edge From="55" To="56" Label="Source1" />
+              <Edge From="56" To="57" Label="Source1" />
+              <Edge From="57" To="58" Label="Source1" />
+            </Edges>
+          </Workflow>
+        </Builder>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>FromBonsaiOSC</Name>
@@ -5233,6 +5234,9 @@
             </Expression>
             <Expression xsi:type="rx:AsyncSubject">
               <Name>RootPath</Name>
+            </Expression>
+            <Expression xsi:type="rx:AsyncSubject">
+              <Name>LoggingRootPath</Name>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>RootPath</Name>
@@ -8029,7 +8033,33 @@
                         <Expression xsi:type="MulticastSubject">
                           <Name>BehaviorCommands</Name>
                         </Expression>
-                        <Expression xsi:type="GroupWorkflow">
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="StringProperty">
+                            <Value>-colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="rx:AsyncSubject">
+                          <Name>FfmpegInputArgs</Name>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="StringProperty">
+                            <Value>-vf "scale=out_color_matrix=bt709:out_range=full,format=bgr24,scale=out_range=full" -c:v h264_nvenc -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -metadata author="Allen Institute for Neural Dynamics" -maxrate 700M -bufsize 350M</Value>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="Combinator">
+                          <Combinator xsi:type="rx:Take">
+                            <rx:Count>1</rx:Count>
+                          </Combinator>
+                        </Expression>
+                        <Expression xsi:type="rx:AsyncSubject">
+                          <Name>FfmpegOutputArgs</Name>
+                        </Expression>
+                        <Expression xsi:type="rx:Defer">
                           <Name>SideCameraLeft</Name>
                           <Workflow>
                             <Nodes>
@@ -8114,6 +8144,7 @@
                               <Expression xsi:type="rx:PublishSubject">
                                 <Name>SideCameraLeftFrames</Name>
                               </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
                               <Expression xsi:type="SubscribeSubject">
                                 <Name>SideCameraLeftFrames</Name>
                               </Expression>
@@ -8121,38 +8152,19 @@
                                 <Combinator xsi:type="harp:CreateTimestamped" />
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/side_camera_left.csv</Format>
-                                <Selector />
+                                <Name>FfmpegOutputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="OutputArguments" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="io:CsvWriter">
-                                <io:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/side_camera_left.csv</io:FileName>
-                                <io:Append>false</io:Append>
-                                <io:Overwrite>true</io:Overwrite>
-                                <io:Suffix>None</io:Suffix>
-                                <io:IncludeHeader>false</io:IncludeHeader>
-                                <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp</io:Selector>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>Value.Image</Selector>
-                              </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/side_camera_left.avi</Format>
-                                <Selector />
+                                <Name>FfmpegInputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="InputArguments" />
                                 </PropertyMappings>
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
@@ -8163,27 +8175,14 @@
                                   <Property Name="FrameRate" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ComPorts</Name>
-                              </Expression>
-                              <Expression xsi:type="Index">
-                                <Operand xsi:type="StringProperty">
-                                  <Value>codec</Value>
-                                </Operand>
-                              </Expression>
-                              <Expression xsi:type="PropertyMapping">
-                                <PropertyMappings>
-                                  <Property Name="OutputArguments" />
-                                </PropertyMappings>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="ffmpeg:VideoWriter">
-                                  <ffmpeg:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/side_camera_left.avi</ffmpeg:FileName>
-                                  <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                                  <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
-                                  <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                                  <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24</ffmpeg:OutputArguments>
-                                </Combinator>
+                              <Expression xsi:type="IncludeWorkflow" Path="AllenNeuralDynamics.Core:LogSpinnakerFfmpeg.bonsai">
+                                <Modality>BehaviorVideos</Modality>
+                                <LogName>SideCameraLeft</LogName>
+                                <VideoExtension>mp4</VideoExtension>
+                                <OutputArguments>-vf "scale=out_color_matrix=bt709:out_range=full" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -maxrate 700M -bufsize 350M</OutputArguments>
+                                <InputArguments>-colorspace rgb -color_primaries bt709 -color_trc linear</InputArguments>
+                                <Verbosity>Verbose</Verbosity>
+                                <FrameRate>0</FrameRate>
                               </Expression>
                             </Nodes>
                             <Edges>
@@ -8203,21 +8202,15 @@
                               <Edge From="13" To="14" Label="Source1" />
                               <Edge From="14" To="15" Label="Source2" />
                               <Edge From="15" To="16" Label="Source1" />
-                              <Edge From="17" To="18" Label="Source1" />
-                              <Edge From="18" To="22" Label="Source1" />
-                              <Edge From="19" To="20" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="26" Label="Source1" />
                               <Edge From="20" To="21" Label="Source1" />
-                              <Edge From="21" To="22" Label="Source2" />
+                              <Edge From="21" To="26" Label="Source2" />
                               <Edge From="22" To="23" Label="Source1" />
-                              <Edge From="23" To="32" Label="Source1" />
+                              <Edge From="23" To="26" Label="Source3" />
                               <Edge From="24" To="25" Label="Source1" />
-                              <Edge From="25" To="26" Label="Source1" />
-                              <Edge From="26" To="32" Label="Source2" />
-                              <Edge From="27" To="28" Label="Source1" />
-                              <Edge From="28" To="32" Label="Source3" />
-                              <Edge From="29" To="30" Label="Source1" />
-                              <Edge From="30" To="31" Label="Source1" />
-                              <Edge From="31" To="32" Label="Source4" />
+                              <Edge From="25" To="26" Label="Source4" />
                             </Edges>
                           </Workflow>
                         </Expression>
@@ -8250,7 +8243,7 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:SubscribeWhen" />
                         </Expression>
-                        <Expression xsi:type="GroupWorkflow">
+                        <Expression xsi:type="rx:Defer">
                           <Name>BottomCamera</Name>
                           <Workflow>
                             <Nodes>
@@ -8335,6 +8328,7 @@
                               <Expression xsi:type="rx:PublishSubject">
                                 <Name>BottomCameraFrames</Name>
                               </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
                               <Expression xsi:type="SubscribeSubject">
                                 <Name>BottomCameraFrames</Name>
                               </Expression>
@@ -8342,41 +8336,19 @@
                                 <Combinator xsi:type="harp:CreateTimestamped" />
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/bottom_camera.csv</Format>
-                                <Selector />
+                                <Name>FfmpegOutputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="OutputArguments" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="io:CsvWriter">
-                                <io:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/bottom_camera.csv</io:FileName>
-                                <io:Append>false</io:Append>
-                                <io:Overwrite>true</io:Overwrite>
-                                <io:Suffix>None</io:Suffix>
-                                <io:IncludeHeader>false</io:IncludeHeader>
-                                <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp</io:Selector>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>Value.Image</Selector>
-                              </Expression>
-                              <Expression xsi:type="rx:PublishSubject">
-                                <Name>CameraImage_Bottom</Name>
-                              </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/bottom_camera.avi</Format>
-                                <Selector />
+                                <Name>FfmpegInputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="InputArguments" />
                                 </PropertyMappings>
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
@@ -8387,27 +8359,14 @@
                                   <Property Name="FrameRate" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ComPorts</Name>
-                              </Expression>
-                              <Expression xsi:type="Index">
-                                <Operand xsi:type="StringProperty">
-                                  <Value>codec</Value>
-                                </Operand>
-                              </Expression>
-                              <Expression xsi:type="PropertyMapping">
-                                <PropertyMappings>
-                                  <Property Name="OutputArguments" />
-                                </PropertyMappings>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="ffmpeg:VideoWriter">
-                                  <ffmpeg:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/bottom_camera.avi</ffmpeg:FileName>
-                                  <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                                  <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
-                                  <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                                  <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24</ffmpeg:OutputArguments>
-                                </Combinator>
+                              <Expression xsi:type="IncludeWorkflow" Path="AllenNeuralDynamics.Core:LogSpinnakerFfmpeg.bonsai">
+                                <Modality>BehaviorVideos</Modality>
+                                <LogName>BottomCamera</LogName>
+                                <VideoExtension>mp4</VideoExtension>
+                                <OutputArguments>-vf "scale=out_color_matrix=bt709:out_range=full" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -maxrate 700M -bufsize 350M</OutputArguments>
+                                <InputArguments>-colorspace rgb -color_primaries bt709 -color_trc linear</InputArguments>
+                                <Verbosity>Verbose</Verbosity>
+                                <FrameRate>0</FrameRate>
                               </Expression>
                             </Nodes>
                             <Edges>
@@ -8427,22 +8386,15 @@
                               <Edge From="13" To="14" Label="Source1" />
                               <Edge From="14" To="15" Label="Source2" />
                               <Edge From="15" To="16" Label="Source1" />
-                              <Edge From="17" To="18" Label="Source1" />
-                              <Edge From="18" To="22" Label="Source1" />
-                              <Edge From="19" To="20" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="26" Label="Source1" />
                               <Edge From="20" To="21" Label="Source1" />
-                              <Edge From="21" To="22" Label="Source2" />
+                              <Edge From="21" To="26" Label="Source2" />
                               <Edge From="22" To="23" Label="Source1" />
-                              <Edge From="23" To="24" Label="Source1" />
-                              <Edge From="24" To="33" Label="Source1" />
-                              <Edge From="25" To="26" Label="Source1" />
-                              <Edge From="26" To="27" Label="Source1" />
-                              <Edge From="27" To="33" Label="Source2" />
-                              <Edge From="28" To="29" Label="Source1" />
-                              <Edge From="29" To="33" Label="Source3" />
-                              <Edge From="30" To="31" Label="Source1" />
-                              <Edge From="31" To="32" Label="Source1" />
-                              <Edge From="32" To="33" Label="Source4" />
+                              <Edge From="23" To="26" Label="Source3" />
+                              <Edge From="24" To="25" Label="Source1" />
+                              <Edge From="25" To="26" Label="Source4" />
                             </Edges>
                           </Workflow>
                         </Expression>
@@ -8475,7 +8427,10 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:SubscribeWhen" />
                         </Expression>
-                        <Expression xsi:type="GroupWorkflow">
+                        <Expression xsi:type="rx:PublishSubject">
+                          <Name>BottomCameraFrames</Name>
+                        </Expression>
+                        <Expression xsi:type="rx:Defer">
                           <Name>SideCameraRight</Name>
                           <Workflow>
                             <Nodes>
@@ -8560,6 +8515,7 @@
                               <Expression xsi:type="rx:PublishSubject">
                                 <Name>SideCameraRightFrames</Name>
                               </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
                               <Expression xsi:type="SubscribeSubject">
                                 <Name>SideCameraRightFrames</Name>
                               </Expression>
@@ -8567,41 +8523,19 @@
                                 <Combinator xsi:type="harp:CreateTimestamped" />
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/side_camera_right.csv</Format>
-                                <Selector />
+                                <Name>FfmpegOutputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="OutputArguments" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="io:CsvWriter">
-                                <io:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/side_camera_right.csv</io:FileName>
-                                <io:Append>false</io:Append>
-                                <io:Overwrite>true</io:Overwrite>
-                                <io:Suffix>None</io:Suffix>
-                                <io:IncludeHeader>false</io:IncludeHeader>
-                                <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp</io:Selector>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>Value.Image</Selector>
-                              </Expression>
-                              <Expression xsi:type="rx:PublishSubject">
-                                <Name>CameraImage_Right</Name>
-                              </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/side_camera_right.avi</Format>
-                                <Selector />
+                                <Name>FfmpegInputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="InputArguments" />
                                 </PropertyMappings>
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
@@ -8612,27 +8546,14 @@
                                   <Property Name="FrameRate" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ComPorts</Name>
-                              </Expression>
-                              <Expression xsi:type="Index">
-                                <Operand xsi:type="StringProperty">
-                                  <Value>codec</Value>
-                                </Operand>
-                              </Expression>
-                              <Expression xsi:type="PropertyMapping">
-                                <PropertyMappings>
-                                  <Property Name="OutputArguments" />
-                                </PropertyMappings>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="ffmpeg:VideoWriter">
-                                  <ffmpeg:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/side_camera_right.avi</ffmpeg:FileName>
-                                  <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                                  <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
-                                  <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                                  <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24</ffmpeg:OutputArguments>
-                                </Combinator>
+                              <Expression xsi:type="IncludeWorkflow" Path="AllenNeuralDynamics.Core:LogSpinnakerFfmpeg.bonsai">
+                                <Modality>BehaviorVideos</Modality>
+                                <LogName>SideCameraRight</LogName>
+                                <VideoExtension>mp4</VideoExtension>
+                                <OutputArguments>-vf "scale=out_color_matrix=bt709:out_range=full" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -maxrate 700M -bufsize 350M</OutputArguments>
+                                <InputArguments>-colorspace rgb -color_primaries bt709 -color_trc linear</InputArguments>
+                                <Verbosity>Verbose</Verbosity>
+                                <FrameRate>0</FrameRate>
                               </Expression>
                             </Nodes>
                             <Edges>
@@ -8652,22 +8573,15 @@
                               <Edge From="13" To="14" Label="Source1" />
                               <Edge From="14" To="15" Label="Source2" />
                               <Edge From="15" To="16" Label="Source1" />
-                              <Edge From="17" To="18" Label="Source1" />
-                              <Edge From="18" To="22" Label="Source1" />
-                              <Edge From="19" To="20" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="26" Label="Source1" />
                               <Edge From="20" To="21" Label="Source1" />
-                              <Edge From="21" To="22" Label="Source2" />
+                              <Edge From="21" To="26" Label="Source2" />
                               <Edge From="22" To="23" Label="Source1" />
-                              <Edge From="23" To="24" Label="Source1" />
-                              <Edge From="24" To="33" Label="Source1" />
-                              <Edge From="25" To="26" Label="Source1" />
-                              <Edge From="26" To="27" Label="Source1" />
-                              <Edge From="27" To="33" Label="Source2" />
-                              <Edge From="28" To="29" Label="Source1" />
-                              <Edge From="29" To="33" Label="Source3" />
-                              <Edge From="30" To="31" Label="Source1" />
-                              <Edge From="31" To="32" Label="Source1" />
-                              <Edge From="32" To="33" Label="Source4" />
+                              <Edge From="23" To="26" Label="Source3" />
+                              <Edge From="24" To="25" Label="Source1" />
+                              <Edge From="25" To="26" Label="Source4" />
                             </Edges>
                           </Workflow>
                         </Expression>
@@ -8700,7 +8614,10 @@
                         <Expression xsi:type="Combinator">
                           <Combinator xsi:type="rx:SubscribeWhen" />
                         </Expression>
-                        <Expression xsi:type="GroupWorkflow">
+                        <Expression xsi:type="rx:PublishSubject">
+                          <Name>SideCameraRightFrames</Name>
+                        </Expression>
+                        <Expression xsi:type="rx:Defer">
                           <Name>BodyCamera</Name>
                           <Workflow>
                             <Nodes>
@@ -8785,6 +8702,7 @@
                               <Expression xsi:type="rx:PublishSubject">
                                 <Name>BodyCameraFrames</Name>
                               </Expression>
+                              <Expression xsi:type="WorkflowOutput" />
                               <Expression xsi:type="SubscribeSubject">
                                 <Name>BodyCameraFrames</Name>
                               </Expression>
@@ -8792,38 +8710,19 @@
                                 <Combinator xsi:type="harp:CreateTimestamped" />
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/body_camera.csv</Format>
-                                <Selector />
+                                <Name>FfmpegOutputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="OutputArguments" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="io:CsvWriter">
-                                <io:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/body_camera.csv</io:FileName>
-                                <io:Append>false</io:Append>
-                                <io:Overwrite>true</io:Overwrite>
-                                <io:Suffix>None</io:Suffix>
-                                <io:IncludeHeader>false</io:IncludeHeader>
-                                <io:Selector>Seconds,Value.ChunkData.FrameID,Value.ChunkData.Timestamp</io:Selector>
-                              </Expression>
-                              <Expression xsi:type="MemberSelector">
-                                <Selector>Value.Image</Selector>
-                              </Expression>
                               <Expression xsi:type="SubscribeSubject">
-                                <Name>RootPath</Name>
-                              </Expression>
-                              <Expression xsi:type="Format">
-                                <Format>{0}/../../behavior-videos/body_camera.avi</Format>
-                                <Selector />
+                                <Name>FfmpegInputArgs</Name>
                               </Expression>
                               <Expression xsi:type="PropertyMapping">
                                 <PropertyMappings>
-                                  <Property Name="FileName" />
+                                  <Property Name="InputArguments" />
                                 </PropertyMappings>
                               </Expression>
                               <Expression xsi:type="SubscribeSubject">
@@ -8834,27 +8733,14 @@
                                   <Property Name="FrameRate" />
                                 </PropertyMappings>
                               </Expression>
-                              <Expression xsi:type="SubscribeSubject">
-                                <Name>ComPorts</Name>
-                              </Expression>
-                              <Expression xsi:type="Index">
-                                <Operand xsi:type="StringProperty">
-                                  <Value>codec</Value>
-                                </Operand>
-                              </Expression>
-                              <Expression xsi:type="PropertyMapping">
-                                <PropertyMappings>
-                                  <Property Name="OutputArguments" />
-                                </PropertyMappings>
-                              </Expression>
-                              <Expression xsi:type="Combinator">
-                                <Combinator xsi:type="ffmpeg:VideoWriter">
-                                  <ffmpeg:FileName>D:\BehaviorData\323_EPHYS3\0\behavior_0_2025-04-05_18-01-27\behavior\raw.harp/../../behavior-videos/body_camera.avi</ffmpeg:FileName>
-                                  <ffmpeg:Suffix>None</ffmpeg:Suffix>
-                                  <ffmpeg:Overwrite>true</ffmpeg:Overwrite>
-                                  <ffmpeg:FrameRate>500</ffmpeg:FrameRate>
-                                  <ffmpeg:OutputArguments>-vcodec h264_nvenc -crf 23 -preset fast -b:v 50M -v 24</ffmpeg:OutputArguments>
-                                </Combinator>
+                              <Expression xsi:type="IncludeWorkflow" Path="AllenNeuralDynamics.Core:LogSpinnakerFfmpeg.bonsai">
+                                <Modality>BehaviorVideos</Modality>
+                                <LogName>BodyCamera</LogName>
+                                <VideoExtension>mp4</VideoExtension>
+                                <OutputArguments>-vf "scale=out_color_matrix=bt709:out_range=full" -c:v h264_nvenc -pix_fmt nv12 -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p4 -rc vbr -cq 12 -b:v 0M -maxrate 700M -bufsize 350M</OutputArguments>
+                                <InputArguments>-colorspace rgb -color_primaries bt709 -color_trc linear</InputArguments>
+                                <Verbosity>Verbose</Verbosity>
+                                <FrameRate>0</FrameRate>
                               </Expression>
                             </Nodes>
                             <Edges>
@@ -8874,21 +8760,15 @@
                               <Edge From="13" To="14" Label="Source1" />
                               <Edge From="14" To="15" Label="Source2" />
                               <Edge From="15" To="16" Label="Source1" />
-                              <Edge From="17" To="18" Label="Source1" />
-                              <Edge From="18" To="22" Label="Source1" />
-                              <Edge From="19" To="20" Label="Source1" />
+                              <Edge From="16" To="17" Label="Source1" />
+                              <Edge From="18" To="19" Label="Source1" />
+                              <Edge From="19" To="26" Label="Source1" />
                               <Edge From="20" To="21" Label="Source1" />
-                              <Edge From="21" To="22" Label="Source2" />
+                              <Edge From="21" To="26" Label="Source2" />
                               <Edge From="22" To="23" Label="Source1" />
-                              <Edge From="23" To="32" Label="Source1" />
+                              <Edge From="23" To="26" Label="Source3" />
                               <Edge From="24" To="25" Label="Source1" />
-                              <Edge From="25" To="26" Label="Source1" />
-                              <Edge From="26" To="32" Label="Source2" />
-                              <Edge From="27" To="28" Label="Source1" />
-                              <Edge From="28" To="32" Label="Source3" />
-                              <Edge From="29" To="30" Label="Source1" />
-                              <Edge From="30" To="31" Label="Source1" />
-                              <Edge From="31" To="32" Label="Source4" />
+                              <Edge From="25" To="26" Label="Source4" />
                             </Edges>
                           </Workflow>
                         </Expression>
@@ -8938,11 +8818,10 @@
                         <Edge From="14" To="15" Label="Source1" />
                         <Edge From="15" To="16" Label="Source1" />
                         <Edge From="16" To="17" Label="Source1" />
-                        <Edge From="18" To="23" Label="Source1" />
+                        <Edge From="18" To="19" Label="Source1" />
                         <Edge From="19" To="20" Label="Source1" />
-                        <Edge From="20" To="21" Label="Source1" />
                         <Edge From="21" To="22" Label="Source1" />
-                        <Edge From="22" To="23" Label="Source2" />
+                        <Edge From="22" To="23" Label="Source1" />
                         <Edge From="24" To="29" Label="Source1" />
                         <Edge From="25" To="26" Label="Source1" />
                         <Edge From="26" To="27" Label="Source1" />
@@ -8953,11 +8832,18 @@
                         <Edge From="32" To="33" Label="Source1" />
                         <Edge From="33" To="34" Label="Source1" />
                         <Edge From="34" To="35" Label="Source2" />
-                        <Edge From="36" To="41" Label="Source1" />
-                        <Edge From="37" To="38" Label="Source1" />
+                        <Edge From="35" To="36" Label="Source1" />
+                        <Edge From="37" To="42" Label="Source1" />
                         <Edge From="38" To="39" Label="Source1" />
                         <Edge From="39" To="40" Label="Source1" />
-                        <Edge From="40" To="41" Label="Source2" />
+                        <Edge From="40" To="41" Label="Source1" />
+                        <Edge From="41" To="42" Label="Source2" />
+                        <Edge From="42" To="43" Label="Source1" />
+                        <Edge From="44" To="49" Label="Source1" />
+                        <Edge From="45" To="46" Label="Source1" />
+                        <Edge From="46" To="47" Label="Source1" />
+                        <Edge From="47" To="48" Label="Source1" />
+                        <Edge From="48" To="49" Label="Source2" />
                       </Edges>
                     </Workflow>
                   </Expression>
@@ -9214,13 +9100,19 @@
               <Combinator xsi:type="rx:SubscribeWhen" />
             </Expression>
             <Expression xsi:type="SubscribeSubject">
-              <Name>CameraImage_Bottom</Name>
+              <Name>BottomCameraFrames</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Item1.Image</Selector>
             </Expression>
             <Expression xsi:type="VisualizerMapping">
               <VisualizerType xsi:type="TypeMapping" TypeArguments="p6:IplImageRotateVisualizer" />
             </Expression>
             <Expression xsi:type="SubscribeSubject">
-              <Name>CameraImage_Right</Name>
+              <Name>SideCameraRightFrames</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Item1.Image</Selector>
             </Expression>
             <Expression xsi:type="VisualizerMapping">
               <VisualizerType xsi:type="TypeMapping" TypeArguments="p6:IplImageRotateVisualizer" />
@@ -9282,47 +9174,50 @@
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="1" To="2" Label="Source1" />
-            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
             <Edge From="4" To="5" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="9" To="10" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="15" To="16" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
-            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
             <Edge From="20" To="21" Label="Source1" />
-            <Edge From="22" To="23" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
             <Edge From="23" To="24" Label="Source1" />
-            <Edge From="25" To="26" Label="Source1" />
+            <Edge From="24" To="25" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
             <Edge From="29" To="30" Label="Source1" />
-            <Edge From="31" To="32" Label="Source1" />
+            <Edge From="30" To="31" Label="Source1" />
             <Edge From="32" To="33" Label="Source1" />
-            <Edge From="34" To="35" Label="Source1" />
-            <Edge From="36" To="37" Label="Source1" />
-            <Edge From="39" To="40" Label="Source1" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="43" To="44" Label="Source1" />
-            <Edge From="45" To="50" Label="Source1" />
-            <Edge From="46" To="47" Label="Source1" />
+            <Edge From="33" To="34" Label="Source1" />
+            <Edge From="35" To="36" Label="Source1" />
+            <Edge From="37" To="38" Label="Source1" />
+            <Edge From="40" To="41" Label="Source1" />
+            <Edge From="42" To="43" Label="Source1" />
+            <Edge From="44" To="45" Label="Source1" />
+            <Edge From="46" To="51" Label="Source1" />
             <Edge From="47" To="48" Label="Source1" />
             <Edge From="48" To="49" Label="Source1" />
-            <Edge From="49" To="50" Label="Source2" />
-            <Edge From="51" To="56" Label="Source1" />
-            <Edge From="52" To="53" Label="Source1" />
+            <Edge From="49" To="50" Label="Source1" />
+            <Edge From="50" To="51" Label="Source2" />
+            <Edge From="52" To="57" Label="Source1" />
             <Edge From="53" To="54" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
-            <Edge From="55" To="56" Label="Source2" />
-            <Edge From="57" To="58" Label="Source1" />
-            <Edge From="58" To="61" Label="Source1" />
+            <Edge From="55" To="56" Label="Source1" />
+            <Edge From="56" To="57" Label="Source2" />
+            <Edge From="58" To="59" Label="Source1" />
             <Edge From="59" To="60" Label="Source1" />
-            <Edge From="60" To="61" Label="Source2" />
+            <Edge From="60" To="64" Label="Source1" />
+            <Edge From="61" To="62" Label="Source1" />
             <Edge From="62" To="63" Label="Source1" />
+            <Edge From="63" To="64" Label="Source2" />
+            <Edge From="65" To="66" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
This PR implements an ffmpeg logger for all cameras. The following caveats should be considered:
- I tried to touch the workflow as little as possible. A better approach would be to adopt the same pattern for dynamically creating cameras as needed like we do in VrForaging but this would require substantial changes.
- The codecs are currently hard-coded according to https://allenneuraldynamics.github.io/aind-file-standards/file_formats/behavior_videos/#acquisitionrawprimary-data-format.
- I did not want to implement them flexibly since I don't have visibility into how the CSV settings are maintained and the currently reserved keywords. If you need it, it should be an easy addition.
- Despite enabling encoding for all cameras, i can make no guarantees as to whether the hardware will be able to keep up with the 4 cameras currently specified at 500fps each (I highly doubt it)
- There was an undocumented prefix on top of the root logging path (i.e. <path>/../../behavior-videos) that I have no idea why was necessary. Perhaps the dynamic foraging GUI is considering something else as being the "root path" than what bonsai is? Lmk if this is an issue, and I can easily fix it.
- The rest of the workflow is still responsible for making sure the triggering only starts AFTER the cameras have started and, ideally, make sure that cameras stop before the recording stops. This will ensure that you get both the start and end of the stream in your data.