### PR TITLE
Add transfer job type to settings model

### DIFF
--- a/src/foraging_gui/settings_model.py
+++ b/src/foraging_gui/settings_model.py
@@ -178,6 +178,7 @@ class DFTSettingsModel(BaseModel):
     save_each_trial: bool
     AutomaticUpload: bool
     manifest_flag_dir: str
+    transfer_service_job_type: str
     auto_engage: bool
     clear_figure_after_save: bool
     add_default_project_name: bool


### PR DESCRIPTION
### Describe changes:

Adds `transfer_service_job_type` to DFTSettingsModel so settings are properly validated.

### What issues or discussions does this update address?

Follow-on to this PR: https://github.com/AllenNeuralDynamics/dynamic-foraging-task/pull/1590
Closes #1590 
Closes #1586 

### Describe the expected change in behavior from the perspective of the experimenter

No change

### Describe any manual update steps for task computers

None

### Was this update tested in 446/447?

No

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?

Provides settings validation for transfer_service_job_type argument written to watchdog manifest to be passed to aind-data-transfer-service