### PR TITLE
add closing stagewidget call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "aind-data-schema==1.1.0",
     "aind-data-schema-models==0.5.6",
     "pydantic >=2.9.2, <3",
-    "stagewidget==1.0.4.dev11",
+    "stagewidget==1.0.5.dev0",
     "python-logging-loki >=0.3.1, <2",
     "pykeepass >=4.0.7, <5",
     "pyyaml >=6, <7",

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3445,6 +3445,10 @@ class Window(QMainWindow):
                 event.ignore()
                 return
 
+        # stop stage widget
+        if self.stage_widget:
+            self.stage_widget.stage_model.closeEvent()
+
         event.accept()
         self.Start.setChecked(False)
         if self.InitializeBonsaiSuccessfully == 1:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:

Uses newest version of stage widget that has a close device method. 

### What issues or discussions does this update address?

Reoccurring stagewidget issue where device won't connect. 

### Describe the expected change in behavior from the perspective of the experimenter

When the GUI is closed, the following logs should appear: 
```
(Stage widget cleanup) Performing emergency stop since GUI is closing
(Stage widget cleanup) Closing any running moving-threads
(Stage widget cleanup) Disconnecting device
```
### Describe any manual update steps for task computers

None

### Was this update tested in 446/447?

No, tested on HBTest (SIPE's test rig that should mimic the 446/447 rigs). Ran the dynamic foraging GUI on there and the stage worked normally without any issues. The new close function always gets called correctly. 

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?

No

