### PR TITLE
returns empty dict instead of nonetype

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -4699,7 +4699,7 @@ class Window(QMainWindow):
                         elif widget.parent().objectName() == "MetaData":
                             CurrentObj = Obj["Metadata_dialog"]
                         elif widget.parent().objectName()=='RandomReward':
-                            CurrentObj=Obj.get('RandomReward_dialog', None)
+                            CurrentObj=Obj.get('RandomReward_dialog', {})
                         else:
                             CurrentObj = Obj.copy()
                     except Exception:


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- returns empty dict instead of none
### What issues or discussions does this update address?
- [#1057](https://github.com/AllenNeuralDynamics/dynamic_foraging_error_tracking/issues/1057)
### Describe the expected change in behavior from the perspective of the experimenter

### Describe any manual update steps for task computers

### Was this update tested in 446/447?

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?



