### PR TITLE
Resize opto window

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -134,8 +134,8 @@ class OptogeneticsDialog(QDialog):
 
         # resize if foraging gui
         if MainWindow.default_ui == "ForagingGUI.ui":
-            self.setMaximumWidth(500)
-            self.QScrollOptogenetics.setFixedSize(500, 271)
+            self.setMaximumWidth(800)
+            self.QScrollOptogenetics.setFixedSize(770, 271)
 
         self.condition_idx = [
             1,

--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -131,6 +131,12 @@ class OptogeneticsDialog(QDialog):
     def __init__(self, MainWindow, parent=None):
         super().__init__(parent)
         uic.loadUi("Optogenetics.ui", self)
+
+        # resize if foraging gui
+        if MainWindow.default_ui == "ForagingGUI.ui":
+            self.setMaximumWidth(500)
+            self.QScrollOptogenetics.setFixedSize(500, 271)
+
         self.condition_idx = [
             1,
             2,

--- a/src/foraging_gui/Optogenetics.ui
+++ b/src/foraging_gui/Optogenetics.ui
@@ -359,8 +359,8 @@
    <widget class="QComboBox" name="SessionAlternating">
     <property name="geometry">
      <rect>
-      <x>820</x>
-      <y>20</y>
+      <x>375</x>
+      <y>60</y>
       <width>81</width>
       <height>20</height>
      </rect>
@@ -388,9 +388,9 @@
    <widget class="QLabel" name="label3_17">
     <property name="geometry">
      <rect>
-      <x>670</x>
-      <y>20</y>
-      <width>141</width>
+      <x>170</x>
+      <y>60</y>
+      <width>200</width>
       <height>20</height>
      </rect>
     </property>


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- resizes opto widget if using the foraging gui to minimum width so users can see all parameters in 446/7
### What issues or discussions does this update address?
- resolves SIPE ticket [4315](https://apps.powerapps.com/play/cb338490-e23d-48e6-9e6d-e600b8d17dd4?tenantId=32669cd6-737f-4b39-8bdd-d6951120d3fc&Hidenavbar=true&ItemID=4315)
### Describe the expected change in behavior from the perspective of the experimenter
- opto window width is minimized
### Describe any manual update steps for task computers
- none 
### Was this update tested in 446/447?
- [ ] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?

no 

