### PR TITLE
Update foraging.bonsai.layout

### DIFF
--- a/src/workflows/foraging.bonsai.layout
+++ b/src/workflows/foraging.bonsai.layout
@@ -10426,7 +10426,7 @@
               <VisualizerTypeName>Bonsai.Design.Visualizers.BooleanTimeSeriesVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <BooleanTimeSeriesVisualizer>
-                  <Capacity>640</Capacity>
+                  <Capacity>60</Capacity>
                 </BooleanTimeSeriesVisualizer>
               </VisualizerSettings>
             </MashupSettings>
@@ -10435,7 +10435,7 @@
               <VisualizerTypeName>Bonsai.Design.Visualizers.BooleanTimeSeriesVisualizer</VisualizerTypeName>
               <VisualizerSettings>
                 <BooleanTimeSeriesVisualizer>
-                  <Capacity>640</Capacity>
+                  <Capacity>60</Capacity>
                 </BooleanTimeSeriesVisualizer>
               </VisualizerSettings>
             </MashupSettings>
@@ -10739,7 +10739,7 @@
     <VisualizerTypeName>Bonsai.Design.Visualizers.TimeSeriesVisualizer</VisualizerTypeName>
     <VisualizerSettings>
       <TimeSeriesVisualizer>
-        <Capacity>640</Capacity>
+        <Capacity>60</Capacity>
         <Min>0</Min>
         <Max>1.1</Max>
         <AutoScale>true</AutoScale>


### PR DESCRIPTION
### Describe changes:
Reduces number of lick events displayed in visualizer before scrolling onward.

### What issues or discussions does this update address?
[](https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/1305)
Too many lick events were being buffered in the lick visualizer. This was caused by capacity of Boolean Time Series Visualizer being set to 640 rather than 60 as is standard.

### Describe the expected change in behavior from the perspective of the experimenter
None

### Describe any manual update steps for task computers
None

### Was this update tested in 446/447?
Yes - 6D

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No impact



