### PR TITLE
changing max open time

### DIFF
--- a/src/foraging_gui/Dialogs.py
+++ b/src/foraging_gui/Dialogs.py
@@ -708,7 +708,7 @@ class WaterCalibrationDialog(QDialog):
         if "Full" not in self.WaterCalibrationPar:
             self.WaterCalibrationPar["Full"] = {}
             self.WaterCalibrationPar["Full"]["TimeMin"] = 0.02
-            self.WaterCalibrationPar["Full"]["TimeMax"] = 0.03
+            self.WaterCalibrationPar["Full"]["TimeMax"] = 0.04
             self.WaterCalibrationPar["Full"]["Stride"] = 0.01
             self.WaterCalibrationPar["Full"]["Interval"] = 0.1
             self.WaterCalibrationPar["Full"]["Cycle"] = 1000


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- resolves https://github.com/AllenNeuralDynamics/aind-behavior-blog/issues/1355
- This change adds the third point (0.04), with the "stride" between points fixed at 0.01. So min=0.02, max=0.04, and stride=0.01 results in 0.02, 0.03, 0.04

### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter

### Describe any manual update steps for task computers

### Was this update tested in 446/447?

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?



