### PR TITLE
FIP metadata update

### DIFF
--- a/src/foraging_gui/RigJsonBuilder.py
+++ b/src/foraging_gui/RigJsonBuilder.py
@@ -478,7 +478,7 @@ def build_rig_json_core(settings, water_calibration, laser_calibration):
 
         components["objectives"] = [
             d.Objective(
-                name="Objective",
+                name="FIP Objective",
                 serial_number=settings["box_settings"][
                     "FipObjectiveSerialNumber"
                 ],


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
- Changes name of FIP objective in the metadata from "Objective" to "FIP Objective"

### What issues or discussions does this update address?
- Its unclear what the objective is used for

### Describe the expected change in behavior from the perspective of the experimenter
- none

### Describe any manual update steps for task computers
- none

### Was this update tested in 446/447?
- no

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- It creates an inconsistency in the metadata. @hagikent How is the metadata for the VR foraging structured? Should we fix old metadata, or just correct going forward?


