### PR TITLE
Pin numpy and pydantic versions in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    "numpy==2.3.4",
+    "numpy >=2, <3",
     "scipy >=1, <2",
     "matplotlib >=3, <4",
     "PyQt5 >=5, <6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    "numpy >=2, <3",
+    "numpy==2.3.4",
     "scipy >=1, <2",
     "matplotlib >=3, <4",
     "PyQt5 >=5, <6",
@@ -37,7 +37,7 @@ dependencies = [
     "deepdiff >=8, <9",
     "aind-data-schema==1.1.0",
     "aind-data-schema-models==0.5.6",
-    "pydantic >=2.9.2, <3",
+    "pydantic==2.10.6",
     "stagewidget==1.0.5",
     "python-logging-loki >=0.3.1, <2",
     "pykeepass >=4.0.7, <5",


### PR DESCRIPTION
### Pull Request instructions:
- Please follow the [update protocol](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki/Software-Update-Procedures)
- Answer the questions below in detail. Your responses will be emailed to experimenters. 
- If the experimenters must do anything new, provide detailed step by step instructions on the [wiki](https://github.com/AllenNeuralDynamics/aind-behavior-blog/wiki)
- If computer maintainers need to manually update anything, provide detailed step by step instructions
- Use markdown syntax in order for your comments to be rendered reliably in the email: "1." instead of "1)", use four spaces for indents.
- If you use the keyword "skip email" in the title, it will skip the email updates
- Merges from "develop" into "production_testing" should use the keyword "production merge" in the title for reliable indexing of updates
- Merges from "production_testing" into "main" should use the keyword "update main"
  
### Describe changes:
Updated dependency versions in pyproject.toml to resolve environment setup and runtime errors.
Pinned:
 - pydantic==2.10.6
 - numpy==2.3.4 
These versions reflect a known working configuration validated during 8D setup.

### What issues or discussions does this update address?
Resolves a PydanticUserError caused by incompatible pydantic versions:
`model_config cannot be used as a model field name`
Aligns repo dependencies with versions confirmed to work by @micahwoodard during troubleshooting setting up rig 8D.

### Describe the expected change in behavior from the perspective of the experimenter
No changes to task functionality or workflow.

### Describe any manual update steps for task computers
Optional> Update dependencies for consistency rinning:
`pip install pydantic==2.10.6 numpy==2.3.4`

### Was this update tested in 446/447?
Tested in Rig 8D

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No



