### PR TITLE
chore: update tag job reusable workflow reference [skip email]

### DIFF
--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
    bump-version:
-     uses: AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main
+     uses: AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main
      with:
        default_branch: main # optional, default: main
      secrets:
-       SERVICE_TOKEN: ${{ secrets.SERVICE_TOKEN }} # required
+       repo-token: ${{ secrets.SERVICE_TOKEN }} # required


### PR DESCRIPTION
### Describe changes:
- Updated workflow references from `AllenNeuralDynamics/aind-github-actions/.github/workflows/tag.yml@main` to `AllenNeuralDynamics/.github/.github/workflows/release-bump-version.yml@main`.
- Updated `SERVICE_TOKEN` to `repo-token`.

### What issues or discussions does this update address?
We are deprecating `AllenNeuralDynamics/aind-github-actions` repo and are in the process of migrating to a new workflow. This PR updates the tag workflow references that point to the old workflow.

### Describe the expected change in behavior from the perspective of the experimenter
None

### Describe any manual update steps for task computers
None

### Was this update tested in 446/447?
No

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
No


