### PR TITLE
Fix spelling of watchdog manifest email field

### DIFF
--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -7299,7 +7299,7 @@ class Window(QMainWindow):
                 "schedule_time": schedule_time,
                 "project_name": self.Metadata_dialog.ProjectName.currentText(),
                 "script": {},
-                "user_email": sci_email 
+                "upload_notification_email": sci_email 
             }
 
             # Define filename of manifest


### PR DESCRIPTION
### Describe changes:

Fix spelling of the watchdog "user_email" -> "upload_notification_email" field to match watchdog [manifest model](https://github.com/AllenNeuralDynamics/aind-watchdog-service/blob/main/src/aind_watchdog_service/models/manifest_config.py#L59)

### What issues or discussions does this update address?

closes #1740 

### Describe the expected change in behavior from the perspective of the experimenter

None

### Describe any manual update steps for task computers

None

### Was this update tested in 446/447?

No

### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?

Yes, it will successfully pass email to aind-data-transfer-service

