### PR TITLE
Adds lifecycle logger to log start, complete, and failure logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "winkerberos; sys_platform == 'win32'",
     "ldap3; sys_platform == 'win32'",
     "msal; sys_platform == 'win32'",
-    "aind-log-utils @ git+https://github.com/AllenNeuralDynamics/aind-log-utils.git@main#subdirectory=python"
+    "aind-log-utils==0.2.8"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "winkerberos; sys_platform == 'win32'",
     "ldap3; sys_platform == 'win32'",
     "msal; sys_platform == 'win32'",
-    "aind-log-utils==0.2.8"
+    "log-schema==0.2.10.dev1"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "winkerberos; sys_platform == 'win32'",
     "ldap3; sys_platform == 'win32'",
     "msal; sys_platform == 'win32'",
+    "aind-log-utils @ git+https://github.com/AllenNeuralDynamics/aind-log-utils.git@main#subdirectory=python"
 ]
 
 [project.optional-dependencies]

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -373,7 +373,7 @@ class Window(QMainWindow):
     def setup_lifecycle_logger(self):
         
         # Ensure the directory exists
-        os.makedirs(os.path.dirname(self.Settings["lifecycle_log_dir"]), exist_ok=True)
+        os.makedirs(os.path(self.Settings["lifecycle_log_dir"]), exist_ok=True)
 
         lifecycle_logger = logging.getLogger("lifecycle")
         lifecycle_logger.setLevel(logging.INFO)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -1616,6 +1616,7 @@ class Window(QMainWindow):
             self.Save.setStyleSheet(
                 "color: white;background-color : mediumorchid"
             )
+
         else:
             # temporary logging
             loggingtype = 1
@@ -3964,10 +3965,6 @@ class Window(QMainWindow):
         if self.CreateNewFolder == 1:
             self._GetSaveFolder()
             self.CreateNewFolder = 0
-            # Need to log start event after session_name has been set in _GetSaveFolder. This will only happen once at start of session.
-            self.lifecycle_logger.info("Session started.", extra={"subject_id": self.behavior_session_model.subject, 
-                                                                      "acquisition_name": self.behavior_session_model.session_name,
-                                                                      "event_type": "stage_start"})
             
         if not os.path.exists(os.path.dirname(self.SaveFileJson)):
             os.makedirs(os.path.dirname(self.SaveFileJson))
@@ -6223,6 +6220,10 @@ class Window(QMainWindow):
                 # Start logging if the formal logging is not started
                 if self.logging_type != 0:
                     self.Ot_log_folder = self._restartlogging()
+                # Need to log start event after session_name has been set in_restartlogging
+                self.lifecycle_logger.info("Session started.", extra={"subject_id": self.behavior_session_model.subject, 
+                                                                "acquisition_name": self.behavior_session_model.session_name,
+                                                                "event_type": "stage_start"})
             except Exception as e:
                 if "ConnectionAbortedError" in str(e):
                     logging.info("lost bonsai connection: restartlogging()")

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -3964,7 +3964,11 @@ class Window(QMainWindow):
         if self.CreateNewFolder == 1:
             self._GetSaveFolder()
             self.CreateNewFolder = 0
-
+            # Need to log start event after session_name has been set in _GetSaveFolder. This will only happen once at start of session.
+            self.lifecycle_logger.info("Session started.", extra={"subject_id": self.behavior_session_model.subject, 
+                                                                      "acquisition_name": self.behavior_session_model.session_name,
+                                                                      "event_type": "stage_start"})
+            
         if not os.path.exists(os.path.dirname(self.SaveFileJson)):
             os.makedirs(os.path.dirname(self.SaveFileJson))
             logging.info(
@@ -6156,12 +6160,6 @@ class Window(QMainWindow):
                     )
             elif self.behavior_session_model.allow_dirty_repo is None:
                 logging.error("Could not check for untracked local changes")
-
-            # log start event
-            if self.StartANewSession != 0:
-                self.lifecycle_logger.info("Session started.", extra={"subject_id": self.behavior_session_model.subject, 
-                                                                      "acquisition_name": self.behavior_session_model.session_name,
-                                                                      "event_type": "stage_start"})
 
             # disable sound button
             self.sound_button.setEnabled(False)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -29,7 +29,7 @@ import requests
 import serial
 import yaml
 
-import aind_log_utils
+import log_schema
 from aind_auto_train.schema.task import TrainingStage
 from aind_behavior_services.session import AindBehaviorSessionModel
 from aind_data_schema.core.session import Session
@@ -382,7 +382,7 @@ class Window(QMainWindow):
         filename = f"lifecycle_log_{timestamp}.jsonl"
         file_handler = logging.FileHandler(os.path.join(self.Settings["lifecycle_log_dir"], filename), encoding="utf-8")
         file_handler.setLevel(logging.INFO)
-        file_handler.setFormatter(aind_log_utils.DefaultFormatter())
+        file_handler.setFormatter(log_schema.DefaultFormatter())
         lifecycle_logger.addHandler(file_handler)
 
         return lifecycle_logger

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -373,7 +373,7 @@ class Window(QMainWindow):
     def setup_lifecycle_logger(self):
         
         # Ensure the directory exists
-        os.makedirs(os.path.dirname(self.SettingsBox["lifecycle_log_dir"]), exist_ok=True)
+        os.makedirs(os.path.dirname(self.Settings["lifecycle_log_dir"]), exist_ok=True)
 
         lifecycle_logger = logging.getLogger("lifecycle")
         lifecycle_logger.setLevel(logging.INFO)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -373,7 +373,7 @@ class Window(QMainWindow):
     def setup_lifecycle_logger(self):
         
         # Ensure the directory exists
-        os.makedirs(os.path.dirname(self.SettingsBox), exist_ok=True)
+        os.makedirs(os.path.dirname(self.SettingsBox["lifecycle_log_dir"]), exist_ok=True)
 
         lifecycle_logger = logging.getLogger("lifecycle")
         lifecycle_logger.setLevel(logging.INFO)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -370,8 +370,12 @@ class Window(QMainWindow):
             self._ReconnectBonsai()
         logging.info("Start up complete")
 
-    def setup_lifecycle_logger(self):
+    def setup_lifecycle_logger(self) -> logging.Logger:
         
+        """
+        Creates logger for start, stop, and failure events with formatter adhering to aind log standards.
+        """
+
         # Ensure the directory exists
         os.makedirs(Path(self.Settings["lifecycle_log_dir"]), exist_ok=True)
 

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -377,7 +377,10 @@ class Window(QMainWindow):
 
         lifecycle_logger = logging.getLogger("lifecycle")
         lifecycle_logger.setLevel(logging.INFO)
-        file_handler = logging.FileHandler(self.Settings["lifecycle_log_dir"], encoding="utf-8")
+
+        timestamp = datetime.now().strftime("%Y%m%dT%H%M%SZ")
+        filename = f"lifecycle_log_{timestamp}.jsonl"
+        file_handler = logging.FileHandler(os.path.join(self.Settings["lifecycle_log_dir"], filename), encoding="utf-8")
         file_handler.setLevel(logging.INFO)
         file_handler.setFormatter(aind_log_utils.DefaultFormatter())
         lifecycle_logger.addHandler(file_handler)

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -28,6 +28,8 @@ import pandas as pd
 import requests
 import serial
 import yaml
+
+import aind_log_utils
 from aind_auto_train.schema.task import TrainingStage
 from aind_behavior_services.session import AindBehaviorSessionModel
 from aind_data_schema.core.session import Session
@@ -351,6 +353,9 @@ class Window(QMainWindow):
 
         # load the rig metadata
         self._load_rig_metadata()
+        
+        # setup life-cycle logger
+        self.lifecycle_logger = self.setup_lifecycle_logger()
 
         # Initializes session log handler as None
         self.session_log_handler = None
@@ -364,6 +369,20 @@ class Window(QMainWindow):
             """
             self._ReconnectBonsai()
         logging.info("Start up complete")
+
+    def setup_lifecycle_logger(self):
+        
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(self.SettingsBox), exist_ok=True)
+
+        lifecycle_logger = logging.getLogger("lifecycle")
+        lifecycle_logger.setLevel(logging.INFO)
+        file_handler = logging.FileHandler(self.Settings["lifecycle_log_dir"], encoding="utf-8")
+        file_handler.setLevel(logging.INFO)
+        file_handler.setFormatter(aind_log_utils.DefaultFormatter())
+        lifecycle_logger.addHandler(file_handler)
+
+        return lifecycle_logger
 
     def _load_rig_metadata(self):
         """Load the latest rig metadata"""
@@ -1960,6 +1979,11 @@ class Window(QMainWindow):
                 "Documents",
                 "aind_watchdog_service",
                 "manifest",
+            ),
+            "lifecycle_log_dir": os.path.join(
+                os.path.expanduser("~"),
+                "Documents",
+                "lifecycle_logs",
             ),
             "transfer_service_job_type": "dynamic_foraging_compression",
             "auto_engage": True,
@@ -4225,6 +4249,12 @@ class Window(QMainWindow):
                 elif session is None:
                     logging.warning(f"Waterlog for mouse {self.behavior_session_model.subject} cannot be added to slims"
                                   f" due do metadata generation failure.")
+                    
+                # add complete log to lifecycle 
+                self.lifecycle_logger.info("Session ended.", extra={"subject_id": self.behavior_session_model.subject, 
+                                                                      "acquisition_name": self.behavior_session_model.session_name,
+                                                                      "event_type": "stage_complete"})
+                
         except Exception as e:
             logging.warning(
                 "Meta data is not saved!",
@@ -6124,6 +6154,12 @@ class Window(QMainWindow):
             elif self.behavior_session_model.allow_dirty_repo is None:
                 logging.error("Could not check for untracked local changes")
 
+            # log start event
+            if self.StartANewSession != 0:
+                self.lifecycle_logger.info("Session started.", extra={"subject_id": self.behavior_session_model.subject, 
+                                                                      "acquisition_name": self.behavior_session_model.session_name,
+                                                                      "event_type": "stage_start"})
+
             # disable sound button
             self.sound_button.setEnabled(False)
 
@@ -6641,6 +6677,9 @@ class Window(QMainWindow):
                         self.ANewTrial = 1
                         self.Start.setChecked(False)
                         self.Start.setStyleSheet("background-color : none")
+                        self.lifecycle_logger.info("Session failed.", extra={"subject_id": self.behavior_session_model.subject, 
+                                                                      "acquisition_name": self.behavior_session_model.session_name,
+                                                                      "event_type": "stage_failure"})
                         break
                 # receive licks and update figures
                 if self.actionDrawing_after_stopping.isChecked() == False:
@@ -7431,7 +7470,6 @@ def setup_loki_logging(box_number):
     )
     handler.setLevel(logging.INFO)
     logger.root.addHandler(handler)
-
 
 def start_gui_log_file(box_number):
     """

--- a/src/foraging_gui/Foraging.py
+++ b/src/foraging_gui/Foraging.py
@@ -373,7 +373,7 @@ class Window(QMainWindow):
     def setup_lifecycle_logger(self):
         
         # Ensure the directory exists
-        os.makedirs(os.path(self.Settings["lifecycle_log_dir"]), exist_ok=True)
+        os.makedirs(Path(self.Settings["lifecycle_log_dir"]), exist_ok=True)
 
         lifecycle_logger = logging.getLogger("lifecycle")
         lifecycle_logger.setLevel(logging.INFO)

--- a/src/foraging_gui/settings_model.py
+++ b/src/foraging_gui/settings_model.py
@@ -1,7 +1,7 @@
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
-
+from pathlib import Path
 
 class BonsaiSettingsModel(BaseModel):
     """
@@ -182,6 +182,7 @@ class DFTSettingsModel(BaseModel):
     save_each_trial: bool
     AutomaticUpload: bool
     manifest_flag_dir: str
+    lifecycle_log_dir: Path
     transfer_service_job_type: str
     auto_engage: bool
     clear_figure_after_save: bool


### PR DESCRIPTION
 
### Describe changes:
Adds lifecycle logger to log start, complete, and failure logs using the aind-log-utils formatter. This will create a log file in a default folder of Documents/lifecycle_logs to be picked up by grafana alloy. Start log will emit after user presses start and acquisition name is defined and stop log will happen after user saves. Final logs will look like 

```
{"timestamp": "2026-05-27T15:02:30.306808Z", "level": "INFO", "message": "Session started.", "subject_id": "0", "acquisition_name": "behavior_0_2026-05-27_08-02-30", "event_type": "stage_start"}
{"timestamp": "2026-05-27T15:03:02.180110Z", "level": "INFO", "message": "Session ended.", "subject_id": "0", "acquisition_name": "behavior_0_2026-05-27_08-02-30", "event_type": "stage_complete"}
```

### What issues or discussions does this update address?

### Describe the expected change in behavior from the perspective of the experimenter
- None
### Describe any manual update steps for task computers
- Need to set up grafana alloy on the frg computers to pick up logs. This can be done asynchronously. 
### Was this update tested in 446/447?
- [x] 446/7
### Does this update impact downstream processing by adding new saved files, or changing their format? If so, have you documented changes?
- does not impact data but log will be used for session tracking. Coordinating with SciComp


